### PR TITLE
rename private member variables to have an underscore prefix

### DIFF
--- a/src/BehaviorsSDKManaged/ManagedUnitTests/Stubs.cs
+++ b/src/BehaviorsSDKManaged/ManagedUnitTests/Stubs.cs
@@ -60,16 +60,16 @@ namespace ManagedUnitTests
 
     public class StubAction : DependencyObject, IAction
     {
-        private readonly object returnValue;
+        private readonly object _returnValue;
 
         public StubAction()
         {
-            this.returnValue = null;
+            this._returnValue = null;
         }
 
         public StubAction(object returnValue)
         {
-            this.returnValue = returnValue;
+            this._returnValue = returnValue;
         }
 
         public object Sender
@@ -95,7 +95,7 @@ namespace ManagedUnitTests
             this.ExecuteCount++;
             this.Sender = sender;
             this.Parameter = parameter;
-            return this.returnValue;
+            return this._returnValue;
         }
     }
 

--- a/src/BehaviorsSDKManaged/ManagedUnitTests/TestVisualTreeHelper.cs
+++ b/src/BehaviorsSDKManaged/ManagedUnitTests/TestVisualTreeHelper.cs
@@ -10,11 +10,11 @@ namespace ManagedUnitTests
     /// </summary>
     internal class TestVisualTreeHelper : IVisualTreeHelper
     {
-        private Dictionary<DependencyObject, DependencyObject> parents = new Dictionary<DependencyObject, DependencyObject>();
+        private Dictionary<DependencyObject, DependencyObject> _parents = new Dictionary<DependencyObject, DependencyObject>();
 
         public void AddChild(DependencyObject parent, DependencyObject child)
         {
-            this.parents[child] = parent;
+            this._parents[child] = parent;
         }
 
         #region IVisualTreeHelper implementation
@@ -22,7 +22,7 @@ namespace ManagedUnitTests
         public DependencyObject GetParent(DependencyObject child)
         {
             DependencyObject parent;
-            this.parents.TryGetValue(child, out parent);
+            this._parents.TryGetValue(child, out parent);
             return parent;
         }
 

--- a/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactions.Design/MetadataTableProvider.cs
+++ b/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactions.Design/MetadataTableProvider.cs
@@ -15,15 +15,15 @@ namespace Microsoft.Xaml.Interactivity.Design
 {
     internal class MetadataTableProvider : IProvideAttributeTable
     {
-        private AttributeTableBuilder attributeTableBuilder;
+        private AttributeTableBuilder _attributeTableBuilder;
 
         public AttributeTable AttributeTable
         {
             get
             {
-                if (attributeTableBuilder == null)
+                if (_attributeTableBuilder == null)
                 {
-                    attributeTableBuilder = new AttributeTableBuilder();
+                    _attributeTableBuilder = new AttributeTableBuilder();
                 }
 
                 #region IncrementalUpdateBehavior
@@ -241,13 +241,13 @@ namespace Microsoft.Xaml.Interactivity.Design
                     new CategoryAttribute(Resources.Category_Common_Properties));
                 #endregion
 
-                return attributeTableBuilder.CreateTable();
+                return _attributeTableBuilder.CreateTable();
             }
         }
 
         private void AddAttribute<T>(Attribute attribute)
         {
-            attributeTableBuilder.AddCustomAttributes(typeof(T), attribute);
+            _attributeTableBuilder.AddCustomAttributes(typeof(T), attribute);
         }
         
         private void AddAttributes<T>(params Attribute[] attributes)
@@ -260,7 +260,7 @@ namespace Microsoft.Xaml.Interactivity.Design
 
         private void AddAttribute<T>(string propertyName, Attribute attribute)
         {
-            attributeTableBuilder.AddCustomAttributes(typeof(T), propertyName, attribute);
+            _attributeTableBuilder.AddCustomAttributes(typeof(T), propertyName, attribute);
         }
 
         private void AddAttributes<T>(string propertyName, params Attribute[] attributes)

--- a/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactions/Core/CallMethodAction.cs
+++ b/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactions/Core/CallMethodAction.cs
@@ -35,9 +35,9 @@ namespace Microsoft.Xaml.Interactions.Core
             typeof(CallMethodAction),
             new PropertyMetadata(null, new PropertyChangedCallback(CallMethodAction.OnTargetObjectChanged)));
 
-        private Type targetObjectType;
-        private List<MethodDescriptor> methodDescriptors = new List<MethodDescriptor>();
-        private MethodDescriptor cachedMethodDescriptor;
+        private Type _targetObjectType;
+        private List<MethodDescriptor> _methodDescriptors = new List<MethodDescriptor>();
+        private MethodDescriptor _cachedMethodDescriptor;
 
         /// <summary>
         /// Gets or sets the name of the method to invoke. This is a dependency property.
@@ -105,7 +105,7 @@ namespace Microsoft.Xaml.Interactions.Core
                         CultureInfo.CurrentCulture,
                         ResourceHelper.CallMethodActionValidMethodNotFoundExceptionMessage,
                         this.MethodName,
-                        this.targetObjectType));
+                        this._targetObjectType));
                 }
 
                 return false;
