### PR TITLE
Added .editorconfig, avoid conflicts with personal C# Code Style settings

### DIFF
--- a/src/BehaviorsSDKManaged/.editorconfig
+++ b/src/BehaviorsSDKManaged/.editorconfig
@@ -1,0 +1,238 @@
+# Remove the line below if you want to inherit .editorconfig settings from higher directories
+root = true
+
+# C# files
+[*.cs]
+
+#### Core EditorConfig Options ####
+
+# Indentation and spacing
+indent_size = 4
+indent_style = space
+tab_width = 4
+
+# New line preferences
+end_of_line = crlf
+insert_final_newline = false
+
+#### .NET Coding Conventions ####
+
+# this. and Me. preferences
+dotnet_style_qualification_for_event = true:silent
+dotnet_style_qualification_for_field = true:silent
+dotnet_style_qualification_for_method = true:silent
+dotnet_style_qualification_for_property = true:silent
+
+# Language keywords vs BCL types preferences
+dotnet_style_predefined_type_for_locals_parameters_members = true:silent
+dotnet_style_predefined_type_for_member_access = true:silent
+
+# Parentheses preferences
+dotnet_style_parentheses_in_arithmetic_binary_operators = always_for_clarity:silent
+dotnet_style_parentheses_in_other_binary_operators = always_for_clarity:silent
+dotnet_style_parentheses_in_other_operators = never_if_unnecessary:silent
+dotnet_style_parentheses_in_relational_binary_operators = always_for_clarity:silent
+
+# Modifier preferences
+dotnet_style_require_accessibility_modifiers = for_non_interface_members:silent
+
+# Expression-level preferences
+csharp_style_deconstructed_variable_declaration = true:suggestion
+csharp_style_inlined_variable_declaration = true:silent
+csharp_style_throw_expression = true:suggestion
+dotnet_style_coalesce_expression = true:suggestion
+dotnet_style_collection_initializer = true:suggestion
+dotnet_style_explicit_tuple_names = true:suggestion
+dotnet_style_null_propagation = true:suggestion
+dotnet_style_object_initializer = true:suggestion
+dotnet_style_prefer_auto_properties = true:silent
+dotnet_style_prefer_conditional_expression_over_assignment = true:silent
+dotnet_style_prefer_conditional_expression_over_return = true:silent
+dotnet_style_prefer_inferred_anonymous_type_member_names = true:suggestion
+dotnet_style_prefer_inferred_tuple_names = true:suggestion
+dotnet_style_prefer_is_null_check_over_reference_equality_method = true:suggestion
+
+# Field preferences
+dotnet_style_readonly_field = true:suggestion
+
+#### C# Coding Conventions ####
+
+# var preferences
+csharp_style_var_elsewhere = true:silent
+csharp_style_var_for_built_in_types = true:silent
+csharp_style_var_when_type_is_apparent = true:silent
+
+# Expression-bodied members
+csharp_style_expression_bodied_accessors = false:silent
+csharp_style_expression_bodied_constructors = false:silent
+csharp_style_expression_bodied_indexers = false:silent
+csharp_style_expression_bodied_lambdas = true:silent
+csharp_style_expression_bodied_methods = false:silent
+csharp_style_expression_bodied_operators = false:silent
+csharp_style_expression_bodied_properties = false:silent
+
+# Pattern matching preferences
+csharp_style_pattern_matching_over_as_with_null_check = true:silent
+csharp_style_pattern_matching_over_is_with_cast_check = true:silent
+
+# Null-checking preferences
+csharp_style_conditional_delegate_call = true:suggestion
+
+# Modifier preferences
+csharp_preferred_modifier_order = public,private,protected,internal,static,extern,new,virtual,abstract,sealed,override,readonly,unsafe,volatile,async
+
+# Code-block preferences
+csharp_prefer_braces = true:suggestion
+
+# Expression-level preferences
+csharp_prefer_simple_default_expression = true:suggestion
+csharp_style_pattern_local_over_anonymous_function = true:suggestion
+
+#### C# Formatting Rules ####
+
+# New line preferences
+csharp_new_line_before_catch = true
+csharp_new_line_before_else = true
+csharp_new_line_before_finally = true
+csharp_new_line_before_members_in_anonymous_types = true
+csharp_new_line_before_members_in_object_initializers = true
+csharp_new_line_before_open_brace = anonymous_methods,anonymous_types,control_blocks,lambdas,methods,object_collection_array_initalizers,types
+csharp_new_line_between_query_expression_clauses = true
+
+# Indentation preferences
+csharp_indent_block_contents = true
+csharp_indent_braces = false
+csharp_indent_case_contents = true
+csharp_indent_case_contents_when_block = true
+csharp_indent_labels = one_less_than_current
+csharp_indent_switch_labels = true
+
+# Space preferences
+csharp_space_after_cast = false
+csharp_space_after_colon_in_inheritance_clause = true
+csharp_space_after_comma = true
+csharp_space_after_dot = false
+csharp_space_after_keywords_in_control_flow_statements = true
+csharp_space_after_semicolon_in_for_statement = true
+csharp_space_around_binary_operators = before_and_after
+csharp_space_around_declaration_statements = false
+csharp_space_before_colon_in_inheritance_clause = true
+csharp_space_before_comma = false
+csharp_space_before_dot = false
+csharp_space_before_open_square_brackets = false
+csharp_space_before_semicolon_in_for_statement = false
+csharp_space_between_empty_square_brackets = false
+csharp_space_between_method_call_empty_parameter_list_parentheses = false
+csharp_space_between_method_call_name_and_opening_parenthesis = false
+csharp_space_between_method_call_parameter_list_parentheses = false
+csharp_space_between_method_declaration_empty_parameter_list_parentheses = false
+csharp_space_between_method_declaration_name_and_open_parenthesis = false
+csharp_space_between_method_declaration_parameter_list_parentheses = false
+csharp_space_between_parentheses = false
+csharp_space_between_square_brackets = false
+
+# Wrapping preferences
+csharp_preserve_single_line_blocks = true
+csharp_preserve_single_line_statements = true
+
+
+# Naming Symbols
+# constant_fields - Define constant fields
+dotnet_naming_symbols.constant_fields.applicable_kinds                            = field
+dotnet_naming_symbols.constant_fields.required_modifiers                          = const
+# non_private_readonly_fields - Define public, internal and protected readonly fields
+dotnet_naming_symbols.non_private_readonly_fields.applicable_accessibilities      = public, internal, protected
+dotnet_naming_symbols.non_private_readonly_fields.applicable_kinds                = field
+dotnet_naming_symbols.non_private_readonly_fields.required_modifiers              = readonly
+# static_readonly_fields - Define static and readonly fields
+dotnet_naming_symbols.static_readonly_fields.applicable_kinds                     = field
+dotnet_naming_symbols.static_readonly_fields.required_modifiers                   = static, readonly
+# private_readonly_fields - Define private readonly fields
+dotnet_naming_symbols.private_readonly_fields.applicable_accessibilities          = private
+dotnet_naming_symbols.private_readonly_fields.applicable_kinds                    = field
+dotnet_naming_symbols.private_readonly_fields.required_modifiers                  = readonly
+# public_internal_fields - Define public and internal fields
+dotnet_naming_symbols.public_internal_protected_fields.applicable_accessibilities = public, internal, protected
+dotnet_naming_symbols.public_internal_protected_fields.applicable_kinds           = field
+# private_protected_fields - Define private and protected fields
+dotnet_naming_symbols.private_protected_fields.applicable_accessibilities         = private, protected
+dotnet_naming_symbols.private_protected_fields.applicable_kinds                   = field
+# public_symbols - Define any public symbol
+dotnet_naming_symbols.public_symbols.applicable_accessibilities                   = public, internal, protected, protected_internal
+dotnet_naming_symbols.public_symbols.applicable_kinds                             = method, property, event, delegate
+# parameters - Defines any parameter
+dotnet_naming_symbols.parameters.applicable_kinds                                 = parameter
+# non_interface_types - Defines class, struct, enum and delegate types
+dotnet_naming_symbols.non_interface_types.applicable_kinds                        = class, struct, enum, delegate
+# interface_types - Defines interfaces
+dotnet_naming_symbols.interface_types.applicable_kinds                            = interface
+
+# Naming Styles
+# camel_case - Define the camelCase style
+dotnet_naming_style.camel_case.capitalization                                     = camel_case
+# pascal_case - Define the Pascal_case style
+dotnet_naming_style.pascal_case.capitalization                                    = pascal_case
+# first_upper - The first character must start with an upper-case character
+dotnet_naming_style.first_upper.capitalization                                    = first_word_upper
+# prefix_interface_interface_with_i - Interfaces must be PascalCase and the first character of an interface must be an 'I'
+dotnet_naming_style.prefix_interface_interface_with_i.capitalization              = pascal_case
+dotnet_naming_style.prefix_interface_interface_with_i.required_prefix             = I
+
+# Naming Rules
+
+# Async
+dotnet_naming_rule.async_methods_end_in_async.severity                            = silent
+dotnet_naming_rule.async_methods_end_in_async.symbols                             = any_async_methods
+dotnet_naming_rule.async_methods_end_in_async.style                               = end_in_async
+
+dotnet_naming_symbols.any_async_methods.applicable_kinds                          = method
+dotnet_naming_symbols.any_async_methods.applicable_accessibilities                = *
+dotnet_naming_symbols.any_async_methods.required_modifiers                        = async
+
+dotnet_naming_style.end_in_async.required_suffix                                  = Async
+dotnet_naming_style.end_in_async.capitalization                                   = pascal_case
+
+# Constant fields must be PascalCase
+dotnet_naming_rule.constant_fields_must_be_pascal_case.severity                   = silent
+dotnet_naming_rule.constant_fields_must_be_pascal_case.symbols                    = constant_fields
+dotnet_naming_rule.constant_fields_must_be_pascal_case.style                      = pascal_case
+# Public, internal and protected readonly fields must be PascalCase
+dotnet_naming_rule.non_private_readonly_fields_must_be_pascal_case.severity       = silent
+dotnet_naming_rule.non_private_readonly_fields_must_be_pascal_case.symbols        = non_private_readonly_fields
+dotnet_naming_rule.non_private_readonly_fields_must_be_pascal_case.style          = pascal_case
+# Static readonly fields must be PascalCase
+dotnet_naming_rule.static_readonly_fields_must_be_pascal_case.severity            = silent
+dotnet_naming_rule.static_readonly_fields_must_be_pascal_case.symbols             = static_readonly_fields
+dotnet_naming_rule.static_readonly_fields_must_be_pascal_case.style               = pascal_case
+# Private readonly fields must be camelCase
+dotnet_naming_rule.private_readonly_fields_must_be_camel_case.severity            = silent
+dotnet_naming_rule.private_readonly_fields_must_be_camel_case.symbols             = private_readonly_fields
+dotnet_naming_rule.private_readonly_fields_must_be_camel_case.style               = camel_case
+# Public and internal fields must be PascalCase
+dotnet_naming_rule.public_internal_protected_fields_must_be_pascal_case.severity  = silent
+dotnet_naming_rule.public_internal_protected_fields_must_be_pascal_case.symbols   = public_internal_protected_fields
+dotnet_naming_rule.public_internal_protected_fields_must_be_pascal_case.style     = pascal_case
+# Private and protected fields must be camelCase
+dotnet_naming_rule.private_fields_must_be_camel_case.severity                     = silent
+dotnet_naming_rule.private_fields_must_be_camel_case.symbols                      = private_protected_fields
+dotnet_naming_rule.private_fields_must_be_camel_case.style                        = prefix_private_field_with_underscore
+# Public members must be capitalized
+dotnet_naming_rule.public_members_must_be_capitalized.severity                    = silent
+dotnet_naming_rule.public_members_must_be_capitalized.symbols                     = public_symbols
+dotnet_naming_rule.public_members_must_be_capitalized.style                       = first_upper
+# Parameters must be camelCase
+dotnet_naming_rule.parameters_must_be_camel_case.severity                         = silent
+dotnet_naming_rule.parameters_must_be_camel_case.symbols                          = parameters
+dotnet_naming_rule.parameters_must_be_camel_case.style                            = camel_case
+# Class, struct, enum and delegates must be PascalCase
+dotnet_naming_rule.non_interface_types_must_be_pascal_case.severity               = silent
+dotnet_naming_rule.non_interface_types_must_be_pascal_case.symbols                = non_interface_types
+dotnet_naming_rule.non_interface_types_must_be_pascal_case.style                  = pascal_case
+# Interfaces must be PascalCase and start with an 'I'
+dotnet_naming_rule.interface_types_must_be_prefixed_with_i.severity               = silent
+dotnet_naming_rule.interface_types_must_be_prefixed_with_i.symbols                = interface_types
+dotnet_naming_rule.interface_types_must_be_prefixed_with_i.style                  = prefix_interface_interface_with_i
+# prefix_private_field_with_underscore - Private fields must be prefixed with _
+dotnet_naming_style.prefix_private_field_with_underscore.capitalization           = camel_case
+dotnet_naming_style.prefix_private_field_with_underscore.required_prefix          = _
+

