### PR TITLE
Added ItemClickBehavior

### DIFF
--- a/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactions/Core/ItemClickBehavior.cs
+++ b/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactions/Core/ItemClickBehavior.cs
@@ -1,0 +1,70 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+namespace Microsoft.Xaml.Interactions.Core
+{
+    using System.Windows.Input;
+    using Windows.UI.Xaml;
+    using Windows.UI.Xaml.Controls;
+    using Interactivity;
+
+    /// <summary>
+    /// A behavior that listens for the <see cref="ListViewBase.ItemClick"/> event on its source and executes a specified command when that event is fired
+    /// </summary>
+    public sealed class ItemClickBehavior : Behavior<ListViewBase>
+    {
+        /// <summary>
+        /// Gets or sets the <see cref="ICommand"/> instance to invoke when the current behavior is triggered
+        /// </summary>
+        public ICommand Command {
+            get => (ICommand)this.GetValue(CommandProperty);
+            set => this.SetValue(CommandProperty, value);
+        }
+
+        /// <summary>
+        /// Identifies the <seealso cref="Command"/> property
+        /// </summary>
+        public static readonly DependencyProperty CommandProperty = DependencyProperty.Register(
+            nameof(Command),
+            typeof(ICommand),
+            typeof(ItemClickBehavior),
+            new PropertyMetadata(default(ICommand)));
+
+        /// <summary>
+        /// Handles a clicked item and invokes the associated command
+        /// </summary>
+        /// <param name="sender">The current <see cref="ListViewBase"/> instance</param>
+        /// <param name="e">The <see cref="ItemClickEventArgs"/> instance with the clicked item</param>
+        private void HandleItemClick(object sender, ItemClickEventArgs e)
+        {
+            if (!(this.Command is ICommand command) ||
+                !command.CanExecute(e.ClickedItem))
+            {
+                return;
+            }
+
+            command.Execute(e.ClickedItem);
+        }
+
+        /// <inheritdoc/>
+        protected override void OnAttached()
+        {
+            base.OnAttached();
+
+            if (this.AssociatedObject != null)
+            {
+                this.AssociatedObject.ItemClick += this.HandleItemClick;
+            }
+        }
+
+        /// <inheritdoc/>
+        protected override void OnDetaching()
+        {
+            base.OnDetaching();
+
+            if (this.AssociatedObject != null)
+            {
+                this.AssociatedObject.ItemClick -= this.HandleItemClick;
+            }
+        }
+    }
+}

--- a/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactions/Microsoft.Xaml.Interactions.csproj
+++ b/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactions/Microsoft.Xaml.Interactions.csproj
@@ -139,6 +139,7 @@
     <Compile Include="Core\GoToStateAction.cs" />
     <Compile Include="Core\IncrementalUpdateBehavior.cs" />
     <Compile Include="Core\InvokeCommandAction.cs" />
+    <Compile Include="Core\ItemClickBehavior.cs" />
     <Compile Include="Core\NavigateToPageAction.cs" />
     <Compile Include="Core\ResourceHelper.cs" />
     <Compile Include="Core\TypeConverterHelper.cs" />


### PR DESCRIPTION
## Feature: new `ItemClickBehavior` type

## Summary

This PR introduces a new `ItemClickBerhavior` type, targeting `ListViewBase` (so it can be used with both `ListView` and `GridView`), which allows to easily invoke a command when an item is clicking, and **also** to pass the clicked item directly as parameter.
This results in more compact and efficient code than using an `EventTriggerBehavior` + an invoke command behavior, and it allows to directly receive the clicked item as argument to the command, which would've otherwise not been possible.

Here's a usage example:

```xml
<ListView
    ItemsSource="{x:Bind ViewModel.Source}"
    IsItemClickEnabled="True">
    <interactivity:Interaction.Behaviors>
        <core:ItemClickBehavior Command="{x:Bind ViewModel.ProcessItemCommand}"/>
    </interactivity:Interaction.Behaviors>
    <ListView.ItemTemplate>
        <DataTemplate>
            <!--Template here...-->
        </DataTemplate>
    </ListView.ItemTemplate>
</ListView>
```

The target command will be invoked when an item is clicked and will receive the `ItemClickEventArgs.ClickedItem` instance directly. This is especially useful when using eg. the `RelayCommand<T>` type (see https://github.com/windows-toolkit/WindowsCommunityToolkit/issues/3230), as you can then also specify the target type of a clicked item and have the command wrap a model directly in the viewmodel:

```csharp
public class MyViewModel : ViewModelBase
{
    public MyViewModel()
    {
        Source = ...;
        ProcessItemCommand = new RelayCommand<MyModel>(ProcessItem);
    }

    public ObservableCollection<MyModel> Source { get; }

    public ICommand ProcessItemCommand { get; }

    private void ProcessItem(MyModel model)
    {
        // Custom logic here...
    }
}
```