@@ -132,13 +132,13 @@ namespace Microsoft.Xaml.Interactions.Core
 
             if (parameterTypeInfo == null)
             {
-                return this.cachedMethodDescriptor;
+                return this._cachedMethodDescriptor;
             }
 
             MethodDescriptor mostDerivedMethod = null;
 
             // Loop over the methods looking for the one whose type is closest to the type of the given parameter.
-            foreach (MethodDescriptor currentMethod in this.methodDescriptors)
+            foreach (MethodDescriptor currentMethod in this._methodDescriptors)
             {
                 TypeInfo currentTypeInfo = currentMethod.SecondParameterTypeInfo;
 
@@ -151,34 +151,34 @@ namespace Microsoft.Xaml.Interactions.Core
                 }
             }
 
-            return mostDerivedMethod ?? this.cachedMethodDescriptor;
+            return mostDerivedMethod ?? this._cachedMethodDescriptor;
         }
 
         private void UpdateTargetType(Type newTargetType)
         {
-            if (newTargetType == this.targetObjectType)
+            if (newTargetType == this._targetObjectType)
             {
                 return;
             }
 
-            this.targetObjectType = newTargetType;
+            this._targetObjectType = newTargetType;
 
             this.UpdateMethodDescriptors();
         }
 
         private void UpdateMethodDescriptors()
         {
-            this.methodDescriptors.Clear();
-            this.cachedMethodDescriptor = null;
+            this._methodDescriptors.Clear();
+            this._cachedMethodDescriptor = null;
 
-            if (string.IsNullOrEmpty(this.MethodName) || this.targetObjectType == null)
+            if (string.IsNullOrEmpty(this.MethodName) || this._targetObjectType == null)
             {
                 return;
             }
 
             // Find all public methods that match the given name  and have either no parameters,
             // or two parameters where the first is of type Object.
-            foreach (MethodInfo method in this.targetObjectType.GetRuntimeMethods())
+            foreach (MethodInfo method in this._targetObjectType.GetRuntimeMethods())
             {
                 if (string.Equals(method.Name, this.MethodName, StringComparison.Ordinal)
                     && method.ReturnType == typeof(void)
@@ -188,11 +188,11 @@ namespace Microsoft.Xaml.Interactions.Core
                     if (parameters.Length == 0)
                     {
                         // There can be only one parameterless method of the given name.
-                        this.cachedMethodDescriptor = new MethodDescriptor(method, parameters);
+                        this._cachedMethodDescriptor = new MethodDescriptor(method, parameters);
                     }
                     else if (parameters.Length == 2 && parameters[0].ParameterType == typeof(object))
                     {
-                        this.methodDescriptors.Add(new MethodDescriptor(method, parameters));
+                        this._methodDescriptors.Add(new MethodDescriptor(method, parameters));
                     }
                 }
             }
@@ -200,21 +200,21 @@ namespace Microsoft.Xaml.Interactions.Core
             // We didn't find a parameterless method, so we want to find a method that accepts null
             // as a second parameter, but if we have more than one of these it is ambigious which
             // we should call, so we do nothing.
-            if (this.cachedMethodDescriptor == null)
+            if (this._cachedMethodDescriptor == null)
             {
-                foreach (MethodDescriptor method in this.methodDescriptors)
+                foreach (MethodDescriptor method in this._methodDescriptors)
                 {
                     TypeInfo typeInfo = method.SecondParameterTypeInfo;
                     if (!typeInfo.IsValueType || (typeInfo.IsGenericType && typeInfo.GetGenericTypeDefinition() == typeof(Nullable<>)))
                     {
-                        if (this.cachedMethodDescriptor != null)
+                        if (this._cachedMethodDescriptor != null)
                         {
-                            this.cachedMethodDescriptor = null;
+                            this._cachedMethodDescriptor = null;
                             return;
                         }
                         else
                         {
-                            this.cachedMethodDescriptor = method;
+                            this._cachedMethodDescriptor = method;
                         }
                     }
                 }

--- a/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactions/Core/EventTriggerBehavior.cs
+++ b/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactions/Core/EventTriggerBehavior.cs
@@ -35,12 +35,12 @@ namespace Microsoft.Xaml.Interactions.Core
             typeof(EventTriggerBehavior),
             new PropertyMetadata(null, new PropertyChangedCallback(EventTriggerBehavior.OnSourceObjectChanged)));
 
-        private object resolvedSource;
-        private Delegate eventHandler;
-        private bool isLoadedEventRegistered;
-        private bool isWindowsRuntimeEvent;
-        private Func<Delegate, EventRegistrationToken> addEventHandlerMethod;
-        private Action<EventRegistrationToken> removeEventHandlerMethod;
+        private object _resolvedSource;
+        private Delegate _eventHandler;
+        private bool _isLoadedEventRegistered;
+        private bool _isWindowsRuntimeEvent;
+        private Func<Delegate, EventRegistrationToken> _addEventHandlerMethod;
+        private Action<EventRegistrationToken> _removeEventHandlerMethod;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="EventTriggerBehavior"/> class.
@@ -102,19 +102,19 @@ namespace Microsoft.Xaml.Interactions.Core
 
         private void SetResolvedSource(object newSource)
         {
-            if (this.AssociatedObject == null || this.resolvedSource == newSource)
+            if (this.AssociatedObject == null || this._resolvedSource == newSource)
             {
                 return;
             }
 
-            if (this.resolvedSource != null)
+            if (this._resolvedSource != null)
             {
                 this.UnregisterEvent(this.EventName);
             }
 
-            this.resolvedSource = newSource;
+            this._resolvedSource = newSource;
 
-            if (this.resolvedSource != null)
+            if (this._resolvedSource != null)
             {
                 this.RegisterEvent(this.EventName);
             }
@@ -141,7 +141,7 @@ namespace Microsoft.Xaml.Interactions.Core
 
             if (eventName != "Loaded")
             {
-                Type sourceObjectType = this.resolvedSource.GetType();
+                Type sourceObjectType = this._resolvedSource.GetType();
                 EventInfo info = sourceObjectType.GetRuntimeEvent(eventName);
                 if (info == null)
                 {
@@ -149,27 +149,27 @@ namespace Microsoft.Xaml.Interactions.Core
                 }
 
                 MethodInfo methodInfo = typeof(EventTriggerBehavior).GetTypeInfo().GetDeclaredMethod("OnEvent");
-                this.eventHandler = methodInfo.CreateDelegate(info.EventHandlerType, this);
+                this._eventHandler = methodInfo.CreateDelegate(info.EventHandlerType, this);
 
-                this.isWindowsRuntimeEvent = EventTriggerBehavior.IsWindowsRuntimeEvent(info);
-                if (this.isWindowsRuntimeEvent)
+                this._isWindowsRuntimeEvent = EventTriggerBehavior.IsWindowsRuntimeEvent(info);
+                if (this._isWindowsRuntimeEvent)
                 {
-                    this.addEventHandlerMethod = add => (EventRegistrationToken)info.AddMethod.Invoke(this.resolvedSource, new object[] { add });
-                    this.removeEventHandlerMethod = token => info.RemoveMethod.Invoke(this.resolvedSource, new object[] { token });
+                    this._addEventHandlerMethod = add => (EventRegistrationToken)info.AddMethod.Invoke(this._resolvedSource, new object[] { add });
+                    this._removeEventHandlerMethod = token => info.RemoveMethod.Invoke(this._resolvedSource, new object[] { token });
 
-                    WindowsRuntimeMarshal.AddEventHandler(this.addEventHandlerMethod, this.removeEventHandlerMethod, this.eventHandler);
+                    WindowsRuntimeMarshal.AddEventHandler(this._addEventHandlerMethod, this._removeEventHandlerMethod, this._eventHandler);
                 }
                 else
                 {
-                    info.AddEventHandler(this.resolvedSource, this.eventHandler);
+                    info.AddEventHandler(this._resolvedSource, this._eventHandler);
                 }
             }
-            else if (!this.isLoadedEventRegistered)
+            else if (!this._isLoadedEventRegistered)
             {
-                FrameworkElement element = this.resolvedSource as FrameworkElement;
+                FrameworkElement element = this._resolvedSource as FrameworkElement;
                 if (element != null && !EventTriggerBehavior.IsElementLoaded(element))
                 {
-                    this.isLoadedEventRegistered = true;
+                    this._isLoadedEventRegistered = true;
                     element.Loaded += this.OnEvent;
                 }
             }
@@ -184,34 +184,34 @@ namespace Microsoft.Xaml.Interactions.Core
 
             if (eventName != "Loaded")
             {
-                if (this.eventHandler == null)
+                if (this._eventHandler == null)
                 {
                     return;
                 }
 
-                EventInfo info = this.resolvedSource.GetType().GetRuntimeEvent(eventName);
-                if (this.isWindowsRuntimeEvent)
+                EventInfo info = this._resolvedSource.GetType().GetRuntimeEvent(eventName);
+                if (this._isWindowsRuntimeEvent)
                 {
-                    WindowsRuntimeMarshal.RemoveEventHandler(this.removeEventHandlerMethod, this.eventHandler);
+                    WindowsRuntimeMarshal.RemoveEventHandler(this._removeEventHandlerMethod, this._eventHandler);
                 }
                 else
                 {
-                    info.RemoveEventHandler(this.resolvedSource, this.eventHandler);
+                    info.RemoveEventHandler(this._resolvedSource, this._eventHandler);
                 }
 
-                this.eventHandler = null;
+                this._eventHandler = null;
             }
-            else if (this.isLoadedEventRegistered)
+            else if (this._isLoadedEventRegistered)
             {
-                this.isLoadedEventRegistered = false;
-                FrameworkElement element = (FrameworkElement)this.resolvedSource;
+                this._isLoadedEventRegistered = false;
+                FrameworkElement element = (FrameworkElement)this._resolvedSource;
                 element.Loaded -= this.OnEvent;
             }
         }
 
         private void OnEvent(object sender, object eventArgs)
         {
-            Interaction.ExecuteActions(this.resolvedSource, this.Actions, eventArgs);
+            Interaction.ExecuteActions(this._resolvedSource, this.Actions, eventArgs);
         }
 
         private static void OnSourceObjectChanged(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs args)
@@ -223,7 +223,7 @@ namespace Microsoft.Xaml.Interactions.Core
         private static void OnEventNameChanged(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs args)
         {
             EventTriggerBehavior behavior = (EventTriggerBehavior)dependencyObject;
-            if (behavior.AssociatedObject == null || behavior.resolvedSource == null)
+            if (behavior.AssociatedObject == null || behavior._resolvedSource == null)
             {
                 return;
             }

--- a/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactions/Core/IncrementalUpdateBehavior.cs
+++ b/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactions/Core/IncrementalUpdateBehavior.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Xaml.Interactions.Core
             typeof(IncrementalUpdateBehavior),
             new PropertyMetadata(null, new PropertyChangedCallback(IncrementalUpdateBehavior.OnIncrementalUpdaterChanged)));
 
-        private IncrementalUpdater updater = null;
+        private IncrementalUpdater _updater = null;
 
         /// <summary>
         /// Gets or sets the relative priority of this incremental update. Lower Phase values are addressed first.
@@ -95,19 +95,19 @@ namespace Microsoft.Xaml.Interactions.Core
 
         private void OnAssociatedObjectUnloaded(object sender, RoutedEventArgs e)
         {
-            if (this.updater != null)
+            if (this._updater != null)
             {
-                this.updater.UncachePhaseElement(this.AssociatedObject, this.Phase);
+                this._updater.UncachePhaseElement(this.AssociatedObject, this.Phase);
             }
 
-            this.updater = null;
+            this._updater = null;
         }
 
         private IncrementalUpdater FindUpdater()
         {
-            if (this.updater != null)
+            if (this._updater != null)
             {
-                return this.updater;
+                return this._updater;
             }
 
             DependencyObject ancestor = this.AssociatedObject;
@@ -158,79 +158,79 @@ namespace Microsoft.Xaml.Interactions.Core
 
         private class IncrementalUpdater
         {
-            private ListViewBase associatedListViewBase = null;
-            private Dictionary<UIElement, ElementCacheRecord> elementCache = new Dictionary<UIElement, ElementCacheRecord>();
+            private ListViewBase _associatedListViewBase = null;
+            private Dictionary<UIElement, ElementCacheRecord> _elementCache = new Dictionary<UIElement, ElementCacheRecord>();
 
             private class PhasedElementRecord
             {
-                private readonly FrameworkElement frameworkElement;
-                private object localOpacity;
-                private object localDataContext;
-                private bool isFrozen;
+                private readonly FrameworkElement _frameworkElement;
+                private object _localOpacity;
+                private object _localDataContext;
+                private bool _isFrozen;
 
                 public PhasedElementRecord(FrameworkElement frameworkElement)
                 {
-                    this.frameworkElement = frameworkElement;
+                    this._frameworkElement = frameworkElement;
                 }
 
-                public FrameworkElement FrameworkElement { get { return this.frameworkElement; } }
+                public FrameworkElement FrameworkElement { get { return this._frameworkElement; } }
 
                 public void FreezeAndHide()
                 {
-                    if (this.isFrozen)
+                    if (this._isFrozen)
                     {
                         return;
                     }
 
-                    this.isFrozen = true;
-                    this.localOpacity = this.frameworkElement.ReadLocalValue(FrameworkElement.OpacityProperty);
-                    this.localDataContext = this.frameworkElement.ReadLocalValue(FrameworkElement.DataContextProperty);
-                    this.frameworkElement.Opacity = 0.0;
-                    this.frameworkElement.DataContext = this.frameworkElement.DataContext;
+                    this._isFrozen = true;
+                    this._localOpacity = this._frameworkElement.ReadLocalValue(FrameworkElement.OpacityProperty);
+                    this._localDataContext = this._frameworkElement.ReadLocalValue(FrameworkElement.DataContextProperty);
+                    this._frameworkElement.Opacity = 0.0;
+                    this._frameworkElement.DataContext = this._frameworkElement.DataContext;
                 }
 
                 public void ThawAndShow()
                 {
-                    if (!this.isFrozen)
+                    if (!this._isFrozen)
                     {
                         return;
                     }
 
-                    if (this.localOpacity != DependencyProperty.UnsetValue)
+                    if (this._localOpacity != DependencyProperty.UnsetValue)
                     {
-                        this.frameworkElement.SetValue(FrameworkElement.OpacityProperty, this.localOpacity);
+                        this._frameworkElement.SetValue(FrameworkElement.OpacityProperty, this._localOpacity);
                     }
                     else
                     {
-                        this.frameworkElement.ClearValue(FrameworkElement.OpacityProperty);
+                        this._frameworkElement.ClearValue(FrameworkElement.OpacityProperty);
                     }
 
-                    if (this.localDataContext != DependencyProperty.UnsetValue)
+                    if (this._localDataContext != DependencyProperty.UnsetValue)
                     {
-                        this.frameworkElement.SetValue(FrameworkElement.DataContextProperty, this.localDataContext);
+                        this._frameworkElement.SetValue(FrameworkElement.DataContextProperty, this._localDataContext);
                     }
                     else
                     {
-                        this.frameworkElement.ClearValue(FrameworkElement.DataContextProperty);
+                        this._frameworkElement.ClearValue(FrameworkElement.DataContextProperty);
                     }
 
-                    this.isFrozen = false;
+                    this._isFrozen = false;
                 }
             }
 
             private class ElementCacheRecord
             {
-                private List<int> phases = new List<int>();
-                private List<List<PhasedElementRecord>> elementsByPhase = new List<List<PhasedElementRecord>>();
+                private List<int> _phases = new List<int>();
+                private List<List<PhasedElementRecord>> _elementsByPhase = new List<List<PhasedElementRecord>>();
 
                 public List<int> Phases
                 {
-                    get { return this.phases; }
+                    get { return this._phases; }
                 }
 
                 public List<List<PhasedElementRecord>> ElementsByPhase
                 {
-                    get { return this.elementsByPhase; }
+                    get { return this._elementsByPhase; }
                 }
             }
 
@@ -239,7 +239,7 @@ namespace Microsoft.Xaml.Interactions.Core
                 UIElement contentTemplateRoot = e.ItemContainer.ContentTemplateRoot;
 
                 ElementCacheRecord elementCacheRecord;
-                if (this.elementCache.TryGetValue(contentTemplateRoot, out elementCacheRecord))
+                if (this._elementCache.TryGetValue(contentTemplateRoot, out elementCacheRecord))
                 {
                     if (!e.InRecycleQueue)
                     {
@@ -280,7 +280,7 @@ namespace Microsoft.Xaml.Interactions.Core
                 UIElement contentTemplateRoot = e.ItemContainer.ContentTemplateRoot;
 
                 ElementCacheRecord elementCacheRecord;
-                if (this.elementCache.TryGetValue(contentTemplateRoot, out elementCacheRecord))
+                if (this._elementCache.TryGetValue(contentTemplateRoot, out elementCacheRecord))
                 {
                     int phaseIndex = elementCacheRecord.Phases.BinarySearch((int)e.Phase);
 
@@ -342,10 +342,10 @@ namespace Microsoft.Xaml.Interactions.Core
                 {
                     // get the cache for this element
                     ElementCacheRecord elementCacheRecord;
-                    if (!this.elementCache.TryGetValue(contentTemplateRoot, out elementCacheRecord))
+                    if (!this._elementCache.TryGetValue(contentTemplateRoot, out elementCacheRecord))
                     {
                         elementCacheRecord = new ElementCacheRecord();
-                        this.elementCache.Add(contentTemplateRoot, elementCacheRecord);
+                        this._elementCache.Add(contentTemplateRoot, elementCacheRecord);
                     }
 
                     // get the cache for this phase
@@ -387,7 +387,7 @@ namespace Microsoft.Xaml.Interactions.Core
                 {
                     // get the cache for this element
                     ElementCacheRecord elementCacheRecord;
-                    if (this.elementCache.TryGetValue(contentTemplateRoot, out elementCacheRecord))
+                    if (this._elementCache.TryGetValue(contentTemplateRoot, out elementCacheRecord))
                     {
                         // get the cache for this phase
                         int phaseIndex = elementCacheRecord.Phases.BinarySearch(phase);
@@ -419,21 +419,21 @@ namespace Microsoft.Xaml.Interactions.Core
 
             public void Attach(DependencyObject dependencyObject)
             {
-                this.associatedListViewBase = dependencyObject as ListViewBase;
+                this._associatedListViewBase = dependencyObject as ListViewBase;
 
-                if (this.associatedListViewBase != null)
+                if (this._associatedListViewBase != null)
                 {
-                    this.associatedListViewBase.ContainerContentChanging += this.OnContainerContentChanging;
+                    this._associatedListViewBase.ContainerContentChanging += this.OnContainerContentChanging;
                 }
             }
 
             public void Detach()
             {
-                if (this.associatedListViewBase != null)
+                if (this._associatedListViewBase != null)
                 {
-                    this.associatedListViewBase.ContainerContentChanging -= this.OnContainerContentChanging;
+                    this._associatedListViewBase.ContainerContentChanging -= this.OnContainerContentChanging;
                 }
-                this.associatedListViewBase = null;
+                this._associatedListViewBase = null;
             }
         }
     }

--- a/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactions/Core/NavigateToPageAction.cs
+++ b/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactions/Core/NavigateToPageAction.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Xaml.Interactions.Core
     /// </summary>
     public sealed class NavigateToPageAction : DependencyObject, IAction
     {
-        private readonly IVisualTreeHelper visualTreeHelper;
+        private readonly IVisualTreeHelper _visualTreeHelper;
 
         /// <summary>
         /// Identifies the <seealso cref="TargetPage"/> dependency property.
@@ -52,7 +52,7 @@ namespace Microsoft.Xaml.Interactions.Core
         /// </param>
         internal NavigateToPageAction(IVisualTreeHelper visualTreeHelper)
         {
-            this.visualTreeHelper = visualTreeHelper;
+            this._visualTreeHelper = visualTreeHelper;
         }
 
         /// <summary>
@@ -123,7 +123,7 @@ namespace Microsoft.Xaml.Interactions.Core
                 navigateElement = senderObject as INavigate;
                 if (navigateElement == null)
                 {
-                    senderObject = this.visualTreeHelper.GetParent(senderObject);
+                    senderObject = this._visualTreeHelper.GetParent(senderObject);
                 }
             }
 

--- a/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactions/Media/ControlStoryboardAction.cs
+++ b/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactions/Media/ControlStoryboardAction.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Xaml.Interactions.Media
 			typeof(ControlStoryboardAction),
 			new PropertyMetadata(null, new PropertyChangedCallback(ControlStoryboardAction.OnStoryboardChanged)));
 
-		private bool isPaused;
+		private bool _isPaused;
 
 		/// <summary>
 		/// Gets or sets the action to execute on the <see cref="Windows.UI.Xaml.Media.Animation.Storyboard"/>. This is a dependency property.
@@ -92,17 +92,17 @@ namespace Microsoft.Xaml.Interactions.Media
 
 						if (currentState == ClockState.Stopped)
 						{
-							this.isPaused = false;
+							this._isPaused = false;
 							this.Storyboard.Begin();
 						}
-						else if (this.isPaused)
+						else if (this._isPaused)
 						{
-							this.isPaused = false;
+							this._isPaused = false;
 							this.Storyboard.Resume();
 						}
 						else
 						{
-							this.isPaused = true;
+							this._isPaused = true;
 							this.Storyboard.Pause();
 						}
 					}
@@ -133,7 +133,7 @@ namespace Microsoft.Xaml.Interactions.Media
 			ControlStoryboardAction action = sender as ControlStoryboardAction;
 			if (action != null)
 			{
-				action.isPaused = false;
+				action._isPaused = false;
 			}
 		}
 	}

--- a/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactions/Media/PlaySoundAction.cs
+++ b/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactions/Media/PlaySoundAction.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Xaml.Interactions.Media
 			typeof(PlaySoundAction),
 			new PropertyMetadata(0.5));
 
-		private Popup popup;
+		private Popup _popup;
 
 		/// <summary>
 		/// Gets or sets the location of the sound file. This is used to set the source property of a <see cref="Windows.UI.Xaml.Controls.MediaElement"/>. This is a dependency property.
@@ -103,9 +103,9 @@ namespace Microsoft.Xaml.Interactions.Media
 				}
 			}
 
