### PR TITLE
Referencing the C# Projects instead of the DLL's in the sample project

### DIFF
--- a/samples/CS/XAMLBehaviorsSample.sln
+++ b/samples/CS/XAMLBehaviorsSample.sln
@@ -1,20 +1,27 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
-VisualStudioVersion = 14.0.23107.0
+# Visual Studio 15
+VisualStudioVersion = 15.0.28307.136
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "XAMLBehaviorsSample", "XAMLBehaviorsSample\XAMLBehaviorsSample.csproj", "{050C4B73-9A9F-469B-9FA7-FB481894391F}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Xaml.Interactions", "..\..\src\BehaviorsSDKManaged\Microsoft.Xaml.Interactions\Microsoft.Xaml.Interactions.csproj", "{A338A7F2-9010-477B-8A6E-6C2B2495C33C}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Xaml.Interactivity", "..\..\src\BehaviorsSDKManaged\Microsoft.Xaml.Interactivity\Microsoft.Xaml.Interactivity.csproj", "{7FFC1385-C3E1-487C-9A81-DE48DD63ECB9}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
 		Debug|ARM = Debug|ARM
 		Debug|x64 = Debug|x64
 		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
 		Release|ARM = Release|ARM
 		Release|x64 = Release|x64
 		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{050C4B73-9A9F-469B-9FA7-FB481894391F}.Debug|Any CPU.ActiveCfg = Debug|x86
 		{050C4B73-9A9F-469B-9FA7-FB481894391F}.Debug|ARM.ActiveCfg = Debug|ARM
 		{050C4B73-9A9F-469B-9FA7-FB481894391F}.Debug|ARM.Build.0 = Debug|ARM
 		{050C4B73-9A9F-469B-9FA7-FB481894391F}.Debug|ARM.Deploy.0 = Debug|ARM
@@ -24,6 +31,7 @@ Global
 		{050C4B73-9A9F-469B-9FA7-FB481894391F}.Debug|x86.ActiveCfg = Debug|x86
 		{050C4B73-9A9F-469B-9FA7-FB481894391F}.Debug|x86.Build.0 = Debug|x86
 		{050C4B73-9A9F-469B-9FA7-FB481894391F}.Debug|x86.Deploy.0 = Debug|x86
+		{050C4B73-9A9F-469B-9FA7-FB481894391F}.Release|Any CPU.ActiveCfg = Release|x86
 		{050C4B73-9A9F-469B-9FA7-FB481894391F}.Release|ARM.ActiveCfg = Release|ARM
 		{050C4B73-9A9F-469B-9FA7-FB481894391F}.Release|ARM.Build.0 = Release|ARM
 		{050C4B73-9A9F-469B-9FA7-FB481894391F}.Release|ARM.Deploy.0 = Release|ARM
@@ -33,8 +41,43 @@ Global
 		{050C4B73-9A9F-469B-9FA7-FB481894391F}.Release|x86.ActiveCfg = Release|x86
 		{050C4B73-9A9F-469B-9FA7-FB481894391F}.Release|x86.Build.0 = Release|x86
 		{050C4B73-9A9F-469B-9FA7-FB481894391F}.Release|x86.Deploy.0 = Release|x86
