### PR TITLE
Only StroneName the AssemblyName.winmd file if it exists

### DIFF
--- a/scripts/Microsoft.Xaml.Behaviors.Signing.targets
+++ b/scripts/Microsoft.Xaml.Behaviors.Signing.targets
@@ -15,7 +15,7 @@
       <Authenticode>Microsoft400</Authenticode>
       <StrongName>StrongName</StrongName>
     </FilesToSign>
-    <FilesToSign Include="$(OutputPath)$(AssemblyName).winmd" Condition="!($(AssemblyName.Contains('.Design')) OR $(AssemblyName.Contains('.DesignTools')))">
+    <FilesToSign Include="$(OutputPath)$(AssemblyName).winmd" Condition="(!($(AssemblyName.Contains('.Design')) OR $(AssemblyName.Contains('.DesignTools')))) AND Exists('$(OutputPath)$(AssemblyName).winmd')">
       <Authenticode>Microsoft400</Authenticode>
       <StrongName>StrongName</StrongName>
     </FilesToSign>


### PR DESCRIPTION
This file will not exist for the ManagedSDK build (only the NativeSDK build).