### PR TITLE
Fixed #76: Properly check for Windows Runtime events in EventTriggerBehavior

### DIFF
--- a/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactions/Core/EventTriggerBehavior.cs
+++ b/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactions/Core/EventTriggerBehavior.cs
@@ -185,7 +185,7 @@ namespace Microsoft.Xaml.Interactions.Core
                 MethodInfo methodInfo = typeof(EventTriggerBehavior).GetTypeInfo().GetDeclaredMethod("OnEvent");
                 this.eventHandler = methodInfo.CreateDelegate(info.EventHandlerType, this);
 
-                this.isWindowsRuntimeEvent = EventTriggerBehavior.IsWindowsRuntimeType(info.EventHandlerType);
+                this.isWindowsRuntimeEvent = EventTriggerBehavior.IsWindowsRuntimeEvent(info);
                 if (this.isWindowsRuntimeEvent)
                 {
                     this.addEventHandlerMethod = add => (EventRegistrationToken)info.AddMethod.Invoke(this.resolvedSource, new object[] { add });
@@ -286,6 +286,13 @@ namespace Microsoft.Xaml.Interactions.Core
             }
 
             return (parent != null || (rootVisual != null && element == rootVisual));
+        }
+
+        private static bool IsWindowsRuntimeEvent(EventInfo eventInfo)
+        {
+            return eventInfo != null &&
+                EventTriggerBehavior.IsWindowsRuntimeType(eventInfo.EventHandlerType) &&
+                EventTriggerBehavior.IsWindowsRuntimeType(eventInfo.DeclaringType);
         }
 
         private static bool IsWindowsRuntimeType(Type type)


### PR DESCRIPTION
Developers can reuse the Windows Runtime event handlers in their custom
controls, but for those cases, the EventTriggerBerhavior shouldn't use
the WindowsRuntimeMarshal class.

This change ensures that not only the EventInfo.EventHandler is checked
for Windows Runtime type, but also that the EventInfo.DeclaringType is
also checked.

This ensures that a custom button extendind the Button Windows Runtime
class will still consider the Click event as a Windows Runtime event,
but a custom MyClick event in it, wouldn't.