### PR TITLE
Fixed #89: Ensured EventTriggerBehavior supports x:Bind bindings

### DIFF
--- a/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactions/Core/EventTriggerBehavior.cs
+++ b/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactions/Core/EventTriggerBehavior.cs
@@ -175,11 +175,7 @@ namespace Microsoft.Xaml.Interactions.Core
                 EventInfo info = sourceObjectType.GetRuntimeEvent(eventName);
                 if (info == null)
                 {
-                    throw new ArgumentException(string.Format(
-                        CultureInfo.CurrentCulture,
-                        ResourceHelper.CannotFindEventNameExceptionMessage,
-                        this.EventName,
-                        sourceObjectType.Name));
+                    return;
                 }
 
                 MethodInfo methodInfo = typeof(EventTriggerBehavior).GetTypeInfo().GetDeclaredMethod("OnEvent");


### PR DESCRIPTION
For x:Bind to work with EventTriggerbehavior, we need to ensure that no exception gets raised for not finding the request event on the source object, as this will might (will) get evaluate at a later phase.

So instead of raising an exception, we just gracefully return from the method.