### PR TITLE
Issue #28: enable symbols, source and XML doc comments for behaviors.

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,3 +60,14 @@ Building Behaviors from Source
  - Open the solution in Visual Studio
  - [Batch Build](https://msdn.microsoft.com/en-us/library/169az28z(v=vs.90).aspx) for x86, x64, and ARM
  - Run scripts/CreateNativeNuGet.cmd 
+
+Symbols
+-------
+
+Note that due to the presence of the -Symbols switch in the nuget pack call embedded in the Create...NuGet.cmd scripts, a second package will be generated called <package name>.symbols.nuget. When uploading your NuGet package to nuget.org, nuget.exe will automatically detect this symbols package file (if it's in the same directory as the dll package) and upload it, not to nuget.org but to symbolsource.org (you can change which symbolsource server endpoint is used using the -Source switch, but this is the default). Note that this does not appear to happen when uploading your nuget package via the nuget.org website. Also note that while you can only upload a given version of a nuget.org package once, you can upload a symbol package for a version as many times as you like. To upload symbols for a nuget package already in nuget.org, you can specify the symbol package explicitly in a nuget push <package> command.
+
+Examples:
+nuget push Microsoft.Xaml.Behaviors.Uwp.Managed.1.0.0.nupkg              // upload the package, and Microsoft.Xaml.Behaviors.Uwp.Managed.1.0.0.symbols.nupkg if present
+nuget push Microsoft.Xaml.Behaviors.Uwp.Managed.1.0.0.symbols.nupkg      // upload just the symbols for Microsoft.Xaml.Behaviors.Uwp.Managed.1.0.0.nupkg
+
+In VS, setting http://srv.symbolsource.org/pdb/Public as a symbol file location will enable lookups to this package. You will have symbols and source in your behavior debugging sessions. Full details at http://docs.nuget.org/Create/Creating-and-Publishing-a-Symbol-Package and http://www.symbolsource.org/Public/Home/VisualStudio.

--- a/scripts/CreateManagedNuGet.cmd
+++ b/scripts/CreateManagedNuGet.cmd
@@ -30,7 +30,7 @@ SET NUGET_ARGS=^
     -nopackageanalysis ^
     -version %VERSION%
 
-nuget pack Microsoft.Xaml.Behaviors.Uwp.Managed.nuspec %NUGET_ARGS%
+nuget pack Microsoft.Xaml.Behaviors.Uwp.Managed.nuspec -Symbols %NUGET_ARGS%
 
 :END
 

--- a/scripts/CreateNativeNuGet.cmd
+++ b/scripts/CreateNativeNuGet.cmd
@@ -25,7 +25,7 @@ SET NUGET_ARGS=^
     -nopackageanalysis ^
     -version %VERSION%
 
-nuget pack Microsoft.Xaml.Behaviors.Uwp.Native.nuspec %NUGET_ARGS%
+nuget pack Microsoft.Xaml.Behaviors.Uwp.Native.nuspec -Symbols %NUGET_ARGS%
 
 :END
 

--- a/scripts/Microsoft.Xaml.Behaviors.Uwp.Managed.nuspec
+++ b/scripts/Microsoft.Xaml.Behaviors.Uwp.Managed.nuspec
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+﻿<?xml version="1.0"?>
 <package >
     <metadata>
         <id>Microsoft.Xaml.Behaviors.Uwp.Managed</id>
@@ -17,15 +17,23 @@
 
     <files>
         <file target="lib\uap10.0\Microsoft.Xaml.Interactivity.dll"                 src="..\out\BehaviorsSDKManaged\bin\AnyCPU\Release\Microsoft.Xaml.Interactivity.dll" />
+        <file target="lib\uap10.0\Microsoft.Xaml.Interactivity.pdb"                 src="..\out\BehaviorsSDKManaged\bin\AnyCPU\Release\Microsoft.Xaml.Interactivity.pdb" />
+        <file target="lib\uap10.0\Microsoft.Xaml.Interactivity.xml"                 src="..\out\BehaviorsSDKManaged\bin\AnyCPU\Release\Microsoft.Xaml.Interactivity.xml" />
         <file target="lib\uap10.0\Microsoft.Xaml.Interactivity.pri"                 src="..\out\BehaviorsSDKManaged\bin\AnyCPU\Release\Microsoft.Xaml.Interactivity.pri" />
         <file target="lib\uap10.0\Microsoft.Xaml.Interactions.dll"                  src="..\out\BehaviorsSDKManaged\bin\AnyCPU\Release\Microsoft.Xaml.Interactions.dll" />
+        <file target="lib\uap10.0\Microsoft.Xaml.Interactions.pdb"                  src="..\out\BehaviorsSDKManaged\bin\AnyCPU\Release\Microsoft.Xaml.Interactions.pdb" />
+        <file target="lib\uap10.0\Microsoft.Xaml.Interactions.xml"                  src="..\out\BehaviorsSDKManaged\bin\AnyCPU\Release\Microsoft.Xaml.Interactions.xml" />
         <file target="lib\uap10.0\Microsoft.Xaml.Interactions.pri"                  src="..\out\BehaviorsSDKManaged\bin\AnyCPU\Release\Microsoft.Xaml.Interactions.pri" />
 
         <file target="lib\uap10.0\Design\Microsoft.Xaml.Interactivity.Design.dll"   src="..\out\BehaviorsSDKManaged\bin\AnyCPU\Release\Microsoft.Xaml.Interactivity.Design.dll" />
+        <file target="lib\uap10.0\Design\Microsoft.Xaml.Interactivity.Design.pdb"   src="..\out\BehaviorsSDKManaged\bin\AnyCPU\Release\Microsoft.Xaml.Interactivity.Design.pdb" />
         <file target="lib\uap10.0\Design\Microsoft.Xaml.Interactions.Design.dll"    src="..\out\BehaviorsSDKManaged\bin\AnyCPU\Release\Microsoft.Xaml.Interactions.Design.dll" />
+        <file target="lib\uap10.0\Design\Microsoft.Xaml.Interactions.Design.pdb"    src="..\out\BehaviorsSDKManaged\bin\AnyCPU\Release\Microsoft.Xaml.Interactions.Design.pdb" />
 
         <file target="lib\uap10.0\Microsoft.Xaml.Interactivity\Properties\Microsoft.Xaml.Interactivity.rd.xml"  src="..\src\BehaviorsSDKManaged\Microsoft.Xaml.Interactivity\Properties\Microsoft.Xaml.Interactivity.rd.xml" />
         <file target="lib\uap10.0\Microsoft.Xaml.Interactions\Properties\Microsoft.Xaml.Interactions.rd.xml"    src="..\src\BehaviorsSDKManaged\Microsoft.Xaml.Interactions\Properties\Microsoft.Xaml.Interactions.rd.xml" />
+
+        <file target="src\BehaviorsSDKManaged" src="..\src\BehaviorsSDKManaged\**\*.cs" />
     </files>
 
 </package>

--- a/scripts/Microsoft.Xaml.Behaviors.Uwp.Native.nuspec
+++ b/scripts/Microsoft.Xaml.Behaviors.Uwp.Native.nuspec
@@ -18,11 +18,15 @@
   <files>
     <file target="lib\uap10.0\Microsoft.Xaml.Interactivity.winmd"               src="..\out\BehaviorsSDKNative\bin\Win32\Release\Microsoft.Xaml.Interactivity\Microsoft.Xaml.Interactivity.winmd" />
     <file target="lib\uap10.0\Microsoft.Xaml.Interactivity.xml"                 src="..\out\BehaviorsSDKNative\bin\Win32\Release\Microsoft.Xaml.Interactivity\Microsoft.Xaml.Interactivity.xml" />
+    <file target="lib\uap10.0\Microsoft.Xaml.Interactivity.pdb"                 src="..\out\BehaviorsSDKNative\bin\Win32\Release\Microsoft.Xaml.Interactivity\Microsoft.Xaml.Interactivity.pdb" />
     <file target="lib\uap10.0\Microsoft.Xaml.Interactions.winmd"                src="..\out\BehaviorsSDKNative\bin\Win32\Release\Microsoft.Xaml.Interactions\Microsoft.Xaml.Interactions.winmd" />
     <file target="lib\uap10.0\Microsoft.Xaml.Interactions.xml"                  src="..\out\BehaviorsSDKNative\bin\Win32\Release\Microsoft.Xaml.Interactions\Microsoft.Xaml.Interactions.xml" />
+    <file target="lib\uap10.0\Microsoft.Xaml.Interactions.pdb"                  src="..\out\BehaviorsSDKNative\bin\Win32\Release\Microsoft.Xaml.Interactions\Microsoft.Xaml.Interactions.pdb" />
 
     <file target="lib\uap10.0\Design\Microsoft.Xaml.Interactivity.Design.dll"   src="..\out\BehaviorsSDKNative\bin\AnyCPU\Release\Microsoft.Xaml.Interactivity.Design.dll" />
+    <file target="lib\uap10.0\Design\Microsoft.Xaml.Interactivity.Design.pdb"   src="..\out\BehaviorsSDKNative\bin\AnyCPU\Release\Microsoft.Xaml.Interactivity.Design.pdb" />
     <file target="lib\uap10.0\Design\Microsoft.Xaml.Interactions.Design.dll"    src="..\out\BehaviorsSDKNative\bin\AnyCPU\Release\Microsoft.Xaml.Interactions.Design.dll" />
+    <file target="lib\uap10.0\Design\Microsoft.Xaml.Interactions.Design.pdb"    src="..\out\BehaviorsSDKNative\bin\AnyCPU\Release\Microsoft.Xaml.Interactions.Design.pdb" />
 
     <file target="lib\uap10.0\en\Microsoft.Xaml.Interactivity.xml"              src="..\out\BehaviorsSDKNative\bin\Win32\Release\Microsoft.Xaml.Interactivity\Microsoft.Xaml.Interactivity.xml" />
     <file target="lib\uap10.0\en\Microsoft.Xaml.Interactions.xml"               src="..\out\BehaviorsSDKNative\bin\Win32\Release\Microsoft.Xaml.Interactions\Microsoft.Xaml.Interactions.xml" />
@@ -30,18 +34,28 @@
     <file target="build\native\Microsoft.Xaml.Behaviors.Uwp.Native.targets"     src="Microsoft.Xaml.Behaviors.Uwp.Native.targets" />
 
     <file target="runtimes\win10-x86\native\Microsoft.Xaml.Interactivity.dll"   src="..\out\BehaviorsSDKNative\bin\Win32\Release\Microsoft.Xaml.Interactivity\Microsoft.Xaml.Interactivity.dll" />
+    <file target="runtimes\win10-x86\native\Microsoft.Xaml.Interactivity.pdb"   src="..\out\BehaviorsSDKNative\bin\Win32\Release\Microsoft.Xaml.Interactivity\Microsoft.Xaml.Interactivity.pdb" />
     <file target="runtimes\win10-x86\native\Microsoft.Xaml.Interactivity.pri"   src="..\out\BehaviorsSDKNative\bin\Win32\Release\Microsoft.Xaml.Interactivity\Microsoft.Xaml.Interactivity.pri" />
     <file target="runtimes\win10-x86\native\Microsoft.Xaml.Interactions.dll"    src="..\out\BehaviorsSDKNative\bin\Win32\Release\Microsoft.Xaml.Interactions\Microsoft.Xaml.Interactions.dll" />
+    <file target="runtimes\win10-x86\native\Microsoft.Xaml.Interactions.pdb"    src="..\out\BehaviorsSDKNative\bin\Win32\Release\Microsoft.Xaml.Interactions\Microsoft.Xaml.Interactions.pdb" />
     <file target="runtimes\win10-x86\native\Microsoft.Xaml.Interactions.pri"    src="..\out\BehaviorsSDKNative\bin\Win32\Release\Microsoft.Xaml.Interactions\Microsoft.Xaml.Interactions.pri" />
 
     <file target="runtimes\win10-x64\native\Microsoft.Xaml.Interactivity.dll"   src="..\out\BehaviorsSDKNative\bin\x64\Release\Microsoft.Xaml.Interactivity\Microsoft.Xaml.Interactivity.dll" />
+    <file target="runtimes\win10-x64\native\Microsoft.Xaml.Interactivity.pdb"   src="..\out\BehaviorsSDKNative\bin\x64\Release\Microsoft.Xaml.Interactivity\Microsoft.Xaml.Interactivity.pdb" />
     <file target="runtimes\win10-x64\native\Microsoft.Xaml.Interactivity.pri"   src="..\out\BehaviorsSDKNative\bin\x64\Release\Microsoft.Xaml.Interactivity\Microsoft.Xaml.Interactivity.pri" />
     <file target="runtimes\win10-x64\native\Microsoft.Xaml.Interactions.dll"    src="..\out\BehaviorsSDKNative\bin\x64\Release\Microsoft.Xaml.Interactions\Microsoft.Xaml.Interactions.dll" />
+    <file target="runtimes\win10-x64\native\Microsoft.Xaml.Interactions.pdb"    src="..\out\BehaviorsSDKNative\bin\x64\Release\Microsoft.Xaml.Interactions\Microsoft.Xaml.Interactions.pdb" />
     <file target="runtimes\win10-x64\native\Microsoft.Xaml.Interactions.pri"    src="..\out\BehaviorsSDKNative\bin\x64\Release\Microsoft.Xaml.Interactions\Microsoft.Xaml.Interactions.pri" />
 
     <file target="runtimes\win10-arm\native\Microsoft.Xaml.Interactivity.dll"   src="..\out\BehaviorsSDKNative\bin\ARM\Release\Microsoft.Xaml.Interactivity\Microsoft.Xaml.Interactivity.dll" />
+    <file target="runtimes\win10-arm\native\Microsoft.Xaml.Interactivity.pdb"   src="..\out\BehaviorsSDKNative\bin\ARM\Release\Microsoft.Xaml.Interactivity\Microsoft.Xaml.Interactivity.pdb" />
     <file target="runtimes\win10-arm\native\Microsoft.Xaml.Interactivity.pri"   src="..\out\BehaviorsSDKNative\bin\ARM\Release\Microsoft.Xaml.Interactivity\Microsoft.Xaml.Interactivity.pri" />
     <file target="runtimes\win10-arm\native\Microsoft.Xaml.Interactions.dll"    src="..\out\BehaviorsSDKNative\bin\ARM\Release\Microsoft.Xaml.Interactions\Microsoft.Xaml.Interactions.dll" />
+    <file target="runtimes\win10-arm\native\Microsoft.Xaml.Interactions.pdb"    src="..\out\BehaviorsSDKNative\bin\ARM\Release\Microsoft.Xaml.Interactions\Microsoft.Xaml.Interactions.pdblib\uap10.0" />
     <file target="runtimes\win10-arm\native\Microsoft.Xaml.Interactions.pri"    src="..\out\BehaviorsSDKNative\bin\ARM\Release\Microsoft.Xaml.Interactions\Microsoft.Xaml.Interactions.pri" />
+
+    <file target="src\BehaviorsSDKNative" src="..\src\BehaviorsSDKNative\**\*.cs" />
+    <file target="src\BehaviorsSDKNative" src="..\src\BehaviorsSDKNative\**\*.cpp" />
+    <file target="src\BehaviorsSDKNative" src="..\src\BehaviorsSDKNative\**\*.h" />
   </files>
 </package>

--- a/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactions/Microsoft.Xaml.Interactions.csproj
+++ b/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactions/Microsoft.Xaml.Interactions.csproj
@@ -27,6 +27,7 @@
     <DefineConstants>DEBUG;TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <DocumentationFile>..\..\..\out\BehaviorsSDKManaged\bin\AnyCPU\Debug\Microsoft.Xaml.Interactions.XML</DocumentationFile>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -35,6 +36,7 @@
     <DefineConstants>TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <DocumentationFile>..\..\..\out\BehaviorsSDKManaged\bin\AnyCPU\Release\Microsoft.Xaml.Interactions.XML</DocumentationFile>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|ARM'">
     <PlatformTarget>ARM</PlatformTarget>

--- a/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactivity/Microsoft.Xaml.Interactivity.csproj
+++ b/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactivity/Microsoft.Xaml.Interactivity.csproj
@@ -27,6 +27,7 @@
     <DefineConstants>DEBUG;TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <DocumentationFile>..\..\..\out\BehaviorsSDKManaged\bin\AnyCPU\Debug\Microsoft.Xaml.Interactivity.XML</DocumentationFile>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -35,6 +36,7 @@
     <DefineConstants>TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <DocumentationFile>..\..\..\out\BehaviorsSDKManaged\bin\AnyCPU\Release\Microsoft.Xaml.Interactivity.XML</DocumentationFile>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|ARM'">
     <PlatformTarget>ARM</PlatformTarget>


### PR DESCRIPTION
Note that native symbols don't light up yet, which could be an issue with symbolsource.org. Worth keeping the changes in the nuspec in case it lights up in the future, so we don't lose the work.
