### PR TITLE
Samples use build output rather than nuget packages

### DIFF
--- a/samples/CS/XAMLBehaviorsSample/XAMLBehaviorsSample.csproj
+++ b/samples/CS/XAMLBehaviorsSample/XAMLBehaviorsSample.csproj
@@ -298,6 +298,16 @@
       <ContainsDesignTimeResources>true</ContainsDesignTimeResources>
     </Page>
   </ItemGroup>
+  <ItemGroup>
+    <Reference Include="Microsoft.Xaml.Interactions, Version=1.0.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\..\out\BehaviorsSDKManaged\bin\AnyCPU\Debug\Microsoft.Xaml.Interactions.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Xaml.Interactivity, Version=1.0.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\..\out\BehaviorsSDKManaged\bin\AnyCPU\Debug\Microsoft.Xaml.Interactivity.dll</HintPath>
+    </Reference>
+  </ItemGroup>
   <PropertyGroup Condition=" '$(VisualStudioVersion)' == '' or '$(VisualStudioVersion)' &lt; '14.0' ">
     <VisualStudioVersion>14.0</VisualStudioVersion>
   </PropertyGroup>

--- a/samples/CS/XAMLBehaviorsSample/project.json
+++ b/samples/CS/XAMLBehaviorsSample/project.json
@@ -1,6 +1,5 @@
 ﻿{
   "dependencies": {
-    "Microsoft.Xaml.Behaviors.Uwp.Managed": "1.0.*",
     "Microsoft.NETCore.UniversalWindowsPlatform": "5.0.0"
   },
   "frameworks": {

--- a/samples/Cpp/XAMLBehaviorsSampleCpp/XAMLBehaviorsSampleCpp.vcxproj
+++ b/samples/Cpp/XAMLBehaviorsSampleCpp/XAMLBehaviorsSampleCpp.vcxproj
@@ -264,9 +264,6 @@
     <AppxManifest Include="Package.appxmanifest">
       <SubType>Designer</SubType>
     </AppxManifest>
-    <None Include="packages.config">
-      <SubType>Designer</SubType>
-    </None>
     <None Include="XAMLBehaviorsSampleCpp_TemporaryKey.pfx" />
   </ItemGroup>
   <ItemGroup>
@@ -339,14 +336,16 @@
     <Media Include="Assets\Ding.mp3" />
     <Media Include="Assets\Whistle.mp3" />
   </ItemGroup>
+  <ItemGroup>
+    <Reference Include="Microsoft.Xaml.Interactions">
+      <HintPath>..\..\..\out\BehaviorsSDKNative\bin\Win32\Debug\Microsoft.Xaml.Interactions\Microsoft.Xaml.Interactions.winmd</HintPath>
+      <IsWinMDFile>true</IsWinMDFile>
+    </Reference>
+    <Reference Include="Microsoft.Xaml.Interactivity">
+      <HintPath>..\..\..\out\BehaviorsSDKNative\bin\Win32\Debug\Microsoft.Xaml.Interactivity\Microsoft.Xaml.Interactivity.winmd</HintPath>
+      <IsWinMDFile>true</IsWinMDFile>
+    </Reference>
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
-  <ImportGroup Label="ExtensionTargets">
-    <Import Project="..\packages\Microsoft.Xaml.Behaviors.Uwp.Native.1.0.0\build\native\Microsoft.Xaml.Behaviors.Uwp.Native.targets" Condition="Exists('..\packages\Microsoft.Xaml.Behaviors.Uwp.Native.1.0.0\build\native\Microsoft.Xaml.Behaviors.Uwp.Native.targets')" />
-  </ImportGroup>
-  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
-    <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
-    </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Microsoft.Xaml.Behaviors.Uwp.Native.1.0.0\build\native\Microsoft.Xaml.Behaviors.Uwp.Native.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Xaml.Behaviors.Uwp.Native.1.0.0\build\native\Microsoft.Xaml.Behaviors.Uwp.Native.targets'))" />
-  </Target>
+  <ImportGroup Label="ExtensionTargets" />
 </Project>

--- a/samples/Cpp/XAMLBehaviorsSampleCpp/packages.config
+++ b/samples/Cpp/XAMLBehaviorsSampleCpp/packages.config
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="BehaviorsSDK-Native" version="1.0.0" targetFramework="native" />
-</packages>


### PR DESCRIPTION
To enable easier testing and issue reproduction both the managed and native sample apps use the build output.

Would definitely like a second pair of eyes on the native sample app.