### PR TITLE
Project references updated

### DIFF
--- a/src/BehaviorsSDKNative/Microsoft.Xaml.Interactions.Design/Microsoft.Xaml.Interactions.Design.csproj
+++ b/src/BehaviorsSDKNative/Microsoft.Xaml.Interactions.Design/Microsoft.Xaml.Interactions.Design.csproj
@@ -44,10 +44,6 @@
     <DelaySign>true</DelaySign>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.Xaml.Interactions">
-      <HintPath>..\..\..\out\$(SolutionName)\bin\Win32\$(Configuration)\Microsoft.Xaml.Interactions\Microsoft.Xaml.Interactions.winmd</HintPath>
-      <Aliases>global</Aliases>
-    </Reference>
     <Reference Include="Microsoft.Windows.Design.Extensibility, Version=4.3.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=x86" />
     <Reference Include="Microsoft.Windows.Design.Interaction, Version=4.3.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=x86" />
     <Reference Include="System" />
@@ -129,6 +125,12 @@
     </None>
     <AppDesigner Include="Properties\" />
     <None Include="..\..\..\key\35MSSharedLib1024.snk" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Microsoft.Xaml.Interactions\Microsoft.Xaml.Interactions.vcxproj">
+      <Project>{eaf5de54-6367-456a-8012-76775f514c5e}</Project>
+      <Name>Microsoft.Xaml.Interactions</Name>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/src/BehaviorsSDKNative/Microsoft.Xaml.Interactivity.Design/Microsoft.Xaml.Interactivity.Design.csproj
+++ b/src/BehaviorsSDKNative/Microsoft.Xaml.Interactivity.Design/Microsoft.Xaml.Interactivity.Design.csproj
@@ -44,10 +44,6 @@
     <DelaySign>true</DelaySign>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.Xaml.Interactivity">
-      <HintPath>..\..\..\out\$(SolutionName)\bin\Win32\$(Configuration)\Microsoft.Xaml.Interactivity\Microsoft.Xaml.Interactivity.winmd</HintPath>
-      <Aliases>global</Aliases>
-    </Reference>
     <Reference Include="Microsoft.Windows.Design.Extensibility, Version=4.3.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=x86" />
     <Reference Include="Microsoft.Windows.Design.Interaction, Version=4.3.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=x86" />
     <Reference Include="System" />
@@ -129,6 +125,12 @@
     </None>
     <AppDesigner Include="Properties\" />
     <None Include="..\..\..\key\35MSSharedLib1024.snk" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Microsoft.Xaml.Interactivity\Microsoft.Xaml.Interactivity.vcxproj">
+      <Project>{721b956c-043c-4658-8aa7-d72fd5f112bf}</Project>
+      <Name>Microsoft.Xaml.Interactivity</Name>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 


### PR DESCRIPTION
it seems the designer projects were not referencing their respective projects in the native solution, but instead a relative folder path.  This was causing the design assemblies to be built prior to the dependent assemblies, which in turn caused the automated build to fail.  Now, I am hoping the dependent projects will be built first which will fix the failing automated builds.  Crossing fingers.