-			this.popup = new Popup();
+			this._popup = new Popup();
 			MediaElement mediaElement = new MediaElement();
-			popup.Child = mediaElement;
+			_popup.Child = mediaElement;
 
 			// It is legal (although not advisable) to provide a video file. By setting visibility to collapsed, only the sound track should play.
 			mediaElement.Visibility = Visibility.Collapsed;
@@ -115,27 +115,27 @@ namespace Microsoft.Xaml.Interactions.Media
 			mediaElement.MediaEnded += this.MediaElement_MediaEnded;
 			mediaElement.MediaFailed += this.MediaElement_MediaFailed;
 
-			this.popup.IsOpen = true;
+			this._popup.IsOpen = true;
 			return true;
 		}
 
 		private void MediaElement_MediaFailed(object sender, ExceptionRoutedEventArgs e)
 		{
-			if (this.popup != null)
+			if (this._popup != null)
 			{
-				this.popup.IsOpen = false;
-				this.popup.Child = null;
-				this.popup = null;
+				this._popup.IsOpen = false;
+				this._popup.Child = null;
+				this._popup = null;
 			}
 		}
 
 		private void MediaElement_MediaEnded(object sender, RoutedEventArgs e)
 		{
-			if (this.popup != null)
+			if (this._popup != null)
 			{
-				this.popup.IsOpen = false;
-				this.popup.Child = null;
-				this.popup = null;
+				this._popup.IsOpen = false;
+				this._popup.Child = null;
+				this._popup = null;
 			}
 		}
 	}

