### PR TITLE
Fix bug #181 Unit tests in ManagedUnitTests project do not run

### DIFF
--- a/src/BehaviorsSDKManaged/ManagedUnitTests/project.json
+++ b/src/BehaviorsSDKManaged/ManagedUnitTests/project.json
@@ -1,5 +1,6 @@
 ﻿{
   "dependencies": {
+    "Microsoft.NET.Test.Sdk": "16.5.0",
     "Microsoft.NETCore.UniversalWindowsPlatform": "6.2.9",
     "MSTest.TestAdapter": "2.1.0",
     "MSTest.TestFramework": "2.1.0"


### PR DESCRIPTION
Added NuGet reference Microsoft.NET.Test.Sdk to ManagedUnitTests project; allowing the unit tests to run.