### PR TITLE
Fix for native behavior memory leak

### DIFF
--- a/src/BehaviorsSDKNative/Microsoft.Xaml.Interactivity/BehaviorCollection.h
+++ b/src/BehaviorsSDKNative/Microsoft.Xaml.Interactivity/BehaviorCollection.h
@@ -24,7 +24,7 @@ namespace Microsoft { namespace Xaml { namespace Interactivity
 		{
 			::Windows::UI::Xaml::DependencyObject^ get()
 			{
-				return this->associatedObject;
+				return this->associatedObject.Resolve<Windows::UI::Xaml::DependencyObject>();
 			}
 		}
 
@@ -46,7 +46,7 @@ namespace Microsoft { namespace Xaml { namespace Interactivity
 		// After a VectorChanged event we need to compare the current state of the collection
 		// with the old collection so that we can call Detach on all removed items.
 		std::vector<IBehavior^> oldCollection;
-		::Windows::UI::Xaml::DependencyObject^ associatedObject;
+		::Platform::WeakReference associatedObject;
 
 		void OnVectorChanged(
 			::Windows::Foundation::Collections::IObservableVector<::Windows::UI::Xaml::DependencyObject^>^ sender,


### PR DESCRIPTION
This fixes a memory leak which occurs with all native behaviors.

The leak was caused by BehaviorCollection holding a strong reference to the associated object that the behaviour is attached to.

With this change a weak reference is held and is resolved through the property getter. The change is minimal as any private references to the member went via the getter already.