### PR TITLE
Update build.yml

### DIFF
--- a/azure-pipelines/build.yml
+++ b/azure-pipelines/build.yml
@@ -17,8 +17,8 @@ variables:
 - name: TimestampPackage
   value: true
 schedules:
-- cron: '0 0 1 * 0'
-  displayName: Monthly CodeQL Build
+- cron: '0 0 * * 0'
+  displayName: Weekly CodeQL Build (Sunday @ Midnight)
   branches:
     include:
     - main


### PR DESCRIPTION
Updated cron schedule to build every Sunday at midnight

Previous cron schedule was meant to run on the first of every month, but was actually set to run on the first of every month if-and-only-if it was a Sunday.