### PR TITLE
Move ContentProperty to base. Resolves #102

### DIFF
--- a/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactions/Core/DataTriggerBehavior.cs
+++ b/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactions/Core/DataTriggerBehavior.cs
@@ -5,13 +5,11 @@ namespace Microsoft.Xaml.Interactions.Core
     using System;
     using System.Globalization;
     using Windows.UI.Xaml;
-    using Windows.UI.Xaml.Markup;
     using Interactivity;
 
     /// <summary>
     /// A behavior that performs actions when the bound data meets a specified condition.
     /// </summary>
-    [ContentPropertyAttribute(Name = "Actions")]
     public sealed class DataTriggerBehavior : Trigger
     {
         /// <summary>

--- a/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactions/Core/EventTriggerBehavior.cs
+++ b/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactions/Core/EventTriggerBehavior.cs
@@ -7,14 +7,12 @@ namespace Microsoft.Xaml.Interactions.Core
     using System.Reflection;
     using System.Runtime.InteropServices.WindowsRuntime;
     using Windows.UI.Xaml;
-    using Windows.UI.Xaml.Markup;
     using Windows.UI.Xaml.Media;
     using Interactivity;
 
     /// <summary>
     /// A behavior that listens for a specified event on its source and executes its actions when that event is fired.
     /// </summary>
-    [ContentPropertyAttribute(Name = "Actions")]
     public sealed class EventTriggerBehavior : Trigger
     {
         /// <summary>

--- a/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactivity/Trigger.cs
+++ b/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactivity/Trigger.cs
@@ -3,12 +3,14 @@
 
 using System;
 using Windows.UI.Xaml;
+using Windows.UI.Xaml.Markup;
 
 namespace Microsoft.Xaml.Interactivity
 {
     /// <summary>
     /// A base class for behaviors, implementing the basic plumbing of ITrigger
     /// </summary>
+    [ContentPropertyAttribute(Name = "Actions")]
     public abstract class Trigger : Behavior, ITrigger
     {
         /// <summary>


### PR DESCRIPTION
Looks like the samples compilation error was caused by the ContentPropertyAttribute not being on the class the declared the property.

Resolves #102 