### PR TITLE
Disable AppxPackageSigning for the UnitTest project

### DIFF
--- a/src/BehaviorsSDKManaged/ManagedUnitTests/ManagedUnitTests.csproj
+++ b/src/BehaviorsSDKManaged/ManagedUnitTests/ManagedUnitTests.csproj
@@ -17,9 +17,9 @@
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{A5A43C5B-DE2A-4C0C-9213-0A381AF9435A};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <PackageCertificateKeyFile>ManagedUnitTests_TemporaryKey.pfx</PackageCertificateKeyFile>
-    <UnitTestPlatformVersion Condition="'$(UnitTestPlatformVersion)' == ''">14.0</UnitTestPlatformVersion>
     <PackageCertificateThumbprint>165EB0CFBCAEED515D3C8ACE42670AD0AE7A6253</PackageCertificateThumbprint>
-    <AppxPackageSigningEnabled>True</AppxPackageSigningEnabled>
+    <AppxPackageSigningEnabled>False</AppxPackageSigningEnabled>
+    <UnitTestPlatformVersion Condition="'$(UnitTestPlatformVersion)' == ''">14.0</UnitTestPlatformVersion>
     <RuntimeIdentifiers>win10-arm;win10-arm-aot;win10-x86;win10-x86-aot;win10-x64;win10-x64-aot</RuntimeIdentifiers>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">


### PR DESCRIPTION
Do we need this??

The current "Temporary" certificate has expired and is causing the builds to fail:

Also grouped the Certificate/Signing properties together to make it a bit easier to see all the related configuration properties.

```
  C:\Program Files\Microsoft Visual Studio\2022\Enterprise\MSBuild\Microsoft\VisualStudio\v17.0\AppxPackage\Microsoft.AppXPackage.Targets(3574,5): error APPX0108: The certificate specified has expired. For more information about renewing certificates, see http://go.microsoft.com/fwlink/?LinkID=241478. [D:\a\XamlBehaviors\XamlBehaviors\src\BehaviorsSDKManaged\ManagedUnitTests\ManagedUnitTests.csproj]

    36 Warning(s)
    1 Error(s)

Time Elapsed 00:04:30.76
Error: Process completed with exit code 1.
```