### PR TITLE
modified native build configuration

### DIFF
--- a/src/BehaviorsSDKNative/BehaviorsSDKNative.sln
+++ b/src/BehaviorsSDKNative/BehaviorsSDKNative.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
-VisualStudioVersion = 14.0.24710.0
+VisualStudioVersion = 14.0.24720.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Microsoft.Xaml.Interactivity", "Microsoft.Xaml.Interactivity\Microsoft.Xaml.Interactivity.vcxproj", "{721B956C-043C-4658-8AA7-D72FD5F112BF}"
 EndProject
@@ -29,6 +29,7 @@ Global
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{721B956C-043C-4658-8AA7-D72FD5F112BF}.Debug|Any CPU.ActiveCfg = Debug|Win32
+		{721B956C-043C-4658-8AA7-D72FD5F112BF}.Debug|Any CPU.Build.0 = Debug|Win32
 		{721B956C-043C-4658-8AA7-D72FD5F112BF}.Debug|ARM.ActiveCfg = Debug|ARM
 		{721B956C-043C-4658-8AA7-D72FD5F112BF}.Debug|ARM.Build.0 = Debug|ARM
 		{721B956C-043C-4658-8AA7-D72FD5F112BF}.Debug|x64.ActiveCfg = Debug|x64
@@ -36,6 +37,7 @@ Global
 		{721B956C-043C-4658-8AA7-D72FD5F112BF}.Debug|x86.ActiveCfg = Debug|Win32
 		{721B956C-043C-4658-8AA7-D72FD5F112BF}.Debug|x86.Build.0 = Debug|Win32
 		{721B956C-043C-4658-8AA7-D72FD5F112BF}.Release|Any CPU.ActiveCfg = Release|Win32
+		{721B956C-043C-4658-8AA7-D72FD5F112BF}.Release|Any CPU.Build.0 = Release|Win32
 		{721B956C-043C-4658-8AA7-D72FD5F112BF}.Release|ARM.ActiveCfg = Release|ARM
 		{721B956C-043C-4658-8AA7-D72FD5F112BF}.Release|ARM.Build.0 = Release|ARM
 		{721B956C-043C-4658-8AA7-D72FD5F112BF}.Release|x64.ActiveCfg = Release|x64
@@ -43,6 +45,7 @@ Global
 		{721B956C-043C-4658-8AA7-D72FD5F112BF}.Release|x86.ActiveCfg = Release|Win32
 		{721B956C-043C-4658-8AA7-D72FD5F112BF}.Release|x86.Build.0 = Release|Win32
 		{EAF5DE54-6367-456A-8012-76775F514C5E}.Debug|Any CPU.ActiveCfg = Debug|Win32
+		{EAF5DE54-6367-456A-8012-76775F514C5E}.Debug|Any CPU.Build.0 = Debug|Win32
 		{EAF5DE54-6367-456A-8012-76775F514C5E}.Debug|ARM.ActiveCfg = Debug|ARM
 		{EAF5DE54-6367-456A-8012-76775F514C5E}.Debug|ARM.Build.0 = Debug|ARM
 		{EAF5DE54-6367-456A-8012-76775F514C5E}.Debug|x64.ActiveCfg = Debug|x64
@@ -50,6 +53,7 @@ Global
 		{EAF5DE54-6367-456A-8012-76775F514C5E}.Debug|x86.ActiveCfg = Debug|Win32
 		{EAF5DE54-6367-456A-8012-76775F514C5E}.Debug|x86.Build.0 = Debug|Win32
 		{EAF5DE54-6367-456A-8012-76775F514C5E}.Release|Any CPU.ActiveCfg = Release|Win32
+		{EAF5DE54-6367-456A-8012-76775F514C5E}.Release|Any CPU.Build.0 = Release|Win32
 		{EAF5DE54-6367-456A-8012-76775F514C5E}.Release|ARM.ActiveCfg = Release|ARM
 		{EAF5DE54-6367-456A-8012-76775F514C5E}.Release|ARM.Build.0 = Release|ARM
 		{EAF5DE54-6367-456A-8012-76775F514C5E}.Release|x64.ActiveCfg = Release|x64


### PR DESCRIPTION
the build configuration for the native solution did not include
Microsoft.Xaml.Interactions or Microsoft.Xaml.Interactivity in the
build.  This cause the AppVeyor automated build to fail.  I modified the
build configuration to see if that would fix the automated build issue.