### PR TITLE
Set the rd.xml files Build Action to Embedded Resource in all projects

### DIFF
--- a/scripts/Microsoft.Xaml.Behaviors.Uwp.Managed.nuspec
+++ b/scripts/Microsoft.Xaml.Behaviors.Uwp.Managed.nuspec
@@ -30,9 +30,6 @@
         <file target="lib\uap10.0\Design\Microsoft.Xaml.Interactions.Design.dll"    src="..\out\BehaviorsSDKManaged\bin\AnyCPU\Release\Microsoft.Xaml.Interactions.Design.dll" />
         <file target="lib\uap10.0\Design\Microsoft.Xaml.Interactions.Design.pdb"    src="..\out\BehaviorsSDKManaged\bin\AnyCPU\Release\Microsoft.Xaml.Interactions.Design.pdb" />
 
-        <file target="lib\uap10.0\Microsoft.Xaml.Interactivity\Properties\Microsoft.Xaml.Interactivity.rd.xml"  src="..\src\BehaviorsSDKManaged\Microsoft.Xaml.Interactivity\Properties\Microsoft.Xaml.Interactivity.rd.xml" />
-        <file target="lib\uap10.0\Microsoft.Xaml.Interactions\Properties\Microsoft.Xaml.Interactions.rd.xml"    src="..\src\BehaviorsSDKManaged\Microsoft.Xaml.Interactions\Properties\Microsoft.Xaml.Interactions.rd.xml" />
-
         <file target="src\BehaviorsSDKManaged\Microsoft.Xaml.Interactions"          src="..\src\BehaviorsSDKManaged\Microsoft.Xaml.Interactions\**\*.cs" />
         <file target="src\BehaviorsSDKManaged\Microsoft.Xaml.Interactions.Design"   src="..\src\BehaviorsSDKManaged\Microsoft.Xaml.Interactions.Design\**\*.cs" />
         <file target="src\BehaviorsSDKManaged\Microsoft.Xaml.Interactivity"         src="..\src\BehaviorsSDKManaged\Microsoft.Xaml.Interactivity\**\*.cs" />

--- a/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactions/Microsoft.Xaml.Interactions.csproj
+++ b/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactions/Microsoft.Xaml.Interactions.csproj
@@ -145,7 +145,7 @@
     <Compile Include="Media\PlaySoundAction.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="..\Version\Version.cs" />
-    <Content Include="Properties\Microsoft.Xaml.Interactions.rd.xml" />
+    <EmbeddedResource Include="Properties\Microsoft.Xaml.Interactions.rd.xml" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.Xaml.Interactivity\Microsoft.Xaml.Interactivity.csproj">

--- a/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactivity/Microsoft.Xaml.Interactivity.csproj
+++ b/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactivity/Microsoft.Xaml.Interactivity.csproj
@@ -144,7 +144,7 @@
     <Compile Include="ResourceHelper.cs" />
     <Compile Include="TypeConstraintAttribute.cs" />
     <Compile Include="VisualStateUtilities.cs" />
-    <Content Include="Properties\Microsoft.Xaml.Interactivity.rd.xml" />
+    <EmbeddedResource Include="Properties\Microsoft.Xaml.Interactivity.rd.xml" />
   </ItemGroup>
   <ItemGroup>
     <XliffResource Include="MultilingualResources\Microsoft.Xaml.Interactivity.de-DE.xlf" />


### PR DESCRIPTION
This is inline with the default value when creating a new library, where
the file has Build Action set to Embedded Resource (as referenced here:
http://blogs.msdn.com/b/dotnet/archive/2014/05/23/net-native-deep-dive-making-your-library-great.aspx)

Also made the necessary changes in the managed nuspec file to ignore
these files as they are no longer required in the output nuget package.