### PR TITLE
Add trim/AOT annotations to WinUI XAML behaviors

### DIFF
--- a/scripts/Microsoft.Xaml.Behaviors.WinUI.Managed.nuspec
+++ b/scripts/Microsoft.Xaml.Behaviors.WinUI.Managed.nuspec
@@ -14,33 +14,33 @@
         <copyright>&#169; Microsoft Corporation. All rights reserved.</copyright>
         <tags>Behavior Action Behaviors Actions Blend Managed C# Interaction Interactivity Interactions WinUI</tags>
         <dependencies>
-          <group targetFramework="net5.0-windows10.0.17763.0">
+          <group targetFramework="net8.0-windows10.0.17763.0">
             <dependency id="Microsoft.WindowsAppSDK" version="1.0.0" />
           </group>
         </dependencies>
     </metadata>
 
     <files>
-        <file target="lib\net5.0-windows10.0.17763.0\Microsoft.Xaml.Interactivity.dll"                     src="..\out\WinUI\BehaviorsSDKManaged\bin\AnyCPU\Release\Microsoft.Xaml.Interactivity.dll" />
-        <file target="lib\net5.0-windows10.0.17763.0\Microsoft.Xaml.Interactivity.pdb"                     src="..\out\WinUI\BehaviorsSDKManaged\bin\AnyCPU\Release\Microsoft.Xaml.Interactivity.pdb" />
-        <file target="lib\net5.0-windows10.0.17763.0\Microsoft.Xaml.Interactivity.xml"                     src="..\out\WinUI\BehaviorsSDKManaged\bin\AnyCPU\Release\Microsoft.Xaml.Interactivity.xml" />
-        <file target="lib\net5.0-windows10.0.17763.0\Microsoft.Xaml.Interactivity.pri"                     src="..\out\WinUI\BehaviorsSDKManaged\bin\AnyCPU\Release\Microsoft.Xaml.Interactivity.pri" />
-        <file target="lib\net5.0-windows10.0.17763.0\Microsoft.Xaml.Interactions.dll"                      src="..\out\WinUI\BehaviorsSDKManaged\bin\AnyCPU\Release\Microsoft.Xaml.Interactions.dll" />
-        <file target="lib\net5.0-windows10.0.17763.0\Microsoft.Xaml.Interactions.pdb"                      src="..\out\WinUI\BehaviorsSDKManaged\bin\AnyCPU\Release\Microsoft.Xaml.Interactions.pdb" />
-        <file target="lib\net5.0-windows10.0.17763.0\Microsoft.Xaml.Interactions.xml"                      src="..\out\WinUI\BehaviorsSDKManaged\bin\AnyCPU\Release\Microsoft.Xaml.Interactions.xml" />
-        <file target="lib\net5.0-windows10.0.17763.0\Microsoft.Xaml.Interactions.pri"                      src="..\out\WinUI\BehaviorsSDKManaged\bin\AnyCPU\Release\Microsoft.Xaml.Interactions.pri" />
+        <file target="lib\net8.0-windows10.0.17763.0\Microsoft.Xaml.Interactivity.dll"                     src="..\out\WinUI\BehaviorsSDKManaged\bin\AnyCPU\Release\Microsoft.Xaml.Interactivity.dll" />
+        <file target="lib\net8.0-windows10.0.17763.0\Microsoft.Xaml.Interactivity.pdb"                     src="..\out\WinUI\BehaviorsSDKManaged\bin\AnyCPU\Release\Microsoft.Xaml.Interactivity.pdb" />
+        <file target="lib\net8.0-windows10.0.17763.0\Microsoft.Xaml.Interactivity.xml"                     src="..\out\WinUI\BehaviorsSDKManaged\bin\AnyCPU\Release\Microsoft.Xaml.Interactivity.xml" />
+        <file target="lib\net8.0-windows10.0.17763.0\Microsoft.Xaml.Interactivity.pri"                     src="..\out\WinUI\BehaviorsSDKManaged\bin\AnyCPU\Release\Microsoft.Xaml.Interactivity.pri" />
+        <file target="lib\net8.0-windows10.0.17763.0\Microsoft.Xaml.Interactions.dll"                      src="..\out\WinUI\BehaviorsSDKManaged\bin\AnyCPU\Release\Microsoft.Xaml.Interactions.dll" />
+        <file target="lib\net8.0-windows10.0.17763.0\Microsoft.Xaml.Interactions.pdb"                      src="..\out\WinUI\BehaviorsSDKManaged\bin\AnyCPU\Release\Microsoft.Xaml.Interactions.pdb" />
+        <file target="lib\net8.0-windows10.0.17763.0\Microsoft.Xaml.Interactions.xml"                      src="..\out\WinUI\BehaviorsSDKManaged\bin\AnyCPU\Release\Microsoft.Xaml.Interactions.xml" />
+        <file target="lib\net8.0-windows10.0.17763.0\Microsoft.Xaml.Interactions.pri"                      src="..\out\WinUI\BehaviorsSDKManaged\bin\AnyCPU\Release\Microsoft.Xaml.Interactions.pri" />
 
         <!--
