### PR TITLE
Add MicroBuild targets to perform signing on DesignTools assemblies.

### DIFF
--- a/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactions/Microsoft.Xaml.Interactions.csproj
+++ b/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactions/Microsoft.Xaml.Interactions.csproj
@@ -177,7 +177,7 @@
   <Import Project="..\..\..\scripts\Microsoft.Xaml.Behaviors.Signing.targets" />
   <Import Project="$(MSBuildExtensionsPath)\Microsoft\WindowsXaml\v$(VisualStudioVersion)\Microsoft.Windows.UI.Xaml.CSharp.targets" />
   <Import Project="$(MSBuildExtensionsPath)\Microsoft\Multilingual App Toolkit\Microsoft.Multilingual.PriResources.targets" Label="MultilingualAppToolkit" Condition="Exists('$(MSBuildExtensionsPath)\Microsoft\Multilingual App Toolkit\Microsoft.Multilingual.PriResources.targets')" />
-  <Target Name="MATPrerequisite" BeforeTargets="PrepareForBuild" Condition="!Exists('$(MSBuildExtensionsPath)\Microsoft\Multilingual App Toolkit\Microsoft.Multilingual.PriResources.targets')" Label="MultilingualAppToolkit">
+  <Target Name="MATPrerequisite" BeforeTargets="PrepareForBuild" Condition="!Exists('$(MSBuildExtensionsPath)\Microsoft\Multilingual App Toolkit\Microsoft.Multilingual.PriResources.targets') AND '$(AzureDevOps)' != 'true'" Label="MultilingualAppToolkit">
     <Warning Text="$(MSBuildProjectFile) is Multilingual build enabled, but the Multilingual App Toolkit is unavailable during the build. If building with Visual Studio, please check to ensure that toolkit is properly installed." />
   </Target>
 </Project>

--- a/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactivity/Microsoft.Xaml.Interactivity.csproj
+++ b/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactivity/Microsoft.Xaml.Interactivity.csproj
@@ -173,7 +173,7 @@
   <Import Project="..\..\..\scripts\Microsoft.Xaml.Behaviors.Signing.targets" />
   <Import Project="$(MSBuildExtensionsPath)\Microsoft\WindowsXaml\v$(VisualStudioVersion)\Microsoft.Windows.UI.Xaml.CSharp.targets" />
   <Import Project="$(MSBuildExtensionsPath)\Microsoft\Multilingual App Toolkit\Microsoft.Multilingual.PriResources.targets" Label="MultilingualAppToolkit" Condition="Exists('$(MSBuildExtensionsPath)\Microsoft\Multilingual App Toolkit\Microsoft.Multilingual.PriResources.targets')" />
-  <Target Name="MATPrerequisite" BeforeTargets="PrepareForBuild" Condition="!Exists('$(MSBuildExtensionsPath)\Microsoft\Multilingual App Toolkit\Microsoft.Multilingual.PriResources.targets')" Label="MultilingualAppToolkit">
+  <Target Name="MATPrerequisite" BeforeTargets="PrepareForBuild" Condition="!Exists('$(MSBuildExtensionsPath)\Microsoft\Multilingual App Toolkit\Microsoft.Multilingual.PriResources.targets') AND '$(AzureDevOps)' != 'true'" Label="MultilingualAppToolkit">
     <Warning Text="$(MSBuildProjectFile) is Multilingual build enabled, but the Multilingual App Toolkit is unavailable during the build. If building with Visual Studio, please check to ensure that toolkit is properly installed." />
   </Target>
 </Project>

--- a/src/BehaviorsSDKNative/BehaviorsSDKNative.sln
+++ b/src/BehaviorsSDKNative/BehaviorsSDKNative.sln
@@ -24,6 +24,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 	ProjectSection(SolutionItems) = preProject
 		..\..\scripts\Microsoft.Xaml.Behaviors.Signing.targets = ..\..\scripts\Microsoft.Xaml.Behaviors.Signing.targets
 		..\..\scripts\Microsoft.Xaml.Behaviors.Uwp.Native.nuspec = ..\..\scripts\Microsoft.Xaml.Behaviors.Uwp.Native.nuspec
