### PR TITLE
Fixes #154 Use invariant culture to parse doubles

### DIFF
--- a/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactions/Core/TypeConverterHelper.cs
+++ b/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactions/Core/TypeConverterHelper.cs
@@ -48,7 +48,7 @@ namespace Microsoft.Xaml.Interactions.Core
                 }
                 else if (string.Equals(destinationTypeFullName, typeof(double).FullName, StringComparison.Ordinal))
                 {
-                    return double.Parse(value, CultureInfo.CurrentCulture);
+                    return double.Parse(value, CultureInfo.InvariantCulture);
                 }
             }
 


### PR DESCRIPTION
This is a potential breaking change, but having said that, I see no reason why this should use `CultureInfo.CurrentCulture` instead of `CultureInfo.InvariantCulture`.

Personally, I was expecting it to be using invariant culture and was surprised when I found it was not!