--- a/src/BehaviorsSDKManaged/.editorconfig
+++ b/src/BehaviorsSDKManaged/.editorconfig
@@ -215,7 +215,7 @@ dotnet_naming_rule.public_internal_protected_fields_must_be_pascal_case.style   
 # Private and protected fields must be camelCase
 dotnet_naming_rule.private_fields_must_be_camel_case.severity                     = silent
 dotnet_naming_rule.private_fields_must_be_camel_case.symbols                      = private_protected_fields
-dotnet_naming_rule.private_fields_must_be_camel_case.style                        = prefix_private_field_with_underscore
+dotnet_naming_rule.private_fields_must_be_camel_case.style                        = camel_case
 # Public members must be capitalized
 dotnet_naming_rule.public_members_must_be_capitalized.severity                    = silent
 dotnet_naming_rule.public_members_must_be_capitalized.symbols                     = public_symbols
@@ -232,7 +232,4 @@ dotnet_naming_rule.non_interface_types_must_be_pascal_case.style                
 dotnet_naming_rule.interface_types_must_be_prefixed_with_i.severity               = silent
 dotnet_naming_rule.interface_types_must_be_prefixed_with_i.symbols                = interface_types
 dotnet_naming_rule.interface_types_must_be_prefixed_with_i.style                  = prefix_interface_interface_with_i
