### PR TITLE
Adds an interface for triggers. Resolves #20

### DIFF
--- a/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactions/Core/DataTriggerBehavior.cs
+++ b/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactions/Core/DataTriggerBehavior.cs
@@ -12,18 +12,8 @@ namespace Microsoft.Xaml.Interactions.Core
     /// A behavior that performs actions when the bound data meets a specified condition.
     /// </summary>
     [ContentPropertyAttribute(Name = "Actions")]
-    public sealed class DataTriggerBehavior : Behavior
+    public sealed class DataTriggerBehavior : Trigger
     {
-        /// <summary> q
-        /// Identifies the <seealso cref="Actions"/> dependency property.
-        /// </summary>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Security", "CA2104:DoNotDeclareReadOnlyMutableReferenceTypes")]
-        public static readonly DependencyProperty ActionsProperty = DependencyProperty.Register(
-            "Actions",
-            typeof(ActionCollection),
-            typeof(DataTriggerBehavior),
-            new PropertyMetadata(null));
-
         /// <summary>
         /// Identifies the <seealso cref="Binding"/> dependency property.
         /// </summary>
@@ -54,24 +44,6 @@ namespace Microsoft.Xaml.Interactions.Core
             typeof(object),
             typeof(DataTriggerBehavior),
             new PropertyMetadata(null, new PropertyChangedCallback(DataTriggerBehavior.OnValueChanged)));
-
-        /// <summary>
-        /// Gets the collection of actions associated with the behavior. This is a dependency property.
-        /// </summary>
-        public ActionCollection Actions
-        {
-            get
-            {
-                ActionCollection actionCollection = (ActionCollection)this.GetValue(DataTriggerBehavior.ActionsProperty);
-                if (actionCollection == null)
-                {
-                    actionCollection = new ActionCollection();
-                    this.SetValue(DataTriggerBehavior.ActionsProperty, actionCollection);
-                }
-
-                return actionCollection;
-            }
-        }
 
         /// <summary>
         /// Gets or sets the bound object that the <see cref="DataTriggerBehavior"/> will listen to. This is a dependency property.

--- a/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactions/Core/EventTriggerBehavior.cs
+++ b/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactions/Core/EventTriggerBehavior.cs
@@ -15,18 +15,8 @@ namespace Microsoft.Xaml.Interactions.Core
     /// A behavior that listens for a specified event on its source and executes its actions when that event is fired.
     /// </summary>
     [ContentPropertyAttribute(Name = "Actions")]
