### PR TITLE
Fixed #103: Check for CommandParamenter value set instead of non-null value

### DIFF
--- a/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactions/Core/InvokeCommandAction.cs
+++ b/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactions/Core/InvokeCommandAction.cs
@@ -158,7 +158,7 @@ namespace Microsoft.Xaml.Interactions.Core
             }
 
             object resolvedParameter;
-            if (this.CommandParameter != null)
+            if (this.ReadLocalValue(InvokeCommandAction.CommandParameterProperty) != DependencyProperty.UnsetValue)
             {
                 resolvedParameter = this.CommandParameter;
             }


### PR DESCRIPTION
As it currently stands, the InvokeCommandAction.CommandParamenter can never have a null value as it will make it fallback to the other approaches, which can raise an InvalidCastException.

A null value should be allowed for the CommandParameter, so instead of doing a null check, I've replaced it with a property unset check.