--- a/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactivity.Design/MetadataTableProvider.cs
+++ b/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactivity.Design/MetadataTableProvider.cs
@@ -12,27 +12,27 @@ namespace Microsoft.Xaml.Interactivity.Design
 {
     internal class MetadataTableProvider : IProvideAttributeTable
     {
-        private AttributeTableBuilder attributeTableBuilder;
+        private AttributeTableBuilder _attributeTableBuilder;
 
         public AttributeTable AttributeTable
         {
             get
             {
-                if (attributeTableBuilder == null)
+                if (_attributeTableBuilder == null)
                 {
-                    attributeTableBuilder = new AttributeTableBuilder();
+                    _attributeTableBuilder = new AttributeTableBuilder();
                 }
 
                 AddAttribute<ActionCollection>(new CategoryAttribute(Resources.Category_Name_Actions));
                 AddAttribute<BehaviorCollection>(new ToolboxBrowsableAttribute(false));
 
-                return attributeTableBuilder.CreateTable();
+                return _attributeTableBuilder.CreateTable();
             }
         }
 
         private void AddAttribute<T>(Attribute attribute)
         {
-            attributeTableBuilder.AddCustomAttributes(typeof(T), attribute);
+            _attributeTableBuilder.AddCustomAttributes(typeof(T), attribute);
         }
     }
 }