-    public sealed class EventTriggerBehavior : Behavior
+    public sealed class EventTriggerBehavior : Trigger
     {
-        /// <summary>
-        /// Identifies the <seealso cref="Actions"/> dependency property.
-        /// </summary>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Security", "CA2104:DoNotDeclareReadOnlyMutableReferenceTypes")]
-        public static readonly DependencyProperty ActionsProperty = DependencyProperty.Register(
-            "Actions",
-            typeof(ActionCollection),
-            typeof(EventTriggerBehavior),
-            new PropertyMetadata(null));
-
         /// <summary>
         /// Identifies the <seealso cref="EventName"/> dependency property.
         /// </summary>
@@ -59,24 +49,6 @@ namespace Microsoft.Xaml.Interactions.Core
         /// </summary>
         public EventTriggerBehavior()
         {
-        }
-
-        /// <summary>
-        /// Gets the collection of actions associated with the behavior. This is a dependency property.
-        /// </summary>
-        public ActionCollection Actions
-        {
-            get
-            {
-                ActionCollection actionCollection = (ActionCollection)this.GetValue(EventTriggerBehavior.ActionsProperty);
-                if (actionCollection == null)
-                {
-                    actionCollection = new ActionCollection();
-                    this.SetValue(EventTriggerBehavior.ActionsProperty, actionCollection);
-                }
-
-                return actionCollection;
-            }
         }
 
         /// <summary>

--- a/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactivity/ITrigger.cs
+++ b/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactivity/ITrigger.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+namespace Microsoft.Xaml.Interactivity
+{
+    /// <summary>
+    /// Interface implemented by all custom triggers.
+    /// </summary>
+    public interface ITrigger : IBehavior
+    {
+        /// <summary>
+        /// Gets the collection of actions associated with the behavior.
+        /// </summary>
+        ActionCollection Actions { get; }
+    }
+}

--- a/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactivity/Microsoft.Xaml.Interactivity.csproj
+++ b/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactivity/Microsoft.Xaml.Interactivity.csproj
@@ -140,6 +140,7 @@
     <Compile Include="IAction.cs" />
     <Compile Include="IBehavior.cs" />
     <Compile Include="Interaction.cs" />
+    <Compile Include="ITrigger.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="..\Version\Version.cs" />
     <Compile Include="ResourceHelper.cs" />

--- a/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactivity/Microsoft.Xaml.Interactivity.csproj
+++ b/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactivity/Microsoft.Xaml.Interactivity.csproj
@@ -144,6 +144,8 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="..\Version\Version.cs" />
     <Compile Include="ResourceHelper.cs" />
+    <Compile Include="Trigger.cs" />
+    <Compile Include="TriggerOfT.cs" />
     <Compile Include="TypeConstraintAttribute.cs" />
     <Compile Include="VisualStateUtilities.cs" />
     <EmbeddedResource Include="Properties\Microsoft.Xaml.Interactivity.rd.xml" />

--- a/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactivity/Trigger.cs
+++ b/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactivity/Trigger.cs
@@ -1,0 +1,43 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using Windows.UI.Xaml;
+
+namespace Microsoft.Xaml.Interactivity
+{
+    /// <summary>
+    /// A base class for behaviors, implementing the basic plumbing of ITrigger
+    /// </summary>
+    /// <typeparam name="T">The object type to attach to</typeparam>
+    public abstract class Trigger : Behavior, ITrigger
+    {
+        /// <summary>
+        /// Identifies the <seealso cref="Actions"/> dependency property.
+        /// </summary>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Security", "CA2104:DoNotDeclareReadOnlyMutableReferenceTypes")]
+        public static readonly DependencyProperty ActionsProperty = DependencyProperty.Register(
+            "Actions",
+            typeof(ActionCollection),
+            typeof(Trigger),
+            new PropertyMetadata(null));
+
+        /// <summary>
+        /// Gets the collection of actions associated with the behavior. This is a dependency property.
+        /// </summary>
+        public ActionCollection Actions
+        {
+            get
+            {
+                ActionCollection actionCollection = (ActionCollection)this.GetValue(Trigger.ActionsProperty);
+                if (actionCollection == null)
+                {
+                    actionCollection = new ActionCollection();
+                    this.SetValue(Trigger.ActionsProperty, actionCollection);
+                }
+
+                return actionCollection;
+            }
+        }
+    }
+}

--- a/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactivity/TriggerOfT.cs
+++ b/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactivity/TriggerOfT.cs
@@ -1,0 +1,42 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using Windows.UI.Xaml;
+
+namespace Microsoft.Xaml.Interactivity
+{
+    /// <summary>
+    /// A base class for behaviors, implementing the basic plumbing of ITrigger
+    /// </summary>
+    public abstract class Trigger<T> : Trigger where T : DependencyObject
+    {
+        /// <summary>
+        /// Gets the object to which this behavior is attached.
+        /// </summary>
+        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+        public new T AssociatedObject
+        {
+            get { return base.AssociatedObject as T; }
+        }
+
+        /// <summary>
+        /// Called after the behavior is attached to the <see cref="Microsoft.Xaml.Interactivity.Behavior.AssociatedObject"/>.
+        /// </summary>
+        /// <remarks>
+        /// Override this to hook up functionality to the <see cref="Microsoft.Xaml.Interactivity.Behavior.AssociatedObject"/>
+        /// </remarks>
+        protected override void OnAttached()
+        {
+            base.OnAttached();
+
+            if (this.AssociatedObject == null)
+            {
+                string actualType = base.AssociatedObject.GetType().FullName;
+                string expectedType = typeof(T).FullName;
+                string message = string.Format(ResourceHelper.GetString("InvalidAssociatedObjectExceptionMessage"), actualType, expectedType);
+                throw new InvalidOperationException(message);
+            }
+        }
+    }
+}


### PR DESCRIPTION
The current design doesn't have a contract for a trigger style behavior now that both triggers and behaviors have been merged into one.

This affects any framework that works with triggers in abstract (such as Caliburn.Micro) where the following is not possible.

``` csharp
IBehavior trigger = CreateTrigger();
IAction action = CreateAction();

trigger.Actions.Add(action);
```

I propose adding a new interface

``` csharp
public interface ITriggerBehavior : IBehavior
{
    ActionCollection Actions { get;}
}
```

and applying to this to the out of the box triggers.