+		{A338A7F2-9010-477B-8A6E-6C2B2495C33C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A338A7F2-9010-477B-8A6E-6C2B2495C33C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A338A7F2-9010-477B-8A6E-6C2B2495C33C}.Debug|ARM.ActiveCfg = Debug|ARM
+		{A338A7F2-9010-477B-8A6E-6C2B2495C33C}.Debug|ARM.Build.0 = Debug|ARM
+		{A338A7F2-9010-477B-8A6E-6C2B2495C33C}.Debug|x64.ActiveCfg = Debug|x64
+		{A338A7F2-9010-477B-8A6E-6C2B2495C33C}.Debug|x64.Build.0 = Debug|x64
+		{A338A7F2-9010-477B-8A6E-6C2B2495C33C}.Debug|x86.ActiveCfg = Debug|x86
+		{A338A7F2-9010-477B-8A6E-6C2B2495C33C}.Debug|x86.Build.0 = Debug|x86
+		{A338A7F2-9010-477B-8A6E-6C2B2495C33C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A338A7F2-9010-477B-8A6E-6C2B2495C33C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A338A7F2-9010-477B-8A6E-6C2B2495C33C}.Release|ARM.ActiveCfg = Release|ARM
+		{A338A7F2-9010-477B-8A6E-6C2B2495C33C}.Release|ARM.Build.0 = Release|ARM
+		{A338A7F2-9010-477B-8A6E-6C2B2495C33C}.Release|x64.ActiveCfg = Release|x64
+		{A338A7F2-9010-477B-8A6E-6C2B2495C33C}.Release|x64.Build.0 = Release|x64
+		{A338A7F2-9010-477B-8A6E-6C2B2495C33C}.Release|x86.ActiveCfg = Release|x86
+		{A338A7F2-9010-477B-8A6E-6C2B2495C33C}.Release|x86.Build.0 = Release|x86
+		{7FFC1385-C3E1-487C-9A81-DE48DD63ECB9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7FFC1385-C3E1-487C-9A81-DE48DD63ECB9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7FFC1385-C3E1-487C-9A81-DE48DD63ECB9}.Debug|ARM.ActiveCfg = Debug|ARM
+		{7FFC1385-C3E1-487C-9A81-DE48DD63ECB9}.Debug|ARM.Build.0 = Debug|ARM
+		{7FFC1385-C3E1-487C-9A81-DE48DD63ECB9}.Debug|x64.ActiveCfg = Debug|x64
+		{7FFC1385-C3E1-487C-9A81-DE48DD63ECB9}.Debug|x64.Build.0 = Debug|x64
+		{7FFC1385-C3E1-487C-9A81-DE48DD63ECB9}.Debug|x86.ActiveCfg = Debug|x86
+		{7FFC1385-C3E1-487C-9A81-DE48DD63ECB9}.Debug|x86.Build.0 = Debug|x86
+		{7FFC1385-C3E1-487C-9A81-DE48DD63ECB9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7FFC1385-C3E1-487C-9A81-DE48DD63ECB9}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7FFC1385-C3E1-487C-9A81-DE48DD63ECB9}.Release|ARM.ActiveCfg = Release|ARM
+		{7FFC1385-C3E1-487C-9A81-DE48DD63ECB9}.Release|ARM.Build.0 = Release|ARM
+		{7FFC1385-C3E1-487C-9A81-DE48DD63ECB9}.Release|x64.ActiveCfg = Release|x64
+		{7FFC1385-C3E1-487C-9A81-DE48DD63ECB9}.Release|x64.Build.0 = Release|x64
+		{7FFC1385-C3E1-487C-9A81-DE48DD63ECB9}.Release|x86.ActiveCfg = Release|x86
+		{7FFC1385-C3E1-487C-9A81-DE48DD63ECB9}.Release|x86.Build.0 = Release|x86
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {BAEA616E-866E-41F8-B6B8-ED0114DDB811}
 	EndGlobalSection
 EndGlobal

--- a/samples/CS/XAMLBehaviorsSample/XAMLBehaviorsSample.csproj
+++ b/samples/CS/XAMLBehaviorsSample/XAMLBehaviorsSample.csproj
@@ -299,14 +299,14 @@
     </Page>
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.Xaml.Interactions, Version=1.0.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\out\BehaviorsSDKManaged\bin\AnyCPU\Debug\Microsoft.Xaml.Interactions.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.Xaml.Interactivity, Version=1.0.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\out\BehaviorsSDKManaged\bin\AnyCPU\Debug\Microsoft.Xaml.Interactivity.dll</HintPath>
-    </Reference>
+    <ProjectReference Include="..\..\..\src\BehaviorsSDKManaged\Microsoft.Xaml.Interactions\Microsoft.Xaml.Interactions.csproj">
+      <Project>{a338a7f2-9010-477b-8a6e-6c2b2495c33c}</Project>
+      <Name>Microsoft.Xaml.Interactions</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\..\src\BehaviorsSDKManaged\Microsoft.Xaml.Interactivity\Microsoft.Xaml.Interactivity.csproj">
+      <Project>{7ffc1385-c3e1-487c-9a81-de48dd63ecb9}</Project>
+      <Name>Microsoft.Xaml.Interactivity</Name>
+    </ProjectReference>
   </ItemGroup>
   <PropertyGroup Condition=" '$(VisualStudioVersion)' == '' or '$(VisualStudioVersion)' &lt; '14.0' ">
     <VisualStudioVersion>14.0</VisualStudioVersion>


### PR DESCRIPTION
Referencing the C# Projects instead of the DLL's in the sample project. This makes it easier to debug and extend the sample project. 