-        <file target="lib\net5.0-windows10.0.17763.0\Design\Microsoft.Xaml.Interactivity.Design.dll"       src="..\out\WinUI\BehaviorsSDKManaged\bin\AnyCPU\Release\Microsoft.Xaml.Interactivity.Design.dll" />
-        <file target="lib\net5.0-windows10.0.17763.0\Design\Microsoft.Xaml.Interactivity.Design.pdb"       src="..\out\WinUI\BehaviorsSDKManaged\bin\AnyCPU\Release\Microsoft.Xaml.Interactivity.Design.pdb" />
-        <file target="lib\net5.0-windows10.0.17763.0\Design\Microsoft.Xaml.Interactions.Design.dll"        src="..\out\WinUI\BehaviorsSDKManaged\bin\AnyCPU\Release\Microsoft.Xaml.Interactions.Design.dll" />
-        <file target="lib\net5.0-windows10.0.17763.0\Design\Microsoft.Xaml.Interactions.Design.pdb"        src="..\out\WinUI\BehaviorsSDKManaged\bin\AnyCPU\Release\Microsoft.Xaml.Interactions.Design.pdb" />
+        <file target="lib\net8.0-windows10.0.17763.0\Design\Microsoft.Xaml.Interactivity.Design.dll"       src="..\out\WinUI\BehaviorsSDKManaged\bin\AnyCPU\Release\Microsoft.Xaml.Interactivity.Design.dll" />
+        <file target="lib\net8.0-windows10.0.17763.0\Design\Microsoft.Xaml.Interactivity.Design.pdb"       src="..\out\WinUI\BehaviorsSDKManaged\bin\AnyCPU\Release\Microsoft.Xaml.Interactivity.Design.pdb" />
+        <file target="lib\net8.0-windows10.0.17763.0\Design\Microsoft.Xaml.Interactions.Design.dll"        src="..\out\WinUI\BehaviorsSDKManaged\bin\AnyCPU\Release\Microsoft.Xaml.Interactions.Design.dll" />
+        <file target="lib\net8.0-windows10.0.17763.0\Design\Microsoft.Xaml.Interactions.Design.pdb"        src="..\out\WinUI\BehaviorsSDKManaged\bin\AnyCPU\Release\Microsoft.Xaml.Interactions.Design.pdb" />
         -->
       