--- a/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactivity/BehaviorCollection.cs
+++ b/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactivity/BehaviorCollection.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Xaml.Interactivity
     {
         // After a VectorChanged event we need to compare the current state of the collection
         // with the old collection so that we can call Detach on all removed items.
-        private readonly List<IBehavior> oldCollection = new List<IBehavior>();
+        private readonly List<IBehavior> _oldCollection = new List<IBehavior>();
 
         /// <summary>
         /// Initializes a new instance of the <see cref="BehaviorCollection"/> class.
@@ -81,14 +81,14 @@ namespace Microsoft.Xaml.Interactivity
             }
 
             this.AssociatedObject = null;
-            this.oldCollection.Clear();
+            this._oldCollection.Clear();
         }
 
         private void BehaviorCollection_VectorChanged(IObservableVector<DependencyObject> sender, IVectorChangedEventArgs eventArgs)
         {
             if (eventArgs.CollectionChange == CollectionChange.Reset)
             {
-                foreach (IBehavior behavior in this.oldCollection)
+                foreach (IBehavior behavior in this._oldCollection)
                 {
                     if (behavior.AssociatedObject != null)
                     {
@@ -96,11 +96,11 @@ namespace Microsoft.Xaml.Interactivity
                     }
                 }
 
-                this.oldCollection.Clear();
+                this._oldCollection.Clear();
 
                 foreach (DependencyObject newItem in this)
                 {
-                    this.oldCollection.Add(this.VerifiedAttach(newItem));
+                    this._oldCollection.Add(this.VerifiedAttach(newItem));
                 }
 
 #if DEBUG
@@ -115,29 +115,29 @@ namespace Microsoft.Xaml.Interactivity
             switch (eventArgs.CollectionChange)
             {
                 case CollectionChange.ItemInserted:
-                    this.oldCollection.Insert(eventIndex, this.VerifiedAttach(changedItem));
+                    this._oldCollection.Insert(eventIndex, this.VerifiedAttach(changedItem));
 
                     break;
 
                 case CollectionChange.ItemChanged:
-                    IBehavior oldItem = this.oldCollection[eventIndex];
+                    IBehavior oldItem = this._oldCollection[eventIndex];
                     if (oldItem.AssociatedObject != null)
                     {
                         oldItem.Detach();
                     }
 
-                    this.oldCollection[eventIndex] = this.VerifiedAttach(changedItem);
+                    this._oldCollection[eventIndex] = this.VerifiedAttach(changedItem);
 
                     break;
 
                 case CollectionChange.ItemRemoved:
-                    oldItem = this.oldCollection[eventIndex];
+                    oldItem = this._oldCollection[eventIndex];
                     if (oldItem.AssociatedObject != null)
                     {
                         oldItem.Detach();
                     }
 
-                    this.oldCollection.RemoveAt(eventIndex);
+                    this._oldCollection.RemoveAt(eventIndex);
                     break;
 
                 default:
@@ -158,7 +158,7 @@ namespace Microsoft.Xaml.Interactivity
                 throw new InvalidOperationException(ResourceHelper.GetString("NonBehaviorAddedToBehaviorCollectionExceptionMessage"));
             }
 
-            if (this.oldCollection.Contains(behavior))
+            if (this._oldCollection.Contains(behavior))
             {
                 throw new InvalidOperationException(ResourceHelper.GetString("DuplicateBehaviorInCollectionExceptionMessage"));
             }
@@ -174,12 +174,12 @@ namespace Microsoft.Xaml.Interactivity
         [Conditional("DEBUG")]
         private void VerifyOldCollectionIntegrity()
         {
-            bool isValid = (this.Count == this.oldCollection.Count);
+            bool isValid = (this.Count == this._oldCollection.Count);
             if (isValid)
             {
                 for (int i = 0; i < this.Count; i++)
                 {
-                    if (this[i] != this.oldCollection[i])
+                    if (this[i] != this._oldCollection[i])
                     {
                         isValid = false;
                         break;

--- a/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactivity/DefaultEventAttribute.cs
+++ b/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactivity/DefaultEventAttribute.cs
@@ -10,8 +10,8 @@ namespace Microsoft.Xaml.Interactivity
 	[AttributeUsage(AttributeTargets.Class, AllowMultiple = true)]
 	public sealed class DefaultEventAttribute : Attribute
 	{
-		private readonly Type targetType;
-		private readonly string eventName;
+		private readonly Type _targetType;
+		private readonly string _eventName;
 
 		/// <summary>
 		/// Initializes a new instance of the <see cref="DefaultEventAttribute"/> class.
@@ -20,8 +20,8 @@ namespace Microsoft.Xaml.Interactivity
 		/// <param name="eventName">The event name for the EventTriggerBehavior.</param>
 		public DefaultEventAttribute(Type targetType, string eventName)
 		{
-			this.targetType = targetType;
-			this.eventName = eventName;
+			this._targetType = targetType;
+			this._eventName = eventName;
 		}
 
 		/// <summary>
@@ -31,7 +31,7 @@ namespace Microsoft.Xaml.Interactivity
 		{
 			get
 			{
-				return this.targetType;
+				return this._targetType;
 			}
 		}
 
@@ -42,7 +42,7 @@ namespace Microsoft.Xaml.Interactivity
 		{
 			get
 			{
-				return this.eventName;
+				return this._eventName;
 			}
 		}
 	}


### PR DESCRIPTION
As discussed in #139, this renames all private member variables to include an underscore prefix. This will help prevent mistakes as to which variable is being used.

NOTE: This does not remove the `this.` prefix from the use of those variables or any other used of the `this.` prefix.

NOTE: The [contributing wiki](https://github.com/Microsoft/XamlBehaviors/wiki/Contributing-Guidelines) will need to be updated once this is merged