-# prefix_private_field_with_underscore - Private fields must be prefixed with _
-dotnet_naming_style.prefix_private_field_with_underscore.capitalization           = camel_case
-dotnet_naming_style.prefix_private_field_with_underscore.required_prefix          = _
 

--- a/src/BehaviorsSDKManaged/BehaviorsSDKManaged.sln
+++ b/src/BehaviorsSDKManaged/BehaviorsSDKManaged.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
-VisualStudioVersion = 14.0.24720.0
+# Visual Studio 15
+VisualStudioVersion = 15.0.28010.2048
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Xaml.Interactivity", "Microsoft.Xaml.Interactivity\Microsoft.Xaml.Interactivity.csproj", "{7FFC1385-C3E1-487C-9A81-DE48DD63ECB9}"
 EndProject
@@ -18,6 +18,11 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Xaml.Interactions
 	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ManagedUnitTests", "ManagedUnitTests\ManagedUnitTests.csproj", "{9A26166B-1E98-4723-9B42-FB64BDC231E6}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{2B3854DD-E11F-4758-A892-E27E9AAD92C6}"
+	ProjectSection(SolutionItems) = preProject
+		.editorconfig = .editorconfig
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -110,5 +115,8 @@ Global
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {5590EAFF-6ECD-427C-A50A-A9ABFD9CDB2B}
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
You get a lot of warnings if you have a conflicting personal VS2017 C# Code Style. For example if you have setup braces on the 'same line' and not on the 'next line'. This .editorconfig file overrides the personal settings which avoids these warnings.