+		..\..\scripts\Microsoft.Xaml.Behaviors.Uwp.Native.targets = ..\..\scripts\Microsoft.Xaml.Behaviors.Uwp.Native.targets
 		Version\NuGetPackageVersion.props = Version\NuGetPackageVersion.props
 	EndProjectSection
 EndProject

--- a/src/BehaviorsSDKNative/Microsoft.Xaml.Interactions.Design/Microsoft.Xaml.Interactions.Design.csproj
+++ b/src/BehaviorsSDKNative/Microsoft.Xaml.Interactions.Design/Microsoft.Xaml.Interactions.Design.csproj
@@ -35,15 +35,6 @@
     <PlatformTarget>x86</PlatformTarget>
   </PropertyGroup>
   <PropertyGroup>
-    <SignAssembly>true</SignAssembly>
-  </PropertyGroup>
-  <PropertyGroup>
-    <AssemblyOriginatorKeyFile>..\..\..\key\Behaviors.snk</AssemblyOriginatorKeyFile>
-  </PropertyGroup>
-  <PropertyGroup>
-    <DelaySign>true</DelaySign>
-  </PropertyGroup>
-  <PropertyGroup>
     <OutputPath>..\..\..\out\$(SolutionName)\bin\$(Platform)\$(Configuration)\</OutputPath>
     <IntermediateOutputPath>..\..\..\out\$(SolutionName)\obj\$(Platform)\$(Configuration)\</IntermediateOutputPath>
   </PropertyGroup>

--- a/src/BehaviorsSDKNative/Microsoft.Xaml.Interactions.DesignTools/Microsoft.Xaml.Interactions.DesignTools.csproj
+++ b/src/BehaviorsSDKNative/Microsoft.Xaml.Interactions.DesignTools/Microsoft.Xaml.Interactions.DesignTools.csproj
@@ -71,6 +71,13 @@
       <Version>16.4.29519.181</Version>
     </PackageReference>
   </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.VisualStudioEng.MicroBuild.Core">
+      <Version>0.4.1</Version>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
   <Import Project="..\Version\NuGetPackageVersion.props" />
   <Import Project="..\..\..\scripts\Microsoft.Xaml.Behaviors.Signing.targets" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/src/BehaviorsSDKNative/Microsoft.Xaml.Interactions/Microsoft.Xaml.Interactions.vcxproj
+++ b/src/BehaviorsSDKNative/Microsoft.Xaml.Interactions/Microsoft.Xaml.Interactions.vcxproj
@@ -287,7 +287,7 @@
   <Import Project="..\..\..\scripts\Microsoft.Xaml.Behaviors.Signing.targets" />
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <Import Project="$(MSBuildExtensionsPath)\Microsoft\Multilingual App Toolkit\Microsoft.Multilingual.PriResources.targets" Label="MultilingualAppToolkit" Condition="Exists('$(MSBuildExtensionsPath)\Microsoft\Multilingual App Toolkit\Microsoft.Multilingual.PriResources.targets')" />
-  <Target Name="MATPrerequisite" BeforeTargets="PrepareForBuild" Condition="!Exists('$(MSBuildExtensionsPath)\Microsoft\Multilingual App Toolkit\Microsoft.Multilingual.PriResources.targets')" Label="MultilingualAppToolkit">
+  <Target Name="MATPrerequisite" BeforeTargets="PrepareForBuild" Condition="!Exists('$(MSBuildExtensionsPath)\Microsoft\Multilingual App Toolkit\Microsoft.Multilingual.PriResources.targets') AND '$(AzureDevOps)' != 'true'" Label="MultilingualAppToolkit">
     <Warning Text="$(MSBuildProjectFile) is Multilingual build enabled, but the Multilingual App Toolkit is unavailable during the build. If building with Visual Studio, please check to ensure that toolkit is properly installed." />
   </Target>
   <ImportGroup Label="ExtensionTargets">