-        <file target="lib\net5.0-windows10.0.17763.0\Design\Microsoft.Xaml.Interactivity.DesignTools.dll"   src="..\out\BehaviorsSDKManaged\bin\AnyCPU\Release\Microsoft.Xaml.Interactivity.DesignTools.dll" />
-        <file target="lib\net5.0-windows10.0.17763.0\Design\Microsoft.Xaml.Interactivity.DesignTools.pdb"   src="..\out\BehaviorsSDKManaged\bin\AnyCPU\Release\Microsoft.Xaml.Interactivity.DesignTools.pdb" />
-        <file target="lib\net5.0-windows10.0.17763.0\Design\Microsoft.Xaml.Interactions.DesignTools.dll"    src="..\out\BehaviorsSDKManaged\bin\AnyCPU\Release\Microsoft.Xaml.Interactions.DesignTools.dll" />
-        <file target="lib\net5.0-windows10.0.17763.0\Design\Microsoft.Xaml.Interactions.DesignTools.pdb"    src="..\out\BehaviorsSDKManaged\bin\AnyCPU\Release\Microsoft.Xaml.Interactions.DesignTools.pdb" />
+        <file target="lib\net8.0-windows10.0.17763.0\Design\Microsoft.Xaml.Interactivity.DesignTools.dll"   src="..\out\BehaviorsSDKManaged\bin\AnyCPU\Release\Microsoft.Xaml.Interactivity.DesignTools.dll" />
+        <file target="lib\net8.0-windows10.0.17763.0\Design\Microsoft.Xaml.Interactivity.DesignTools.pdb"   src="..\out\BehaviorsSDKManaged\bin\AnyCPU\Release\Microsoft.Xaml.Interactivity.DesignTools.pdb" />
+        <file target="lib\net8.0-windows10.0.17763.0\Design\Microsoft.Xaml.Interactions.DesignTools.dll"    src="..\out\BehaviorsSDKManaged\bin\AnyCPU\Release\Microsoft.Xaml.Interactions.DesignTools.dll" />
+        <file target="lib\net8.0-windows10.0.17763.0\Design\Microsoft.Xaml.Interactions.DesignTools.pdb"    src="..\out\BehaviorsSDKManaged\bin\AnyCPU\Release\Microsoft.Xaml.Interactions.DesignTools.pdb" />
 
         <file target="src\BehaviorsSDKManaged\Microsoft.Xaml.Interactions.WinUI"              src="..\src\BehaviorsSDKManaged\Microsoft.Xaml.Interactions.Shared\**\*.cs" />
         <file target="src\BehaviorsSDKManaged\Microsoft.Xaml.Interactivity.WinUI"             src="..\src\BehaviorsSDKManaged\Microsoft.Xaml.Interactivity.Shared\**\*.cs" />

--- a/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactions.Shared/Core/CallMethodAction.cs
+++ b/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactions.Shared/Core/CallMethodAction.cs
@@ -21,6 +21,9 @@ namespace Microsoft.Xaml.Interactions.Core
     /// <summary>
     /// An action that calls a method on a specified object when invoked.
     /// </summary>
