### PR TITLE
Removed 'extern alias WindowsRuntime', which was failing to build

### DIFF
--- a/scripts/Microsoft.Xaml.Behaviors.Signing.targets
+++ b/scripts/Microsoft.Xaml.Behaviors.Signing.targets
@@ -9,8 +9,8 @@
 
   <ItemGroup>
     <FilesToSign Include="$(OutputPath)$(AssemblyName).dll">
-      <Authenticode>Microsoft</Authenticode>
-      <StrongName>72</StrongName>
+      <Authenticode>Microsoft400</Authenticode>
+      <StrongName>StrongName</StrongName>
     </FilesToSign>
   </ItemGroup>
 

--- a/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactivity.Design/MetadataTableProvider.cs
+++ b/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactivity.Design/MetadataTableProvider.cs
@@ -1,10 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved. 
 // Licensed under the MIT license. See LICENSE file in the project root for full license information. 
 
-#if !SurfaceIsolation
-extern alias WindowsRuntime;
-#endif
-
 using System.ComponentModel;
 
 #if SurfaceIsolation

--- a/src/BehaviorsSDKManaged/Version/NuGetPackageVersion.props
+++ b/src/BehaviorsSDKManaged/Version/NuGetPackageVersion.props
@@ -1,5 +1,5 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <PackageVersion>2.0.2-rc1</PackageVersion>
+    <PackageVersion>2.0.2-rc2</PackageVersion>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Removed 'extern alias WindowsRuntime', which was failing to build without the 10240 Windows SDK.

No behavioral impact.
Smoke tested installation of UWP behaviors in Blend.