--- a/src/BehaviorsSDKNative/Microsoft.Xaml.Interactivity.Design/Microsoft.Xaml.Interactivity.Design.csproj
+++ b/src/BehaviorsSDKNative/Microsoft.Xaml.Interactivity.Design/Microsoft.Xaml.Interactivity.Design.csproj
@@ -76,12 +76,6 @@
       <Aliases>WindowsRuntime</Aliases>
       <Private>False</Private>
     </Reference>
-    <!--<Reference Include="System.Runtime">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>$(ProgramFiles)\Reference Assemblies\Microsoft\Framework\.NETCore\v4.5.1\System.Runtime.dll</HintPath>
-      <Aliases>WindowsRuntime</Aliases>
-      <Private>False</Private>
-    </Reference>-->
     <Reference Include="System.Runtime.InteropServices.WindowsRuntime">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>$(ProgramFiles)\Reference Assemblies\Microsoft\Framework\.NETCore\v4.5.1\System.Runtime.InteropServices.WindowsRuntime.dll</HintPath>
@@ -146,11 +140,4 @@
   </ItemGroup>
   <Import Project="..\..\..\scripts\Microsoft.Xaml.Behaviors.Signing.targets" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
-       Other similar extension points exist, see Microsoft.Common.targets.
-  <Target Name="BeforeBuild">
-  </Target>
-  <Target Name="AfterBuild">
-  </Target>
-  -->
 </Project>

--- a/src/BehaviorsSDKNative/Microsoft.Xaml.Interactivity.DesignTools/Microsoft.Xaml.Interactivity.DesignTools.csproj
+++ b/src/BehaviorsSDKNative/Microsoft.Xaml.Interactivity.DesignTools/Microsoft.Xaml.Interactivity.DesignTools.csproj
@@ -71,6 +71,13 @@
       <Version>16.4.29519.181</Version>
     </PackageReference>
   </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.VisualStudioEng.MicroBuild.Core">
+      <Version>0.4.1</Version>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
   <Import Project="..\Version\NuGetPackageVersion.props" />
   <Import Project="..\..\..\scripts\Microsoft.Xaml.Behaviors.Signing.targets" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/src/BehaviorsSDKNative/Microsoft.Xaml.Interactivity/Microsoft.Xaml.Interactivity.vcxproj
+++ b/src/BehaviorsSDKNative/Microsoft.Xaml.Interactivity/Microsoft.Xaml.Interactivity.vcxproj
@@ -277,7 +277,7 @@
   <Import Project="..\..\..\scripts\Microsoft.Xaml.Behaviors.Signing.targets" />
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <Import Project="$(MSBuildExtensionsPath)\Microsoft\Multilingual App Toolkit\Microsoft.Multilingual.PriResources.targets" Label="MultilingualAppToolkit" Condition="Exists('$(MSBuildExtensionsPath)\Microsoft\Multilingual App Toolkit\Microsoft.Multilingual.PriResources.targets')" />
-  <Target Name="MATPrerequisite" BeforeTargets="PrepareForBuild" Condition="!Exists('$(MSBuildExtensionsPath)\Microsoft\Multilingual App Toolkit\Microsoft.Multilingual.PriResources.targets')" Label="MultilingualAppToolkit">
+  <Target Name="MATPrerequisite" BeforeTargets="PrepareForBuild" Condition="!Exists('$(MSBuildExtensionsPath)\Microsoft\Multilingual App Toolkit\Microsoft.Multilingual.PriResources.targets') AND '$(AzureDevOps)' != 'true'" Label="MultilingualAppToolkit">
     <Warning Text="$(MSBuildProjectFile) is Multilingual build enabled, but the Multilingual App Toolkit is unavailable during the build. If building with Visual Studio, please check to ensure that toolkit is properly installed." />
   </Target>
   <ImportGroup Label="ExtensionTargets">


### PR DESCRIPTION
Microbuild imports are missing from DesignTools projects. They've been added in.