+#if NET5_0_OR_GREATER
+    [RequiresUnreferencedCode("This action is not trim-safe.")]
+#endif
     public sealed class CallMethodAction : DependencyObject, IAction
     {
         /// <summary>

--- a/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactions.Shared/Core/CallMethodAction.cs
+++ b/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactions.Shared/Core/CallMethodAction.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Xaml.Interactions.Core
     /// <summary>
     /// An action that calls a method on a specified object when invoked.
     /// </summary>
-#if NET5_0_OR_GREATER
+#if NET8_0_OR_GREATER
     [RequiresUnreferencedCode("This action is not trim-safe.")]
 #endif
     public sealed class CallMethodAction : DependencyObject, IAction

--- a/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactions.Shared/Core/ChangePropertyAction.cs
+++ b/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactions.Shared/Core/ChangePropertyAction.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Xaml.Interactions.Core
     /// <summary>
     /// An action that will change a specified property to a specified value when invoked.
     /// </summary>
-#if NET5_0_OR_GREATER
+#if NET8_0_OR_GREATER
     [RequiresUnreferencedCode("This action is not trim-safe.")]
 #endif
     public sealed class ChangePropertyAction : DependencyObject, IAction

--- a/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactions.Shared/Core/ChangePropertyAction.cs
+++ b/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactions.Shared/Core/ChangePropertyAction.cs
@@ -19,6 +19,9 @@ namespace Microsoft.Xaml.Interactions.Core
     /// <summary>
     /// An action that will change a specified property to a specified value when invoked.
     /// </summary>
+#if NET5_0_OR_GREATER
+    [RequiresUnreferencedCode("This action is not trim-safe.")]
+#endif
     public sealed class ChangePropertyAction : DependencyObject, IAction
     {
         /// <summary>

--- a/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactions.Shared/Core/DataBindingHelper.cs
+++ b/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactions.Shared/Core/DataBindingHelper.cs
@@ -3,6 +3,9 @@
 
 using System;
 using System.Collections.Generic;
+#if NET5_0_OR_GREATER
+using System.Diagnostics.CodeAnalysis;
+#endif
 using System.Reflection;
 
 using Microsoft.Xaml.Interactivity;
@@ -29,6 +32,9 @@ namespace Microsoft.Xaml.Interactions.Core
         /// bindings on the action  may not be up-to-date. This routine is called before the action
         /// is executed in order to guarantee that all bindings are refreshed with the most current data.
         /// </remarks>
+#if NET5_0_OR_GREATER
+        [RequiresUnreferencedCode("This method accesses all fields of input action objects.")]
+#endif
         public static void RefreshDataBindingsOnActions(ActionCollection actions)
         {
             foreach (DependencyObject action in actions)
@@ -40,7 +46,11 @@ namespace Microsoft.Xaml.Interactions.Core
             }
         }
 
-        private static IEnumerable<DependencyProperty> GetDependencyProperties(Type type)
+        private static IEnumerable<DependencyProperty> GetDependencyProperties(
+#if NET5_0_OR_GREATER
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+            Type type)
         {
             List<DependencyProperty> propertyList = null;
 

--- a/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactions.Shared/Core/DataBindingHelper.cs
+++ b/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactions.Shared/Core/DataBindingHelper.cs
@@ -3,7 +3,7 @@
 
 using System;
 using System.Collections.Generic;
-#if NET5_0_OR_GREATER
+#if NET8_0_OR_GREATER
 using System.Diagnostics.CodeAnalysis;
 #endif
 using System.Reflection;
@@ -32,7 +32,7 @@ namespace Microsoft.Xaml.Interactions.Core
         /// bindings on the action  may not be up-to-date. This routine is called before the action
         /// is executed in order to guarantee that all bindings are refreshed with the most current data.
         /// </remarks>
-#if NET5_0_OR_GREATER
+#if NET8_0_OR_GREATER
         [RequiresUnreferencedCode("This method accesses all fields of input action objects.")]
 #endif
         public static void RefreshDataBindingsOnActions(ActionCollection actions)
@@ -47,7 +47,7 @@ namespace Microsoft.Xaml.Interactions.Core
         }
 
         private static IEnumerable<DependencyProperty> GetDependencyProperties(
-#if NET5_0_OR_GREATER
+#if NET8_0_OR_GREATER
             [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
 #endif
             Type type)

--- a/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactions.Shared/Core/DataTriggerBehavior.cs
+++ b/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactions.Shared/Core/DataTriggerBehavior.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Xaml.Interactions.Core
     /// <summary>
     /// A behavior that performs actions when the bound data meets a specified condition.
     /// </summary>
-#if NET5_0_OR_GREATER
+#if NET8_0_OR_GREATER
     [RequiresUnreferencedCode("This behavior is not trim-safe.")]
 #endif
     public sealed class DataTriggerBehavior : Trigger

--- a/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactions.Shared/Core/DataTriggerBehavior.cs
+++ b/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactions.Shared/Core/DataTriggerBehavior.cs
@@ -18,6 +18,9 @@ namespace Microsoft.Xaml.Interactions.Core
     /// <summary>
     /// A behavior that performs actions when the bound data meets a specified condition.
     /// </summary>
+#if NET5_0_OR_GREATER
+    [RequiresUnreferencedCode("This behavior is not trim-safe.")]
+#endif
     public sealed class DataTriggerBehavior : Trigger
     {
         /// <summary>

--- a/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactions.Shared/Core/EventTriggerBehavior.cs
+++ b/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactions.Shared/Core/EventTriggerBehavior.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Xaml.Interactions.Core
     /// <summary>
     /// A behavior that listens for a specified event on its source and executes its actions when that event is fired.
     /// </summary>
-#if NET5_0_OR_GREATER
+#if NET8_0_OR_GREATER
     [RequiresUnreferencedCode("This behavior is not trim-safe.")]
 #endif
     public sealed class EventTriggerBehavior : Trigger

--- a/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactions.Shared/Core/GoToStateAction.cs
+++ b/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactions.Shared/Core/GoToStateAction.cs
@@ -127,7 +127,7 @@ namespace Microsoft.Xaml.Interactions.Core
             }
 
             FrameworkElement element = sender as FrameworkElement;
-            if (element == null || !EventTriggerBehavior.IsElementLoaded(element))
+            if (element == null || !EventTriggerBehaviorHelpers.IsElementLoaded(element))
             {
                 return false;
             }

--- a/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactions.Shared/Core/ResourceHelper.cs
+++ b/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactions.Shared/Core/ResourceHelper.cs
@@ -7,13 +7,13 @@ namespace Microsoft.Xaml.Interactions.Core
 
     internal static class ResourceHelper
     {
-#if NET5_0
+#if NET8_0_OR_GREATER
         private static ResourceLoader strings = new ResourceLoader(ResourceLoader.GetDefaultResourceFilePath(), "Microsoft.Xaml.Interactions/Strings");
 #endif
 
         public static string GetString(string resourceName)
         {
-#if !NET5_0 
+#if !NET8_0_OR_GREATER 
             var strings = ResourceLoader.GetForCurrentView("Microsoft.Xaml.Interactions/Strings");
 #endif
             return strings.GetString(resourceName);

--- a/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactions.WinUI/Microsoft.Xaml.Interactions.WinUI.csproj
+++ b/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactions.WinUI/Microsoft.Xaml.Interactions.WinUI.csproj
@@ -9,6 +9,7 @@
     <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
     <SupportedOSPlatformVersion>$(TargetPlatformMinVersion)</SupportedOSPlatformVersion>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+    <IsAotCompatible>true</IsAotCompatible>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactions.WinUI/Microsoft.Xaml.Interactions.WinUI.csproj
+++ b/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactions.WinUI/Microsoft.Xaml.Interactions.WinUI.csproj
@@ -1,10 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFramework>net5.0-windows10.0.17763.0</TargetFramework>
+    <TargetFramework>net8.0-windows10.0.17763.0</TargetFramework>
     <TargetPlatformVersion>10.0.17763.0</TargetPlatformVersion>
     <RootNamespace>Microsoft.Xaml.Interactions</RootNamespace>
-    <Platforms>AnyCPU;x86;x64</Platforms>
+    <Platforms>AnyCPU;x86;x64;arm64</Platforms>
+    <RuntimeIdentifiers>win-x86;win-x64;win-arm64</RuntimeIdentifiers>
     <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
     <SupportedOSPlatformVersion>$(TargetPlatformMinVersion)</SupportedOSPlatformVersion>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
@@ -122,7 +123,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.0.0" />
+    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.5.240607001" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.Xaml.Interactivity.WinUI\Microsoft.Xaml.Interactivity.WinUI.csproj">

--- a/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactivity.Shared/BehaviorCollection.cs
+++ b/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactivity.Shared/BehaviorCollection.cs
@@ -187,7 +187,7 @@ namespace Microsoft.Xaml.Interactivity
             {
                 for (int i = 0; i < this.Count; i++)
                 {
-                    if (this[i] != this._oldCollection[i])
+                    if (!ReferenceEquals(this[i], this._oldCollection[i]))
                     {
                         isValid = false;
                         break;

--- a/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactivity.Shared/ResourceHelper.cs
+++ b/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactivity.Shared/ResourceHelper.cs
@@ -6,13 +6,13 @@ namespace Microsoft.Xaml.Interactivity
 
     internal static class ResourceHelper
     {
-#if NET5_0
+#if NET8_0_OR_GREATER
         private static ResourceLoader strings = new ResourceLoader(ResourceLoader.GetDefaultResourceFilePath(), "Microsoft.Xaml.Interactivity/Strings");
 #endif
 
         public static string GetString(string resourceName)
         {
-#if !NET5_0
+#if !NET8_0_OR_GREATER
             ResourceLoader strings = ResourceLoader.GetForCurrentView("Microsoft.Xaml.Interactivity/Strings");
 #endif
             return strings.GetString(resourceName);

--- a/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactivity.WinUI/Microsoft.Xaml.Interactivity.WinUI.csproj
+++ b/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactivity.WinUI/Microsoft.Xaml.Interactivity.WinUI.csproj
@@ -1,10 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFramework>net5.0-windows10.0.17763.0</TargetFramework>
+    <TargetFramework>net8.0-windows10.0.17763.0</TargetFramework>
     <TargetPlatformVersion>10.0.17763.0</TargetPlatformVersion>
     <RootNamespace>Microsoft.Xaml.Interactivity</RootNamespace>
-    <Platforms>AnyCPU;x86;x64</Platforms>
+    <Platforms>AnyCPU;x86;x64;arm64</Platforms>
+    <RuntimeIdentifiers>win-x86;win-x64;win-arm64</RuntimeIdentifiers>
     <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
     <SupportedOSPlatformVersion>$(TargetPlatformMinVersion)</SupportedOSPlatformVersion>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
@@ -118,7 +119,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.0.0" />
+    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.5.240607001" />
   </ItemGroup>
   <ItemGroup>
     <PRIResource Include="..\Microsoft.Xaml.Interactivity\Resources\de-DE\Strings.resw">

--- a/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactivity.WinUI/Microsoft.Xaml.Interactivity.WinUI.csproj
+++ b/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactivity.WinUI/Microsoft.Xaml.Interactivity.WinUI.csproj
@@ -9,6 +9,7 @@
     <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
     <SupportedOSPlatformVersion>$(TargetPlatformMinVersion)</SupportedOSPlatformVersion>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+    <IsAotCompatible>true</IsAotCompatible>
   </PropertyGroup>
   <PropertyGroup>
     <OutputPath>..\..\..\out\WinUI\$(SolutionName)\bin\$(Platform)\$(Configuration)\</OutputPath>

--- a/src/BehaviorsSDKManaged/global.json
+++ b/src/BehaviorsSDKManaged/global.json
@@ -1,7 +1,8 @@
 {
   "sdk":
   {
-    "version": "5.0.403"
+    "version": "8.0.300",
+    "rollForward": "latestFeature"
   },
   "msbuild-sdks": {
     "MSBuild.Sdk.Extras": "3.0.23"


### PR DESCRIPTION
This PR introduces the following changes:
- Update the .NET TFM from .NET 5 to .NET 8
  - .NET 5 is EOL, .NET 6 is going to be EOL in a few months, .NET 8 has gone GA for over a year already now
  - We also need .NET 8 to be able to set `IsAotCompatible`
- Bump WASDK dependency to latest stable
- Add trim/AOT annotations to the XAML behaviors projects