### PR TITLE
Add support for UWP on modern .NET

### DIFF
--- a/.github/workflows/managed-build.yml
+++ b/.github/workflows/managed-build.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: windows-latest
     steps:
     - name: Checkout XamlBehaviors.git 
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Install the .NET 9.0.100 SDK
-      uses: actions/setup-dotnet@v3
+      uses: actions/setup-dotnet@v4
       with:
         dotnet-version: 9.0.100
 

--- a/.github/workflows/managed-build.yml
+++ b/.github/workflows/managed-build.yml
@@ -13,10 +13,10 @@ jobs:
     - name: Checkout XamlBehaviors.git 
       uses: actions/checkout@v3
 
-    - name: Install the .NET 8.0.400 SDK
+    - name: Install the .NET 9.0.100 SDK
       uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: 8.0.400
+        dotnet-version: 9.0.100
 
     - name: Setup MSBuild
       uses: microsoft/setup-msbuild@v2

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ The [documentation](https://github.com/Microsoft/XamlBehaviors/wiki) explains ho
 
 #### What You Need
 
-- [Visual Studio 2017 w/ Universal Windows Tools](https://visualstudio.microsoft.com/vs/features/universal-windows-platform/)
+- [Visual Studio 2022 17.12+ w/ Universal Windows Tools](https://visualstudio.microsoft.com/vs/features/universal-windows-platform/)
 - [Multilingual App Toolkit](https://developer.microsoft.com/en-us/windows/develop/multilingual-app-toolkit)
 
 #### Clone the Repository

--- a/azure-pipelines/build.yml
+++ b/azure-pipelines/build.yml
@@ -82,9 +82,9 @@ extends:
             SourceFolder: out
             Contents: '**\'
         - task: UseDotNet@2
-          displayName: Use .NET Core sdk 8.0.400
+          displayName: Use .NET SDK 9.0.100
           inputs:
-            version: 8.0.400
+            version: 9.0.100
             performMultiLevelLookup: true
         - task: NuGetToolInstaller@1
           displayName: Use NuGet 6.x

--- a/scripts/Microsoft.Xaml.Behaviors.Uwp.Managed.nuspec
+++ b/scripts/Microsoft.Xaml.Behaviors.Uwp.Managed.nuspec
@@ -13,6 +13,15 @@
         <iconUrl>http://go.microsoft.com/fwlink/?LinkID=708511</iconUrl>
         <copyright>&#169; Microsoft Corporation. All rights reserved.</copyright>
         <tags>Behavior Action Behaviors Actions Blend Managed C# Interaction Interactivity Interactions</tags>
+            <dependencies>
+                <group targetFramework="net8.0-windows10.0.18362" />
+                <group targetFramework="uap10.0" />
+            </dependencies>
+            <frameworkReferences>
+            <group targetFramework="net8.0-windows10.0.18362">
+                <frameworkReference name="Microsoft.Windows.SDK.NET.Ref.Xaml" />
+            </group>
+        </frameworkReferences>
     </metadata>
 
     <files>
@@ -25,34 +34,34 @@
         <file target="lib\uap10.0\Microsoft.Xaml.Interactions.xml"                      src="..\out\BehaviorsSDKManaged\bin\AnyCPU\Release\Microsoft.Xaml.Interactions.xml" />
         <file target="lib\uap10.0\Microsoft.Xaml.Interactions.pri"                      src="..\out\BehaviorsSDKManaged\bin\AnyCPU\Release\Microsoft.Xaml.Interactions.pri" />
 
-        <file target="lib\net8.0-windows10.0.22621.0\Microsoft.Xaml.Interactivity.dll"  src="..\out\uwp\BehaviorsSDKManaged\bin\AnyCPU\Release\Microsoft.Xaml.Interactivity.dll" />
-        <file target="lib\net8.0-windows10.0.22621.0\Microsoft.Xaml.Interactivity.pdb"  src="..\out\uwp\BehaviorsSDKManaged\bin\AnyCPU\Release\Microsoft.Xaml.Interactivity.pdb" />
-        <file target="lib\net8.0-windows10.0.22621.0\Microsoft.Xaml.Interactivity.xml"  src="..\out\uwp\BehaviorsSDKManaged\bin\AnyCPU\Release\Microsoft.Xaml.Interactivity.xml" />
-        <file target="lib\net8.0-windows10.0.22621.0\Microsoft.Xaml.Interactivity.pri"  src="..\out\uwp\BehaviorsSDKManaged\bin\AnyCPU\Release\Microsoft.Xaml.Interactivity.pri" />
-        <file target="lib\net8.0-windows10.0.22621.0\Microsoft.Xaml.Interactions.dll"   src="..\out\uwp\BehaviorsSDKManaged\bin\AnyCPU\Release\Microsoft.Xaml.Interactions.dll" />
-        <file target="lib\net8.0-windows10.0.22621.0\Microsoft.Xaml.Interactions.pdb"   src="..\out\uwp\BehaviorsSDKManaged\bin\AnyCPU\Release\Microsoft.Xaml.Interactions.pdb" />
-        <file target="lib\net8.0-windows10.0.22621.0\Microsoft.Xaml.Interactions.xml"   src="..\out\uwp\BehaviorsSDKManaged\bin\AnyCPU\Release\Microsoft.Xaml.Interactions.xml" />
-        <file target="lib\net8.0-windows10.0.22621.0\Microsoft.Xaml.Interactions.pri"   src="..\out\uwp\BehaviorsSDKManaged\bin\AnyCPU\Release\Microsoft.Xaml.Interactions.pri" />
+        <file target="lib\net8.0-windows10.0.18362.0\Microsoft.Xaml.Interactivity.dll"  src="..\out\uwp\BehaviorsSDKManaged\bin\AnyCPU\Release\Microsoft.Xaml.Interactivity.dll" />
+        <file target="lib\net8.0-windows10.0.18362.0\Microsoft.Xaml.Interactivity.pdb"  src="..\out\uwp\BehaviorsSDKManaged\bin\AnyCPU\Release\Microsoft.Xaml.Interactivity.pdb" />
+        <file target="lib\net8.0-windows10.0.18362.0\Microsoft.Xaml.Interactivity.xml"  src="..\out\uwp\BehaviorsSDKManaged\bin\AnyCPU\Release\Microsoft.Xaml.Interactivity.xml" />
+        <file target="lib\net8.0-windows10.0.18362.0\Microsoft.Xaml.Interactivity.pri"  src="..\out\uwp\BehaviorsSDKManaged\bin\AnyCPU\Release\Microsoft.Xaml.Interactivity.pri" />
+        <file target="lib\net8.0-windows10.0.18362.0\Microsoft.Xaml.Interactions.dll"   src="..\out\uwp\BehaviorsSDKManaged\bin\AnyCPU\Release\Microsoft.Xaml.Interactions.dll" />
+        <file target="lib\net8.0-windows10.0.18362.0\Microsoft.Xaml.Interactions.pdb"   src="..\out\uwp\BehaviorsSDKManaged\bin\AnyCPU\Release\Microsoft.Xaml.Interactions.pdb" />
+        <file target="lib\net8.0-windows10.0.18362.0\Microsoft.Xaml.Interactions.xml"   src="..\out\uwp\BehaviorsSDKManaged\bin\AnyCPU\Release\Microsoft.Xaml.Interactions.xml" />
+        <file target="lib\net8.0-windows10.0.18362.0\Microsoft.Xaml.Interactions.pri"   src="..\out\uwp\BehaviorsSDKManaged\bin\AnyCPU\Release\Microsoft.Xaml.Interactions.pri" />
 
         <file target="lib\uap10.0\Design\Microsoft.Xaml.Interactivity.Design.dll"       src="..\out\BehaviorsSDKManaged\bin\AnyCPU\Release\Microsoft.Xaml.Interactivity.Design.dll" />
         <file target="lib\uap10.0\Design\Microsoft.Xaml.Interactivity.Design.pdb"       src="..\out\BehaviorsSDKManaged\bin\AnyCPU\Release\Microsoft.Xaml.Interactivity.Design.pdb" />
         <file target="lib\uap10.0\Design\Microsoft.Xaml.Interactions.Design.dll"        src="..\out\BehaviorsSDKManaged\bin\AnyCPU\Release\Microsoft.Xaml.Interactions.Design.dll" />
         <file target="lib\uap10.0\Design\Microsoft.Xaml.Interactions.Design.pdb"        src="..\out\BehaviorsSDKManaged\bin\AnyCPU\Release\Microsoft.Xaml.Interactions.Design.pdb" />
 
-        <file target="lib\net8.0-windows10.0.22621.0\Design\Microsoft.Xaml.Interactivity.Design.dll"       src="..\out\BehaviorsSDKManaged\bin\AnyCPU\Release\Microsoft.Xaml.Interactivity.Design.dll" />
-        <file target="lib\net8.0-windows10.0.22621.0\Design\Microsoft.Xaml.Interactivity.Design.pdb"       src="..\out\BehaviorsSDKManaged\bin\AnyCPU\Release\Microsoft.Xaml.Interactivity.Design.pdb" />
-        <file target="lib\net8.0-windows10.0.22621.0\Design\Microsoft.Xaml.Interactions.Design.dll"        src="..\out\BehaviorsSDKManaged\bin\AnyCPU\Release\Microsoft.Xaml.Interactions.Design.dll" />
-        <file target="lib\net8.0-windows10.0.22621.0\Design\Microsoft.Xaml.Interactions.Design.pdb"        src="..\out\BehaviorsSDKManaged\bin\AnyCPU\Release\Microsoft.Xaml.Interactions.Design.pdb" />
+        <file target="lib\net8.0-windows10.0.18362.0\Design\Microsoft.Xaml.Interactivity.Design.dll"       src="..\out\BehaviorsSDKManaged\bin\AnyCPU\Release\Microsoft.Xaml.Interactivity.Design.dll" />
+        <file target="lib\net8.0-windows10.0.18362.0\Design\Microsoft.Xaml.Interactivity.Design.pdb"       src="..\out\BehaviorsSDKManaged\bin\AnyCPU\Release\Microsoft.Xaml.Interactivity.Design.pdb" />
+        <file target="lib\net8.0-windows10.0.18362.0\Design\Microsoft.Xaml.Interactions.Design.dll"        src="..\out\BehaviorsSDKManaged\bin\AnyCPU\Release\Microsoft.Xaml.Interactions.Design.dll" />
+        <file target="lib\net8.0-windows10.0.18362.0\Design\Microsoft.Xaml.Interactions.Design.pdb"        src="..\out\BehaviorsSDKManaged\bin\AnyCPU\Release\Microsoft.Xaml.Interactions.Design.pdb" />
 
         <file target="lib\uap10.0\Design\Microsoft.Xaml.Interactivity.DesignTools.dll"   src="..\out\BehaviorsSDKManaged\bin\AnyCPU\Release\Microsoft.Xaml.Interactivity.DesignTools.dll" />
         <file target="lib\uap10.0\Design\Microsoft.Xaml.Interactivity.DesignTools.pdb"   src="..\out\BehaviorsSDKManaged\bin\AnyCPU\Release\Microsoft.Xaml.Interactivity.DesignTools.pdb" />
         <file target="lib\uap10.0\Design\Microsoft.Xaml.Interactions.DesignTools.dll"    src="..\out\BehaviorsSDKManaged\bin\AnyCPU\Release\Microsoft.Xaml.Interactions.DesignTools.dll" />
         <file target="lib\uap10.0\Design\Microsoft.Xaml.Interactions.DesignTools.pdb"    src="..\out\BehaviorsSDKManaged\bin\AnyCPU\Release\Microsoft.Xaml.Interactions.DesignTools.pdb" />
 
-        <file target="lib\net8.0-windows10.0.22621.0\Design\Microsoft.Xaml.Interactivity.DesignTools.dll"   src="..\out\BehaviorsSDKManaged\bin\AnyCPU\Release\Microsoft.Xaml.Interactivity.DesignTools.dll" />
-        <file target="lib\net8.0-windows10.0.22621.0\Design\Microsoft.Xaml.Interactivity.DesignTools.pdb"   src="..\out\BehaviorsSDKManaged\bin\AnyCPU\Release\Microsoft.Xaml.Interactivity.DesignTools.pdb" />
-        <file target="lib\net8.0-windows10.0.22621.0\Design\Microsoft.Xaml.Interactions.DesignTools.dll"    src="..\out\BehaviorsSDKManaged\bin\AnyCPU\Release\Microsoft.Xaml.Interactions.DesignTools.dll" />
-        <file target="lib\net8.0-windows10.0.22621.0\Design\Microsoft.Xaml.Interactions.DesignTools.pdb"    src="..\out\BehaviorsSDKManaged\bin\AnyCPU\Release\Microsoft.Xaml.Interactions.DesignTools.pdb" />
+        <file target="lib\net8.0-windows10.0.18362.0\Design\Microsoft.Xaml.Interactivity.DesignTools.dll"   src="..\out\BehaviorsSDKManaged\bin\AnyCPU\Release\Microsoft.Xaml.Interactivity.DesignTools.dll" />
+        <file target="lib\net8.0-windows10.0.18362.0\Design\Microsoft.Xaml.Interactivity.DesignTools.pdb"   src="..\out\BehaviorsSDKManaged\bin\AnyCPU\Release\Microsoft.Xaml.Interactivity.DesignTools.pdb" />
+        <file target="lib\net8.0-windows10.0.18362.0\Design\Microsoft.Xaml.Interactions.DesignTools.dll"    src="..\out\BehaviorsSDKManaged\bin\AnyCPU\Release\Microsoft.Xaml.Interactions.DesignTools.dll" />
+        <file target="lib\net8.0-windows10.0.18362.0\Design\Microsoft.Xaml.Interactions.DesignTools.pdb"    src="..\out\BehaviorsSDKManaged\bin\AnyCPU\Release\Microsoft.Xaml.Interactions.DesignTools.pdb" />
 
         <file target="src\BehaviorsSDKManaged\Microsoft.Xaml.Interactions"              src="..\src\BehaviorsSDKManaged\Microsoft.Xaml.Interactions\**\*.cs" />
         <file target="src\BehaviorsSDKManaged\Microsoft.Xaml.Interactions.Design"       src="..\src\BehaviorsSDKManaged\Microsoft.Xaml.Interactions.Design\**\*.cs" />

--- a/scripts/Microsoft.Xaml.Behaviors.Uwp.Managed.nuspec
+++ b/scripts/Microsoft.Xaml.Behaviors.Uwp.Managed.nuspec
@@ -39,10 +39,20 @@
         <file target="lib\uap10.0\Design\Microsoft.Xaml.Interactions.Design.dll"        src="..\out\BehaviorsSDKManaged\bin\AnyCPU\Release\Microsoft.Xaml.Interactions.Design.dll" />
         <file target="lib\uap10.0\Design\Microsoft.Xaml.Interactions.Design.pdb"        src="..\out\BehaviorsSDKManaged\bin\AnyCPU\Release\Microsoft.Xaml.Interactions.Design.pdb" />
 
+        <file target="lib\net8.0-windows10.0.22621.0\Design\Microsoft.Xaml.Interactivity.Design.dll"       src="..\out\BehaviorsSDKManaged\bin\AnyCPU\Release\Microsoft.Xaml.Interactivity.Design.dll" />
+        <file target="lib\net8.0-windows10.0.22621.0\Design\Microsoft.Xaml.Interactivity.Design.pdb"       src="..\out\BehaviorsSDKManaged\bin\AnyCPU\Release\Microsoft.Xaml.Interactivity.Design.pdb" />
+        <file target="lib\net8.0-windows10.0.22621.0\Design\Microsoft.Xaml.Interactions.Design.dll"        src="..\out\BehaviorsSDKManaged\bin\AnyCPU\Release\Microsoft.Xaml.Interactions.Design.dll" />
+        <file target="lib\net8.0-windows10.0.22621.0\Design\Microsoft.Xaml.Interactions.Design.pdb"        src="..\out\BehaviorsSDKManaged\bin\AnyCPU\Release\Microsoft.Xaml.Interactions.Design.pdb" />
+
         <file target="lib\uap10.0\Design\Microsoft.Xaml.Interactivity.DesignTools.dll"   src="..\out\BehaviorsSDKManaged\bin\AnyCPU\Release\Microsoft.Xaml.Interactivity.DesignTools.dll" />
         <file target="lib\uap10.0\Design\Microsoft.Xaml.Interactivity.DesignTools.pdb"   src="..\out\BehaviorsSDKManaged\bin\AnyCPU\Release\Microsoft.Xaml.Interactivity.DesignTools.pdb" />
         <file target="lib\uap10.0\Design\Microsoft.Xaml.Interactions.DesignTools.dll"    src="..\out\BehaviorsSDKManaged\bin\AnyCPU\Release\Microsoft.Xaml.Interactions.DesignTools.dll" />
         <file target="lib\uap10.0\Design\Microsoft.Xaml.Interactions.DesignTools.pdb"    src="..\out\BehaviorsSDKManaged\bin\AnyCPU\Release\Microsoft.Xaml.Interactions.DesignTools.pdb" />
+
+        <file target="lib\net8.0-windows10.0.22621.0\Design\Microsoft.Xaml.Interactivity.DesignTools.dll"   src="..\out\BehaviorsSDKManaged\bin\AnyCPU\Release\Microsoft.Xaml.Interactivity.DesignTools.dll" />
+        <file target="lib\net8.0-windows10.0.22621.0\Design\Microsoft.Xaml.Interactivity.DesignTools.pdb"   src="..\out\BehaviorsSDKManaged\bin\AnyCPU\Release\Microsoft.Xaml.Interactivity.DesignTools.pdb" />
+        <file target="lib\net8.0-windows10.0.22621.0\Design\Microsoft.Xaml.Interactions.DesignTools.dll"    src="..\out\BehaviorsSDKManaged\bin\AnyCPU\Release\Microsoft.Xaml.Interactions.DesignTools.dll" />
+        <file target="lib\net8.0-windows10.0.22621.0\Design\Microsoft.Xaml.Interactions.DesignTools.pdb"    src="..\out\BehaviorsSDKManaged\bin\AnyCPU\Release\Microsoft.Xaml.Interactions.DesignTools.pdb" />
 
         <file target="src\BehaviorsSDKManaged\Microsoft.Xaml.Interactions"              src="..\src\BehaviorsSDKManaged\Microsoft.Xaml.Interactions\**\*.cs" />
         <file target="src\BehaviorsSDKManaged\Microsoft.Xaml.Interactions.Design"       src="..\src\BehaviorsSDKManaged\Microsoft.Xaml.Interactions.Design\**\*.cs" />

--- a/scripts/Microsoft.Xaml.Behaviors.Uwp.Managed.nuspec
+++ b/scripts/Microsoft.Xaml.Behaviors.Uwp.Managed.nuspec
@@ -25,6 +25,15 @@
         <file target="lib\uap10.0\Microsoft.Xaml.Interactions.xml"                      src="..\out\BehaviorsSDKManaged\bin\AnyCPU\Release\Microsoft.Xaml.Interactions.xml" />
         <file target="lib\uap10.0\Microsoft.Xaml.Interactions.pri"                      src="..\out\BehaviorsSDKManaged\bin\AnyCPU\Release\Microsoft.Xaml.Interactions.pri" />
 
+        <file target="lib\net8.0-windows10.0.22621.0\Microsoft.Xaml.Interactivity.dll"  src="..\out\uwp\BehaviorsSDKManaged\bin\AnyCPU\Release\Microsoft.Xaml.Interactivity.dll" />
+        <file target="lib\net8.0-windows10.0.22621.0\Microsoft.Xaml.Interactivity.pdb"  src="..\out\uwp\BehaviorsSDKManaged\bin\AnyCPU\Release\Microsoft.Xaml.Interactivity.pdb" />
+        <file target="lib\net8.0-windows10.0.22621.0\Microsoft.Xaml.Interactivity.xml"  src="..\out\uwp\BehaviorsSDKManaged\bin\AnyCPU\Release\Microsoft.Xaml.Interactivity.xml" />
+        <file target="lib\net8.0-windows10.0.22621.0\Microsoft.Xaml.Interactivity.pri"  src="..\out\uwp\BehaviorsSDKManaged\bin\AnyCPU\Release\Microsoft.Xaml.Interactivity.pri" />
+        <file target="lib\net8.0-windows10.0.22621.0\Microsoft.Xaml.Interactions.dll"   src="..\out\uwp\BehaviorsSDKManaged\bin\AnyCPU\Release\Microsoft.Xaml.Interactions.dll" />
+        <file target="lib\net8.0-windows10.0.22621.0\Microsoft.Xaml.Interactions.pdb"   src="..\out\uwp\BehaviorsSDKManaged\bin\AnyCPU\Release\Microsoft.Xaml.Interactions.pdb" />
+        <file target="lib\net8.0-windows10.0.22621.0\Microsoft.Xaml.Interactions.xml"   src="..\out\uwp\BehaviorsSDKManaged\bin\AnyCPU\Release\Microsoft.Xaml.Interactions.xml" />
+        <file target="lib\net8.0-windows10.0.22621.0\Microsoft.Xaml.Interactions.pri"   src="..\out\uwp\BehaviorsSDKManaged\bin\AnyCPU\Release\Microsoft.Xaml.Interactions.pri" />
+
         <file target="lib\uap10.0\Design\Microsoft.Xaml.Interactivity.Design.dll"       src="..\out\BehaviorsSDKManaged\bin\AnyCPU\Release\Microsoft.Xaml.Interactivity.Design.dll" />
         <file target="lib\uap10.0\Design\Microsoft.Xaml.Interactivity.Design.pdb"       src="..\out\BehaviorsSDKManaged\bin\AnyCPU\Release\Microsoft.Xaml.Interactivity.Design.pdb" />
         <file target="lib\uap10.0\Design\Microsoft.Xaml.Interactions.Design.dll"        src="..\out\BehaviorsSDKManaged\bin\AnyCPU\Release\Microsoft.Xaml.Interactions.Design.dll" />

--- a/src/BehaviorsSDKManaged/BehaviorsSDKManaged.sln
+++ b/src/BehaviorsSDKManaged/BehaviorsSDKManaged.sln
@@ -54,7 +54,9 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Platforms", "Platforms", "{
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Uwp", "Uwp", "{67B23F04-942D-43D5-B501-8540BF0923B6}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Xaml.Interactivity.Uwp", "Microsoft.Xaml.Interactivity.Uwp\Microsoft.Xaml.Interactivity.Uwp.csproj", "{E6A328C8-2D9A-459A-86EE-F1C50CC6DADD}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Xaml.Interactivity.Uwp", "Microsoft.Xaml.Interactivity.Uwp\Microsoft.Xaml.Interactivity.Uwp.csproj", "{E6A328C8-2D9A-459A-86EE-F1C50CC6DADD}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Xaml.Interactions.Uwp", "Microsoft.Xaml.Interactions.Uwp\Microsoft.Xaml.Interactions.Uwp.csproj", "{B1C5E139-C8DF-46B5-9ABC-4515BDECAFA3}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -231,6 +233,26 @@ Global
 		{E6A328C8-2D9A-459A-86EE-F1C50CC6DADD}.Release|x64.Build.0 = Release|x64
 		{E6A328C8-2D9A-459A-86EE-F1C50CC6DADD}.Release|x86.ActiveCfg = Release|x86
 		{E6A328C8-2D9A-459A-86EE-F1C50CC6DADD}.Release|x86.Build.0 = Release|x86
+		{B1C5E139-C8DF-46B5-9ABC-4515BDECAFA3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B1C5E139-C8DF-46B5-9ABC-4515BDECAFA3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B1C5E139-C8DF-46B5-9ABC-4515BDECAFA3}.Debug|ARM.ActiveCfg = Debug|Any CPU
+		{B1C5E139-C8DF-46B5-9ABC-4515BDECAFA3}.Debug|ARM.Build.0 = Debug|Any CPU
+		{B1C5E139-C8DF-46B5-9ABC-4515BDECAFA3}.Debug|ARM64.ActiveCfg = Debug|Any CPU
+		{B1C5E139-C8DF-46B5-9ABC-4515BDECAFA3}.Debug|ARM64.Build.0 = Debug|Any CPU
+		{B1C5E139-C8DF-46B5-9ABC-4515BDECAFA3}.Debug|x64.ActiveCfg = Debug|x64
+		{B1C5E139-C8DF-46B5-9ABC-4515BDECAFA3}.Debug|x64.Build.0 = Debug|x64
+		{B1C5E139-C8DF-46B5-9ABC-4515BDECAFA3}.Debug|x86.ActiveCfg = Debug|x86
+		{B1C5E139-C8DF-46B5-9ABC-4515BDECAFA3}.Debug|x86.Build.0 = Debug|x86
+		{B1C5E139-C8DF-46B5-9ABC-4515BDECAFA3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B1C5E139-C8DF-46B5-9ABC-4515BDECAFA3}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B1C5E139-C8DF-46B5-9ABC-4515BDECAFA3}.Release|ARM.ActiveCfg = Release|Any CPU
+		{B1C5E139-C8DF-46B5-9ABC-4515BDECAFA3}.Release|ARM.Build.0 = Release|Any CPU
+		{B1C5E139-C8DF-46B5-9ABC-4515BDECAFA3}.Release|ARM64.ActiveCfg = Release|Any CPU
+		{B1C5E139-C8DF-46B5-9ABC-4515BDECAFA3}.Release|ARM64.Build.0 = Release|Any CPU
+		{B1C5E139-C8DF-46B5-9ABC-4515BDECAFA3}.Release|x64.ActiveCfg = Release|x64
+		{B1C5E139-C8DF-46B5-9ABC-4515BDECAFA3}.Release|x64.Build.0 = Release|x64
+		{B1C5E139-C8DF-46B5-9ABC-4515BDECAFA3}.Release|x86.ActiveCfg = Release|x86
+		{B1C5E139-C8DF-46B5-9ABC-4515BDECAFA3}.Release|x86.Build.0 = Release|x86
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -249,6 +271,7 @@ Global
 		{67E69A39-4F60-4F46-98D3-13C8DE05F0E4} = {6DC88A28-BB73-411D-A94C-D1D2637289C8}
 		{67B23F04-942D-43D5-B501-8540BF0923B6} = {6DC88A28-BB73-411D-A94C-D1D2637289C8}
 		{E6A328C8-2D9A-459A-86EE-F1C50CC6DADD} = {67B23F04-942D-43D5-B501-8540BF0923B6}
+		{B1C5E139-C8DF-46B5-9ABC-4515BDECAFA3} = {67B23F04-942D-43D5-B501-8540BF0923B6}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {5590EAFF-6ECD-427C-A50A-A9ABFD9CDB2B}

--- a/src/BehaviorsSDKManaged/BehaviorsSDKManaged.sln
+++ b/src/BehaviorsSDKManaged/BehaviorsSDKManaged.sln
@@ -283,6 +283,7 @@ Global
 		Microsoft.Xaml.Interactivity.Shared\Microsoft.Xaml.Interactivity.Shared.projitems*{7119f232-7bef-42f9-9ba1-52654adc98b6}*SharedItemsImports = 5
 		Microsoft.Xaml.Interactivity.Shared\Microsoft.Xaml.Interactivity.Shared.projitems*{7ffc1385-c3e1-487c-9a81-de48dd63ecb9}*SharedItemsImports = 4
 		Microsoft.Xaml.Interactions.Shared\Microsoft.Xaml.Interactions.Shared.projitems*{a338a7f2-9010-477b-8a6e-6c2b2495c33c}*SharedItemsImports = 4
+		Microsoft.Xaml.Interactions.Shared\Microsoft.Xaml.Interactions.Shared.projitems*{b1c5e139-c8df-46b5-9abc-4515bdecafa3}*SharedItemsImports = 5
 		Microsoft.Xaml.Interactivity.Shared\Microsoft.Xaml.Interactivity.Shared.projitems*{e6a328c8-2d9a-459a-86ee-f1c50cc6dadd}*SharedItemsImports = 5
 	EndGlobalSection
 EndGlobal

--- a/src/BehaviorsSDKManaged/BehaviorsSDKManaged.sln
+++ b/src/BehaviorsSDKManaged/BehaviorsSDKManaged.sln
@@ -56,7 +56,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Uwp", "Uwp", "{67B23F04-942
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Xaml.Interactivity.Uwp", "Microsoft.Xaml.Interactivity.Uwp\Microsoft.Xaml.Interactivity.Uwp.csproj", "{E6A328C8-2D9A-459A-86EE-F1C50CC6DADD}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Xaml.Interactions.Uwp", "Microsoft.Xaml.Interactions.Uwp\Microsoft.Xaml.Interactions.Uwp.csproj", "{B1C5E139-C8DF-46B5-9ABC-4515BDECAFA3}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Xaml.Interactions.Uwp", "Microsoft.Xaml.Interactions.Uwp\Microsoft.Xaml.Interactions.Uwp.csproj", "{B1C5E139-C8DF-46B5-9ABC-4515BDECAFA3}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -283,5 +283,6 @@ Global
 		Microsoft.Xaml.Interactivity.Shared\Microsoft.Xaml.Interactivity.Shared.projitems*{7119f232-7bef-42f9-9ba1-52654adc98b6}*SharedItemsImports = 5
 		Microsoft.Xaml.Interactivity.Shared\Microsoft.Xaml.Interactivity.Shared.projitems*{7ffc1385-c3e1-487c-9a81-de48dd63ecb9}*SharedItemsImports = 4
 		Microsoft.Xaml.Interactions.Shared\Microsoft.Xaml.Interactions.Shared.projitems*{a338a7f2-9010-477b-8a6e-6c2b2495c33c}*SharedItemsImports = 4
+		Microsoft.Xaml.Interactivity.Shared\Microsoft.Xaml.Interactivity.Shared.projitems*{e6a328c8-2d9a-459a-86ee-f1c50cc6dadd}*SharedItemsImports = 5
 	EndGlobalSection
 EndGlobal

--- a/src/BehaviorsSDKManaged/BehaviorsSDKManaged.sln
+++ b/src/BehaviorsSDKManaged/BehaviorsSDKManaged.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.29806.167
+# Visual Studio Version 17
+VisualStudioVersion = 17.10.35027.167
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Xaml.Interactivity", "Microsoft.Xaml.Interactivity\Microsoft.Xaml.Interactivity.csproj", "{7FFC1385-C3E1-487C-9A81-DE48DD63ECB9}"
 EndProject
@@ -36,9 +36,9 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Xaml.Interactivit
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "WinUI", "WinUI", "{0A3F92B2-BCF6-4456-8C6B-76A7D85F2276}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Xaml.Interactions.WinUI", "Microsoft.Xaml.Interactions.WinUI\Microsoft.Xaml.Interactions.WinUI.csproj", "{53214A0E-68BB-4891-B3C4-55E0FA108661}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Xaml.Interactions.WinUI", "Microsoft.Xaml.Interactions.WinUI\Microsoft.Xaml.Interactions.WinUI.csproj", "{53214A0E-68BB-4891-B3C4-55E0FA108661}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Xaml.Interactivity.WinUI", "Microsoft.Xaml.Interactivity.WinUI\Microsoft.Xaml.Interactivity.WinUI.csproj", "{7119F232-7BEF-42F9-9BA1-52654ADC98B6}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Xaml.Interactivity.WinUI", "Microsoft.Xaml.Interactivity.WinUI\Microsoft.Xaml.Interactivity.WinUI.csproj", "{7119F232-7BEF-42F9-9BA1-52654ADC98B6}"
 EndProject
 Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "Microsoft.Xaml.Interactions.Shared", "Microsoft.Xaml.Interactions.Shared\Microsoft.Xaml.Interactions.Shared.shproj", "{0B356A23-7184-4E11-9706-2BF6A5FC82EB}"
 EndProject
@@ -52,15 +52,11 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Legacy", "Legacy", "{67E69A
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Platforms", "Platforms", "{6DC88A28-BB73-411D-A94C-D1D2637289C8}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Uwp", "Uwp", "{67B23F04-942D-43D5-B501-8540BF0923B6}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Xaml.Interactivity.Uwp", "Microsoft.Xaml.Interactivity.Uwp\Microsoft.Xaml.Interactivity.Uwp.csproj", "{E6A328C8-2D9A-459A-86EE-F1C50CC6DADD}"
+EndProject
 Global
-	GlobalSection(SharedMSBuildProjectFiles) = preSolution
-		Microsoft.Xaml.Interactions.Shared\Microsoft.Xaml.Interactions.Shared.projitems*{0b356a23-7184-4e11-9706-2bf6a5fc82eb}*SharedItemsImports = 13
-		Microsoft.Xaml.Interactivity.Shared\Microsoft.Xaml.Interactivity.Shared.projitems*{52e3ed43-3013-4155-ad87-6df52a265d59}*SharedItemsImports = 13
-		Microsoft.Xaml.Interactions.Shared\Microsoft.Xaml.Interactions.Shared.projitems*{53214a0e-68bb-4891-b3c4-55e0fa108661}*SharedItemsImports = 5
-		Microsoft.Xaml.Interactivity.Shared\Microsoft.Xaml.Interactivity.Shared.projitems*{7119f232-7bef-42f9-9ba1-52654adc98b6}*SharedItemsImports = 5
-		Microsoft.Xaml.Interactivity.Shared\Microsoft.Xaml.Interactivity.Shared.projitems*{7ffc1385-c3e1-487c-9a81-de48dd63ecb9}*SharedItemsImports = 4
-		Microsoft.Xaml.Interactions.Shared\Microsoft.Xaml.Interactions.Shared.projitems*{a338a7f2-9010-477b-8a6e-6c2b2495c33c}*SharedItemsImports = 4
-	EndGlobalSection
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
 		Debug|ARM64 = Debug|ARM64
@@ -215,6 +211,26 @@ Global
 		{7119F232-7BEF-42F9-9BA1-52654ADC98B6}.Release|x64.Build.0 = Release|x64
 		{7119F232-7BEF-42F9-9BA1-52654ADC98B6}.Release|x86.ActiveCfg = Release|x86
 		{7119F232-7BEF-42F9-9BA1-52654ADC98B6}.Release|x86.Build.0 = Release|x86
+		{E6A328C8-2D9A-459A-86EE-F1C50CC6DADD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E6A328C8-2D9A-459A-86EE-F1C50CC6DADD}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E6A328C8-2D9A-459A-86EE-F1C50CC6DADD}.Debug|ARM.ActiveCfg = Debug|Any CPU
+		{E6A328C8-2D9A-459A-86EE-F1C50CC6DADD}.Debug|ARM.Build.0 = Debug|Any CPU
+		{E6A328C8-2D9A-459A-86EE-F1C50CC6DADD}.Debug|ARM64.ActiveCfg = Debug|Any CPU
+		{E6A328C8-2D9A-459A-86EE-F1C50CC6DADD}.Debug|ARM64.Build.0 = Debug|Any CPU
+		{E6A328C8-2D9A-459A-86EE-F1C50CC6DADD}.Debug|x64.ActiveCfg = Debug|x64
+		{E6A328C8-2D9A-459A-86EE-F1C50CC6DADD}.Debug|x64.Build.0 = Debug|x64
+		{E6A328C8-2D9A-459A-86EE-F1C50CC6DADD}.Debug|x86.ActiveCfg = Debug|x86
+		{E6A328C8-2D9A-459A-86EE-F1C50CC6DADD}.Debug|x86.Build.0 = Debug|x86
+		{E6A328C8-2D9A-459A-86EE-F1C50CC6DADD}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E6A328C8-2D9A-459A-86EE-F1C50CC6DADD}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E6A328C8-2D9A-459A-86EE-F1C50CC6DADD}.Release|ARM.ActiveCfg = Release|Any CPU
+		{E6A328C8-2D9A-459A-86EE-F1C50CC6DADD}.Release|ARM.Build.0 = Release|Any CPU
+		{E6A328C8-2D9A-459A-86EE-F1C50CC6DADD}.Release|ARM64.ActiveCfg = Release|Any CPU
+		{E6A328C8-2D9A-459A-86EE-F1C50CC6DADD}.Release|ARM64.Build.0 = Release|Any CPU
+		{E6A328C8-2D9A-459A-86EE-F1C50CC6DADD}.Release|x64.ActiveCfg = Release|x64
+		{E6A328C8-2D9A-459A-86EE-F1C50CC6DADD}.Release|x64.Build.0 = Release|x64
+		{E6A328C8-2D9A-459A-86EE-F1C50CC6DADD}.Release|x86.ActiveCfg = Release|x86
+		{E6A328C8-2D9A-459A-86EE-F1C50CC6DADD}.Release|x86.Build.0 = Release|x86
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -231,8 +247,18 @@ Global
 		{53214A0E-68BB-4891-B3C4-55E0FA108661} = {0A3F92B2-BCF6-4456-8C6B-76A7D85F2276}
 		{7119F232-7BEF-42F9-9BA1-52654ADC98B6} = {0A3F92B2-BCF6-4456-8C6B-76A7D85F2276}
 		{67E69A39-4F60-4F46-98D3-13C8DE05F0E4} = {6DC88A28-BB73-411D-A94C-D1D2637289C8}
+		{67B23F04-942D-43D5-B501-8540BF0923B6} = {6DC88A28-BB73-411D-A94C-D1D2637289C8}
+		{E6A328C8-2D9A-459A-86EE-F1C50CC6DADD} = {67B23F04-942D-43D5-B501-8540BF0923B6}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {5590EAFF-6ECD-427C-A50A-A9ABFD9CDB2B}
+	EndGlobalSection
+	GlobalSection(SharedMSBuildProjectFiles) = preSolution
+		Microsoft.Xaml.Interactions.Shared\Microsoft.Xaml.Interactions.Shared.projitems*{0b356a23-7184-4e11-9706-2bf6a5fc82eb}*SharedItemsImports = 13
+		Microsoft.Xaml.Interactivity.Shared\Microsoft.Xaml.Interactivity.Shared.projitems*{52e3ed43-3013-4155-ad87-6df52a265d59}*SharedItemsImports = 13
+		Microsoft.Xaml.Interactions.Shared\Microsoft.Xaml.Interactions.Shared.projitems*{53214a0e-68bb-4891-b3c4-55e0fa108661}*SharedItemsImports = 5
+		Microsoft.Xaml.Interactivity.Shared\Microsoft.Xaml.Interactivity.Shared.projitems*{7119f232-7bef-42f9-9ba1-52654adc98b6}*SharedItemsImports = 5
+		Microsoft.Xaml.Interactivity.Shared\Microsoft.Xaml.Interactivity.Shared.projitems*{7ffc1385-c3e1-487c-9a81-de48dd63ecb9}*SharedItemsImports = 4
+		Microsoft.Xaml.Interactions.Shared\Microsoft.Xaml.Interactions.Shared.projitems*{a338a7f2-9010-477b-8a6e-6c2b2495c33c}*SharedItemsImports = 4
 	EndGlobalSection
 EndGlobal

--- a/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactions.DesignTools/Microsoft.Xaml.Interactions.DesignTools.csproj
+++ b/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactions.DesignTools/Microsoft.Xaml.Interactions.DesignTools.csproj
@@ -95,7 +95,7 @@
     <PackageProjectUrl>http://go.microsoft.com/fwlink/?LinkID=651678</PackageProjectUrl>
     <PackageIconUrl>http://go.microsoft.com/fwlink/?LinkID=708511</PackageIconUrl>
     <NuspecFile>..\..\..\scripts\Microsoft.Xaml.Behaviors.Uwp.Managed.nuspec</NuspecFile>
-    <PackageOutputPath>..\..\..\scripts</PackageOutputPath>
+    <PackageOutputPath>..\..\..\out\NuGetPackages</PackageOutputPath>
   </PropertyGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>

--- a/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactions.Shared/Core/EventTriggerBehavior.cs
+++ b/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactions.Shared/Core/EventTriggerBehavior.cs
@@ -13,6 +13,8 @@ using Microsoft.UI.Xaml.Media;
 #else
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Media;
+#endif
+#if WINDOWS_UWP && !NET8_0_OR_GREATER
 using System.Runtime.InteropServices.WindowsRuntime;
 #endif
 
@@ -49,7 +51,7 @@ namespace Microsoft.Xaml.Interactions.Core
         private object _resolvedSource;
         private Delegate _eventHandler;
         private bool _isLoadedEventRegistered;
-#if !WinUI
+#if !NET8_0_OR_GREATER
         private bool _isWindowsRuntimeEvent;
         private Func<Delegate, EventRegistrationToken> _addEventHandlerMethod;
         private Action<EventRegistrationToken> _removeEventHandlerMethod;
@@ -164,7 +166,7 @@ namespace Microsoft.Xaml.Interactions.Core
                 MethodInfo methodInfo = typeof(EventTriggerBehavior).GetTypeInfo().GetDeclaredMethod("OnEvent");
                 this._eventHandler = methodInfo.CreateDelegate(info.EventHandlerType, this);
 
-#if WinUI
+#if NET8_0_OR_GREATER
                 info.AddEventHandler(this._resolvedSource, this._eventHandler);
 #else
                 this._isWindowsRuntimeEvent = EventTriggerBehavior.IsWindowsRuntimeEvent(info);
@@ -207,7 +209,7 @@ namespace Microsoft.Xaml.Interactions.Core
                 }
 
                 EventInfo info = this._resolvedSource.GetType().GetRuntimeEvent(eventName);
-#if WinUI
+#if NET8_0_OR_GREATER
                 info.RemoveEventHandler(this._resolvedSource, this._eventHandler);
 #else
                 if (this._isWindowsRuntimeEvent)
@@ -256,7 +258,7 @@ namespace Microsoft.Xaml.Interactions.Core
             behavior.RegisterEvent(newEventName);
         }
 
-#if !WinUI
+#if !NET8_0_OR_GREATER
         private static bool IsWindowsRuntimeEvent(EventInfo eventInfo)
         {
             return eventInfo != null &&

--- a/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactions.Shared/Core/ResourceHelper.cs
+++ b/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactions.Shared/Core/ResourceHelper.cs
@@ -7,13 +7,13 @@ namespace Microsoft.Xaml.Interactions.Core
 
     internal static class ResourceHelper
     {
-#if NET8_0_OR_GREATER
+#if NET8_0_OR_GREATER && !MODERN_WINDOWS_UWP
         private static ResourceLoader strings = new ResourceLoader(ResourceLoader.GetDefaultResourceFilePath(), "Microsoft.Xaml.Interactions/Strings");
 #endif
 
         public static string GetString(string resourceName)
         {
-#if !NET8_0_OR_GREATER 
+#if !NET8_0_OR_GREATER || MODERN_WINDOWS_UWP
             var strings = ResourceLoader.GetForCurrentView("Microsoft.Xaml.Interactions/Strings");
 #endif
             return strings.GetString(resourceName);

--- a/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactions.Uwp/Microsoft.Xaml.Interactions.Uwp.csproj
+++ b/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactions.Uwp/Microsoft.Xaml.Interactions.Uwp.csproj
@@ -1,0 +1,9 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactions.Uwp/Microsoft.Xaml.Interactions.Uwp.csproj
+++ b/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactions.Uwp/Microsoft.Xaml.Interactions.Uwp.csproj
@@ -110,6 +110,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.1.3" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.Windows.SDK.CPP" Version="10.0.26100.2161" PrivateAssets="all" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.Xaml.Interactivity.Uwp\Microsoft.Xaml.Interactivity.Uwp.csproj">

--- a/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactions.Uwp/Microsoft.Xaml.Interactions.Uwp.csproj
+++ b/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactions.Uwp/Microsoft.Xaml.Interactions.Uwp.csproj
@@ -1,9 +1,213 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<OutputType>Library</OutputType>
+		<TargetFramework>net8.0-windows10.0.22621.0</TargetFramework>
+		<TargetPlatformVersion>10.0.22621.0</TargetPlatformVersion>
+		<WindowsSdkPackageVersion>10.0.22621.37-preview</WindowsSdkPackageVersion>
+		<UseUwp>true</UseUwp>
+		<UseUwpTools>true</UseUwpTools>
+		<RootNamespace>Microsoft.Xaml.Interactions</RootNamespace>
+		<Platforms>AnyCPU;x86;x64;arm64</Platforms>
+		<RuntimeIdentifiers>win-x86;win-x64;win-arm64</RuntimeIdentifiers>
+		<TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
+		<SupportedOSPlatformVersion>$(TargetPlatformMinVersion)</SupportedOSPlatformVersion>
+		<AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+		<IsAotCompatible>true</IsAotCompatible>
 
-  <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
-  </PropertyGroup>
-
+		<!-- Temporary workaround, will be fixed in VS 17.12 P1 -->
+		<AddMicrosoftVCLibsSDKReference>false</AddMicrosoftVCLibsSDKReference>
+		<AddMicrosoftUniversalCRTDebugSDKReference>false</AddMicrosoftUniversalCRTDebugSDKReference>
+	</PropertyGroup>
+	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+		<PlatformTarget>AnyCPU</PlatformTarget>
+		<DebugSymbols>true</DebugSymbols>
+		<DebugType>full</DebugType>
+		<Optimize>false</Optimize>
+		<OutputPath>..\..\..\out\Uwp\BehaviorsSDKManaged\bin\AnyCPU\Debug\</OutputPath>
+		<DefineConstants>DEBUG;TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
+		<ErrorReport>prompt</ErrorReport>
+		<WarningLevel>4</WarningLevel>
+	</PropertyGroup>
+	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+		<PlatformTarget>AnyCPU</PlatformTarget>
+		<DebugType>pdbonly</DebugType>
+		<Optimize>true</Optimize>
+		<OutputPath>..\..\..\out\Uwp\BehaviorsSDKManaged\bin\AnyCPU\Release\</OutputPath>
+		<DefineConstants>TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
+		<ErrorReport>prompt</ErrorReport>
+		<WarningLevel>4</WarningLevel>
+		<DocumentationFile>..\..\..\out\Uwp\BehaviorsSDKManaged\bin\AnyCPU\Release\Microsoft.Xaml.Interactions.xml</DocumentationFile>
+	</PropertyGroup>
+	<PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
+		<PlatformTarget>x86</PlatformTarget>
+		<DebugSymbols>true</DebugSymbols>
+		<OutputPath>..\..\..\out\Uwp\BehaviorsSDKManaged\bin\x86\Debug\</OutputPath>
+		<DefineConstants>DEBUG;TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
+		<NoWarn>;2008</NoWarn>
+		<DebugType>full</DebugType>
+		<UseVSHostingProcess>false</UseVSHostingProcess>
+		<ErrorReport>prompt</ErrorReport>
+	</PropertyGroup>
+	<PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x86'">
+		<PlatformTarget>x86</PlatformTarget>
+		<OutputPath>..\..\..\out\Uwp\BehaviorsSDKManaged\bin\x86\Release\</OutputPath>
+		<DefineConstants>TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
+		<Optimize>true</Optimize>
+		<NoWarn>;2008</NoWarn>
+		<DebugType>pdbonly</DebugType>
+		<UseVSHostingProcess>false</UseVSHostingProcess>
+		<ErrorReport>prompt</ErrorReport>
+		<DocumentationFile>..\..\..\out\Uwp\BehaviorsSDKManaged\bin\x86\Release\Microsoft.Xaml.Interactions.xml</DocumentationFile>
+	</PropertyGroup>
+	<PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|ARM'">
+		<PlatformTarget>ARM</PlatformTarget>
+		<DebugSymbols>true</DebugSymbols>
+		<OutputPath>..\..\..\out\Uwp\BehaviorsSDKManaged\bin\ARM\Debug\</OutputPath>
+		<DefineConstants>DEBUG;TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
+		<NoWarn>;2008</NoWarn>
+		<DebugType>full</DebugType>
+		<UseVSHostingProcess>false</UseVSHostingProcess>
+		<ErrorReport>prompt</ErrorReport>
+	</PropertyGroup>
+	<PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|ARM'">
+		<PlatformTarget>ARM</PlatformTarget>
+		<OutputPath>..\..\..\out\Uwp\BehaviorsSDKManaged\bin\ARM\Release\</OutputPath>
+		<DefineConstants>TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
+		<Optimize>true</Optimize>
+		<NoWarn>;2008</NoWarn>
+		<DebugType>pdbonly</DebugType>
+		<UseVSHostingProcess>false</UseVSHostingProcess>
+		<ErrorReport>prompt</ErrorReport>
+	</PropertyGroup>
+	<PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|ARM64'">
+		<PlatformTarget>ARM64</PlatformTarget>
+		<DebugSymbols>true</DebugSymbols>
+		<OutputPath>..\..\..\out\Uwp\BehaviorsSDKManaged\bin\ARM64\Debug\</OutputPath>
+		<DefineConstants>DEBUG;TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
+		<NoWarn>;2008</NoWarn>
+		<DebugType>full</DebugType>
+		<UseVSHostingProcess>false</UseVSHostingProcess>
+		<ErrorReport>prompt</ErrorReport>
+	</PropertyGroup>
+	<PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|ARM64'">
+		<PlatformTarget>ARM64</PlatformTarget>
+		<OutputPath>..\..\..\out\Uwp\BehaviorsSDKManaged\bin\ARM\Release\</OutputPath>
+		<DefineConstants>TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
+		<Optimize>true</Optimize>
+		<NoWarn>;2008</NoWarn>
+		<DebugType>pdbonly</DebugType>
+		<UseVSHostingProcess>false</UseVSHostingProcess>
+		<ErrorReport>prompt</ErrorReport>
+	</PropertyGroup>
+	<PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
+		<PlatformTarget>x64</PlatformTarget>
+		<DebugSymbols>true</DebugSymbols>
+		<OutputPath>..\..\..\out\Uwp\BehaviorsSDKManaged\bin\x64\Debug\</OutputPath>
+		<DefineConstants>DEBUG;TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
+		<NoWarn>;2008</NoWarn>
+		<DebugType>full</DebugType>
+		<UseVSHostingProcess>false</UseVSHostingProcess>
+		<ErrorReport>prompt</ErrorReport>
+	</PropertyGroup>
+	<PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
+		<PlatformTarget>x64</PlatformTarget>
+		<OutputPath>..\..\..\out\Uwp\BehaviorsSDKManaged\bin\x64\Release\</OutputPath>
+		<DefineConstants>TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
+		<Optimize>true</Optimize>
+		<NoWarn>;2008</NoWarn>
+		<DebugType>pdbonly</DebugType>
+		<UseVSHostingProcess>false</UseVSHostingProcess>
+		<ErrorReport>prompt</ErrorReport>
+		<DocumentationFile>..\..\..\out\Uwp\BehaviorsSDKManaged\bin\x64\Release\Microsoft.Xaml.Interactions.xml</DocumentationFile>
+	</PropertyGroup>
+	<PropertyGroup>
+		<RestoreProjectStyle>PackageReference</RestoreProjectStyle>
+	</PropertyGroup>
+	<ItemGroup>
+	  <Compile Include="..\Microsoft.Xaml.Interactions.WinUI\Properties\AssemblyInfo.cs" Link="Properties\AssemblyInfo.cs" />
+	</ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="Microsoft.VisualStudioEng.MicroBuild.Core" Version="1.0.0">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
+	</ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\Microsoft.Xaml.Interactivity.Uwp\Microsoft.Xaml.Interactivity.Uwp.csproj">
+			<Project>{b1c5e139-c8df-46b5-9abc-4515bdecafa3}</Project>
+			<Name>Microsoft.Xaml.Interactivity.Uwp</Name>
+		</ProjectReference>
+	</ItemGroup>
+	<ItemGroup>
+		<PRIResource Include="..\Microsoft.Xaml.Interactions\Resources\de-DE\Strings.resw">
+			<Link>Resources\de-DE\Strings.resw</Link>
+		</PRIResource>
+	</ItemGroup>
+	<ItemGroup>
+		<PRIResource Include="..\Microsoft.Xaml.Interactions\Resources\en-us\Strings.resw">
+			<Link>Resources\en-US\Strings.resw</Link>
+		</PRIResource>
+	</ItemGroup>
+	<ItemGroup>
+		<PRIResource Include="..\Microsoft.Xaml.Interactions\Resources\es-ES\Strings.resw">
+			<Link>Resources\es-ES\Strings.resw</Link>
+		</PRIResource>
+	</ItemGroup>
+	<ItemGroup>
+		<PRIResource Include="..\Microsoft.Xaml.Interactions\Resources\fr-FR\Strings.resw">
+			<Link>Resources\fr-FR\Strings.resw</Link>
+		</PRIResource>
+	</ItemGroup>
+	<ItemGroup>
+		<PRIResource Include="..\Microsoft.Xaml.Interactions\Resources\it-IT\Strings.resw">
+			<Link>Resources\it-IT\Strings.resw</Link>
+		</PRIResource>
+	</ItemGroup>
+	<ItemGroup>
+		<PRIResource Include="..\Microsoft.Xaml.Interactions\Resources\ja-JP\Strings.resw">
+			<Link>Resources\ja-JP\Strings.resw</Link>
+		</PRIResource>
+	</ItemGroup>
+	<ItemGroup>
+		<PRIResource Include="..\Microsoft.Xaml.Interactions\Resources\ko-KR\Strings.resw">
+			<Link>Resources\ko-KR\Strings.resw</Link>
+		</PRIResource>
+	</ItemGroup>
+	<ItemGroup>
+		<PRIResource Include="..\Microsoft.Xaml.Interactions\Resources\pt-BR\Strings.resw">
+			<Link>Resources\pt-BR\Strings.resw</Link>
+		</PRIResource>
+	</ItemGroup>
+	<ItemGroup>
+		<PRIResource Include="..\Microsoft.Xaml.Interactions\Resources\ru-RU\Strings.resw">
+			<Link>Resources\ru-RU\Strings.resw</Link>
+		</PRIResource>
+	</ItemGroup>
+	<ItemGroup>
+		<PRIResource Include="..\Microsoft.Xaml.Interactions\Resources\uk-UA\Strings.resw">
+			<Link>Resources\uk-UA\Strings.resw</Link>
+		</PRIResource>
+	</ItemGroup>
+	<ItemGroup>
+		<PRIResource Include="..\Microsoft.Xaml.Interactions\Resources\zh-CN\Strings.resw">
+			<Link>Resources\zh-CN\Strings.resw</Link>
+		</PRIResource>
+	</ItemGroup>
+	<ItemGroup>
+		<PRIResource Include="..\Microsoft.Xaml.Interactions\Resources\zh-TW\Strings.resw">
+			<Link>Resources\zh-TW\Strings.resw</Link>
+		</PRIResource>
+	</ItemGroup>
+	<Import Project="..\Microsoft.Xaml.Interactions.Shared\Microsoft.Xaml.Interactions.Shared.projitems" Label="Shared" />
+	<PropertyGroup Condition=" '$(VisualStudioVersion)' == '' or '$(VisualStudioVersion)' &lt; '14.0' ">
+		<VisualStudioVersion>14.0</VisualStudioVersion>
+	</PropertyGroup>
+	<Import Project="..\..\..\scripts\Microsoft.Xaml.Behaviors.Signing.targets" />
+	<PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
+		<DocumentationFile>..\..\..\out\Uwp\BehaviorsSDKManaged\bin\$(Platform)\Release\Microsoft.Xaml.Interactions.xml</DocumentationFile>
+	</PropertyGroup>
+	<PropertyGroup>
+		<DefineConstants>$(DefineConstants);MODERN_WINDOWS_UWP</DefineConstants>
+		<AssemblyName>Microsoft.Xaml.Interactions</AssemblyName>
+	</PropertyGroup>
 </Project>

--- a/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactions.Uwp/Microsoft.Xaml.Interactions.Uwp.csproj
+++ b/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactions.Uwp/Microsoft.Xaml.Interactions.Uwp.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFramework>net8.0-windows10.0.22621.0</TargetFramework>
-    <WindowsSdkPackageVersion>10.0.22621.39</WindowsSdkPackageVersion>
+    <TargetFramework>net8.0-windows10.0.26100.0</TargetFramework>
+    <WindowsSdkPackageVersion>10.0.26100.39</WindowsSdkPackageVersion>
     <TargetPlatformMinVersion>10.0.18362.0</TargetPlatformMinVersion>
     <RootNamespace>Microsoft.Xaml.Interactions</RootNamespace>
     <UseUwp>true</UseUwp>

--- a/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactions.Uwp/Microsoft.Xaml.Interactions.Uwp.csproj
+++ b/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactions.Uwp/Microsoft.Xaml.Interactions.Uwp.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <TargetFramework>net8.0-windows10.0.26100.0</TargetFramework>
-    <WindowsSdkPackageVersion>10.0.26100.39</WindowsSdkPackageVersion>
+    <WindowsSdkPackageVersion>10.0.26100.54</WindowsSdkPackageVersion>
     <TargetPlatformMinVersion>10.0.18362.0</TargetPlatformMinVersion>
     <RootNamespace>Microsoft.Xaml.Interactions</RootNamespace>
     <UseUwp>true</UseUwp>

--- a/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactions.Uwp/Microsoft.Xaml.Interactions.Uwp.csproj
+++ b/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactions.Uwp/Microsoft.Xaml.Interactions.Uwp.csproj
@@ -2,22 +2,21 @@
     <PropertyGroup>
         <OutputType>Library</OutputType>
         <TargetFramework>net8.0-windows10.0.22621.0</TargetFramework>
+        <WindowsSdkPackageVersion>10.0.22621.39</WindowsSdkPackageVersion>
         <TargetPlatformVersion>10.0.22621.0</TargetPlatformVersion>
         <TargetPlatformMinVersion>10.0.18362.0</TargetPlatformMinVersion>
-        <WindowsSdkPackageVersion>10.0.22621.39</WindowsSdkPackageVersion>
-        <UseUwp>true</UseUwp>
-        <UseUwpTools>true</UseUwpTools>
         <RootNamespace>Microsoft.Xaml.Interactions</RootNamespace>
+        <UseUwp>true</UseUwp>
+        <UseUwpTools>true</UseUwpTools>        
         <DefaultLanguage>en-US</DefaultLanguage>
         <Platforms>AnyCPU;x86;x64;arm64</Platforms>
         <RuntimeIdentifiers>win-x86;win-x64;win-arm64</RuntimeIdentifiers>
         <SupportedOSPlatformVersion>$(TargetPlatformMinVersion)</SupportedOSPlatformVersion>
         <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
         <IsAotCompatible>true</IsAotCompatible>
-
-        <!-- Temporary workaround, will be fixed in VS 17.12 P1 -->
-        <AddMicrosoftVCLibsSDKReference>false</AddMicrosoftVCLibsSDKReference>
-        <AddMicrosoftUniversalCRTDebugSDKReference>false</AddMicrosoftUniversalCRTDebugSDKReference>
+        <DisableRuntimeMarshalling>true</DisableRuntimeMarshalling>
+        <CsWinRTGenerateProjection>false</CsWinRTGenerateProjection>
+        <CsWinRTAotWarningLevel>2</CsWinRTAotWarningLevel>
     </PropertyGroup>
     <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
         <PlatformTarget>AnyCPU</PlatformTarget>
@@ -59,26 +58,6 @@
         <UseVSHostingProcess>false</UseVSHostingProcess>
         <ErrorReport>prompt</ErrorReport>
         <DocumentationFile>..\..\..\out\Uwp\BehaviorsSDKManaged\bin\x86\Release\Microsoft.Xaml.Interactions.xml</DocumentationFile>
-    </PropertyGroup>
-    <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|ARM'">
-        <PlatformTarget>ARM</PlatformTarget>
-        <DebugSymbols>true</DebugSymbols>
-        <OutputPath>..\..\..\out\Uwp\BehaviorsSDKManaged\bin\ARM\Debug\</OutputPath>
-        <DefineConstants>DEBUG;TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
-        <NoWarn>;2008</NoWarn>
-        <DebugType>full</DebugType>
-        <UseVSHostingProcess>false</UseVSHostingProcess>
-        <ErrorReport>prompt</ErrorReport>
-    </PropertyGroup>
-    <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|ARM'">
-        <PlatformTarget>ARM</PlatformTarget>
-        <OutputPath>..\..\..\out\Uwp\BehaviorsSDKManaged\bin\ARM\Release\</OutputPath>
-        <DefineConstants>TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
-        <Optimize>true</Optimize>
-        <NoWarn>;2008</NoWarn>
-        <DebugType>pdbonly</DebugType>
-        <UseVSHostingProcess>false</UseVSHostingProcess>
-        <ErrorReport>prompt</ErrorReport>
     </PropertyGroup>
     <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|ARM64'">
         <PlatformTarget>ARM64</PlatformTarget>
@@ -132,6 +111,7 @@
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
+        <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.1.1" PrivateAssets="all" />
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="..\Microsoft.Xaml.Interactivity.Uwp\Microsoft.Xaml.Interactivity.Uwp.csproj">

--- a/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactions.Uwp/Microsoft.Xaml.Interactions.Uwp.csproj
+++ b/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactions.Uwp/Microsoft.Xaml.Interactions.Uwp.csproj
@@ -109,7 +109,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.1.1" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.1.3" PrivateAssets="all" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.Xaml.Interactivity.Uwp\Microsoft.Xaml.Interactivity.Uwp.csproj">

--- a/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactions.Uwp/Microsoft.Xaml.Interactions.Uwp.csproj
+++ b/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactions.Uwp/Microsoft.Xaml.Interactions.Uwp.csproj
@@ -1,194 +1,194 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-    <PropertyGroup>
-        <OutputType>Library</OutputType>
-        <TargetFramework>net8.0-windows10.0.22621.0</TargetFramework>
-        <WindowsSdkPackageVersion>10.0.22621.39</WindowsSdkPackageVersion>
-        <TargetPlatformVersion>10.0.22621.0</TargetPlatformVersion>
-        <TargetPlatformMinVersion>10.0.18362.0</TargetPlatformMinVersion>
-        <RootNamespace>Microsoft.Xaml.Interactions</RootNamespace>
-        <UseUwp>true</UseUwp>
-        <UseUwpTools>true</UseUwpTools>        
-        <DefaultLanguage>en-US</DefaultLanguage>
-        <Platforms>AnyCPU;x86;x64;arm64</Platforms>
-        <RuntimeIdentifiers>win-x86;win-x64;win-arm64</RuntimeIdentifiers>
-        <SupportedOSPlatformVersion>$(TargetPlatformMinVersion)</SupportedOSPlatformVersion>
-        <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
-        <IsAotCompatible>true</IsAotCompatible>
-        <DisableRuntimeMarshalling>true</DisableRuntimeMarshalling>
-        <CsWinRTGenerateProjection>false</CsWinRTGenerateProjection>
-        <CsWinRTAotWarningLevel>2</CsWinRTAotWarningLevel>
-    </PropertyGroup>
-    <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-        <PlatformTarget>AnyCPU</PlatformTarget>
-        <DebugSymbols>true</DebugSymbols>
-        <DebugType>full</DebugType>
-        <Optimize>false</Optimize>
-        <OutputPath>..\..\..\out\Uwp\BehaviorsSDKManaged\bin\AnyCPU\Debug\</OutputPath>
-        <DefineConstants>DEBUG;TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
-        <ErrorReport>prompt</ErrorReport>
-        <WarningLevel>4</WarningLevel>
-    </PropertyGroup>
-    <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-        <PlatformTarget>AnyCPU</PlatformTarget>
-        <DebugType>pdbonly</DebugType>
-        <Optimize>true</Optimize>
-        <OutputPath>..\..\..\out\Uwp\BehaviorsSDKManaged\bin\AnyCPU\Release\</OutputPath>
-        <DefineConstants>TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
-        <ErrorReport>prompt</ErrorReport>
-        <WarningLevel>4</WarningLevel>
-        <DocumentationFile>..\..\..\out\Uwp\BehaviorsSDKManaged\bin\AnyCPU\Release\Microsoft.Xaml.Interactions.xml</DocumentationFile>
-    </PropertyGroup>
-    <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
-        <PlatformTarget>x86</PlatformTarget>
-        <DebugSymbols>true</DebugSymbols>
-        <OutputPath>..\..\..\out\Uwp\BehaviorsSDKManaged\bin\x86\Debug\</OutputPath>
-        <DefineConstants>DEBUG;TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
-        <NoWarn>;2008</NoWarn>
-        <DebugType>full</DebugType>
-        <UseVSHostingProcess>false</UseVSHostingProcess>
-        <ErrorReport>prompt</ErrorReport>
-    </PropertyGroup>
-    <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x86'">
-        <PlatformTarget>x86</PlatformTarget>
-        <OutputPath>..\..\..\out\Uwp\BehaviorsSDKManaged\bin\x86\Release\</OutputPath>
-        <DefineConstants>TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
-        <Optimize>true</Optimize>
-        <NoWarn>;2008</NoWarn>
-        <DebugType>pdbonly</DebugType>
-        <UseVSHostingProcess>false</UseVSHostingProcess>
-        <ErrorReport>prompt</ErrorReport>
-        <DocumentationFile>..\..\..\out\Uwp\BehaviorsSDKManaged\bin\x86\Release\Microsoft.Xaml.Interactions.xml</DocumentationFile>
-    </PropertyGroup>
-    <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|ARM64'">
-        <PlatformTarget>ARM64</PlatformTarget>
-        <DebugSymbols>true</DebugSymbols>
-        <OutputPath>..\..\..\out\Uwp\BehaviorsSDKManaged\bin\ARM64\Debug\</OutputPath>
-        <DefineConstants>DEBUG;TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
-        <NoWarn>;2008</NoWarn>
-        <DebugType>full</DebugType>
-        <UseVSHostingProcess>false</UseVSHostingProcess>
-        <ErrorReport>prompt</ErrorReport>
-    </PropertyGroup>
-    <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|ARM64'">
-        <PlatformTarget>ARM64</PlatformTarget>
-        <OutputPath>..\..\..\out\Uwp\BehaviorsSDKManaged\bin\ARM\Release\</OutputPath>
-        <DefineConstants>TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
-        <Optimize>true</Optimize>
-        <NoWarn>;2008</NoWarn>
-        <DebugType>pdbonly</DebugType>
-        <UseVSHostingProcess>false</UseVSHostingProcess>
-        <ErrorReport>prompt</ErrorReport>
-    </PropertyGroup>
-    <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
-        <PlatformTarget>x64</PlatformTarget>
-        <DebugSymbols>true</DebugSymbols>
-        <OutputPath>..\..\..\out\Uwp\BehaviorsSDKManaged\bin\x64\Debug\</OutputPath>
-        <DefineConstants>DEBUG;TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
-        <NoWarn>;2008</NoWarn>
-        <DebugType>full</DebugType>
-        <UseVSHostingProcess>false</UseVSHostingProcess>
-        <ErrorReport>prompt</ErrorReport>
-    </PropertyGroup>
-    <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
-        <PlatformTarget>x64</PlatformTarget>
-        <OutputPath>..\..\..\out\Uwp\BehaviorsSDKManaged\bin\x64\Release\</OutputPath>
-        <DefineConstants>TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
-        <Optimize>true</Optimize>
-        <NoWarn>;2008</NoWarn>
-        <DebugType>pdbonly</DebugType>
-        <UseVSHostingProcess>false</UseVSHostingProcess>
-        <ErrorReport>prompt</ErrorReport>
-        <DocumentationFile>..\..\..\out\Uwp\BehaviorsSDKManaged\bin\x64\Release\Microsoft.Xaml.Interactions.xml</DocumentationFile>
-    </PropertyGroup>
-    <PropertyGroup>
-        <RestoreProjectStyle>PackageReference</RestoreProjectStyle>
-    </PropertyGroup>
-    <ItemGroup>
-      <Compile Include="..\Microsoft.Xaml.Interactions.WinUI\Properties\AssemblyInfo.cs" Link="Properties\AssemblyInfo.cs" />
-    </ItemGroup>
-    <ItemGroup>
-        <PackageReference Include="Microsoft.VisualStudioEng.MicroBuild.Core" Version="1.0.0">
-            <PrivateAssets>all</PrivateAssets>
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-        </PackageReference>
-        <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.1.1" PrivateAssets="all" />
-    </ItemGroup>
-    <ItemGroup>
-        <ProjectReference Include="..\Microsoft.Xaml.Interactivity.Uwp\Microsoft.Xaml.Interactivity.Uwp.csproj">
-            <Project>{b1c5e139-c8df-46b5-9abc-4515bdecafa3}</Project>
-            <Name>Microsoft.Xaml.Interactivity.Uwp</Name>
-        </ProjectReference>
-    </ItemGroup>
-    <ItemGroup>
-        <PRIResource Include="..\Microsoft.Xaml.Interactions\Resources\de-DE\Strings.resw">
-            <Link>Resources\de-DE\Strings.resw</Link>
-        </PRIResource>
-    </ItemGroup>
-    <ItemGroup>
-        <PRIResource Include="..\Microsoft.Xaml.Interactions\Resources\en-us\Strings.resw">
-            <Link>Resources\en-US\Strings.resw</Link>
-        </PRIResource>
-    </ItemGroup>
-    <ItemGroup>
-        <PRIResource Include="..\Microsoft.Xaml.Interactions\Resources\es-ES\Strings.resw">
-            <Link>Resources\es-ES\Strings.resw</Link>
-        </PRIResource>
-    </ItemGroup>
-    <ItemGroup>
-        <PRIResource Include="..\Microsoft.Xaml.Interactions\Resources\fr-FR\Strings.resw">
-            <Link>Resources\fr-FR\Strings.resw</Link>
-        </PRIResource>
-    </ItemGroup>
-    <ItemGroup>
-        <PRIResource Include="..\Microsoft.Xaml.Interactions\Resources\it-IT\Strings.resw">
-            <Link>Resources\it-IT\Strings.resw</Link>
-        </PRIResource>
-    </ItemGroup>
-    <ItemGroup>
-        <PRIResource Include="..\Microsoft.Xaml.Interactions\Resources\ja-JP\Strings.resw">
-            <Link>Resources\ja-JP\Strings.resw</Link>
-        </PRIResource>
-    </ItemGroup>
-    <ItemGroup>
-        <PRIResource Include="..\Microsoft.Xaml.Interactions\Resources\ko-KR\Strings.resw">
-            <Link>Resources\ko-KR\Strings.resw</Link>
-        </PRIResource>
-    </ItemGroup>
-    <ItemGroup>
-        <PRIResource Include="..\Microsoft.Xaml.Interactions\Resources\pt-BR\Strings.resw">
-            <Link>Resources\pt-BR\Strings.resw</Link>
-        </PRIResource>
-    </ItemGroup>
-    <ItemGroup>
-        <PRIResource Include="..\Microsoft.Xaml.Interactions\Resources\ru-RU\Strings.resw">
-            <Link>Resources\ru-RU\Strings.resw</Link>
-        </PRIResource>
-    </ItemGroup>
-    <ItemGroup>
-        <PRIResource Include="..\Microsoft.Xaml.Interactions\Resources\uk-UA\Strings.resw">
-            <Link>Resources\uk-UA\Strings.resw</Link>
-        </PRIResource>
-    </ItemGroup>
-    <ItemGroup>
-        <PRIResource Include="..\Microsoft.Xaml.Interactions\Resources\zh-CN\Strings.resw">
-            <Link>Resources\zh-CN\Strings.resw</Link>
-        </PRIResource>
-    </ItemGroup>
-    <ItemGroup>
-        <PRIResource Include="..\Microsoft.Xaml.Interactions\Resources\zh-TW\Strings.resw">
-            <Link>Resources\zh-TW\Strings.resw</Link>
-        </PRIResource>
-    </ItemGroup>
-    <Import Project="..\Microsoft.Xaml.Interactions.Shared\Microsoft.Xaml.Interactions.Shared.projitems" Label="Shared" />
-    <PropertyGroup Condition=" '$(VisualStudioVersion)' == '' or '$(VisualStudioVersion)' &lt; '14.0' ">
-        <VisualStudioVersion>14.0</VisualStudioVersion>
-    </PropertyGroup>
-    <Import Project="..\..\..\scripts\Microsoft.Xaml.Behaviors.Signing.targets" />
-    <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
-        <DocumentationFile>..\..\..\out\Uwp\BehaviorsSDKManaged\bin\$(Platform)\Release\Microsoft.Xaml.Interactions.xml</DocumentationFile>
-    </PropertyGroup>
-    <PropertyGroup>
-        <DefineConstants>$(DefineConstants);MODERN_WINDOWS_UWP</DefineConstants>
-        <AssemblyName>Microsoft.Xaml.Interactions</AssemblyName>
-    </PropertyGroup>
+  <PropertyGroup>
+    <OutputType>Library</OutputType>
+    <TargetFramework>net8.0-windows10.0.22621.0</TargetFramework>
+    <WindowsSdkPackageVersion>10.0.22621.39</WindowsSdkPackageVersion>
+    <TargetPlatformVersion>10.0.22621.0</TargetPlatformVersion>
+    <TargetPlatformMinVersion>10.0.18362.0</TargetPlatformMinVersion>
+    <RootNamespace>Microsoft.Xaml.Interactions</RootNamespace>
+    <UseUwp>true</UseUwp>
+    <UseUwpTools>true</UseUwpTools>    
+    <DefaultLanguage>en-US</DefaultLanguage>
+    <Platforms>AnyCPU;x86;x64;arm64</Platforms>
+    <RuntimeIdentifiers>win-x86;win-x64;win-arm64</RuntimeIdentifiers>
+    <SupportedOSPlatformVersion>$(TargetPlatformMinVersion)</SupportedOSPlatformVersion>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+    <IsAotCompatible>true</IsAotCompatible>
+    <DisableRuntimeMarshalling>true</DisableRuntimeMarshalling>
+    <CsWinRTGenerateProjection>false</CsWinRTGenerateProjection>
+    <CsWinRTAotWarningLevel>2</CsWinRTAotWarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>..\..\..\out\Uwp\BehaviorsSDKManaged\bin\AnyCPU\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>..\..\..\out\Uwp\BehaviorsSDKManaged\bin\AnyCPU\Release\</OutputPath>
+    <DefineConstants>TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <DocumentationFile>..\..\..\out\Uwp\BehaviorsSDKManaged\bin\AnyCPU\Release\Microsoft.Xaml.Interactions.xml</DocumentationFile>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
+    <PlatformTarget>x86</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>..\..\..\out\Uwp\BehaviorsSDKManaged\bin\x86\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
+    <NoWarn>;2008</NoWarn>
+    <DebugType>full</DebugType>
+    <UseVSHostingProcess>false</UseVSHostingProcess>
+    <ErrorReport>prompt</ErrorReport>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x86'">
+    <PlatformTarget>x86</PlatformTarget>
+    <OutputPath>..\..\..\out\Uwp\BehaviorsSDKManaged\bin\x86\Release\</OutputPath>
+    <DefineConstants>TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
+    <Optimize>true</Optimize>
+    <NoWarn>;2008</NoWarn>
+    <DebugType>pdbonly</DebugType>
+    <UseVSHostingProcess>false</UseVSHostingProcess>
+    <ErrorReport>prompt</ErrorReport>
+    <DocumentationFile>..\..\..\out\Uwp\BehaviorsSDKManaged\bin\x86\Release\Microsoft.Xaml.Interactions.xml</DocumentationFile>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|ARM64'">
+    <PlatformTarget>ARM64</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>..\..\..\out\Uwp\BehaviorsSDKManaged\bin\ARM64\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
+    <NoWarn>;2008</NoWarn>
+    <DebugType>full</DebugType>
+    <UseVSHostingProcess>false</UseVSHostingProcess>
+    <ErrorReport>prompt</ErrorReport>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|ARM64'">
+    <PlatformTarget>ARM64</PlatformTarget>
+    <OutputPath>..\..\..\out\Uwp\BehaviorsSDKManaged\bin\ARM\Release\</OutputPath>
+    <DefineConstants>TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
+    <Optimize>true</Optimize>
+    <NoWarn>;2008</NoWarn>
+    <DebugType>pdbonly</DebugType>
+    <UseVSHostingProcess>false</UseVSHostingProcess>
+    <ErrorReport>prompt</ErrorReport>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
+    <PlatformTarget>x64</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>..\..\..\out\Uwp\BehaviorsSDKManaged\bin\x64\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
+    <NoWarn>;2008</NoWarn>
+    <DebugType>full</DebugType>
+    <UseVSHostingProcess>false</UseVSHostingProcess>
+    <ErrorReport>prompt</ErrorReport>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
+    <PlatformTarget>x64</PlatformTarget>
+    <OutputPath>..\..\..\out\Uwp\BehaviorsSDKManaged\bin\x64\Release\</OutputPath>
+    <DefineConstants>TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
+    <Optimize>true</Optimize>
+    <NoWarn>;2008</NoWarn>
+    <DebugType>pdbonly</DebugType>
+    <UseVSHostingProcess>false</UseVSHostingProcess>
+    <ErrorReport>prompt</ErrorReport>
+    <DocumentationFile>..\..\..\out\Uwp\BehaviorsSDKManaged\bin\x64\Release\Microsoft.Xaml.Interactions.xml</DocumentationFile>
+  </PropertyGroup>
+  <PropertyGroup>
+    <RestoreProjectStyle>PackageReference</RestoreProjectStyle>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="..\Microsoft.Xaml.Interactions.WinUI\Properties\AssemblyInfo.cs" Link="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.VisualStudioEng.MicroBuild.Core" Version="1.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.1.1" PrivateAssets="all" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Microsoft.Xaml.Interactivity.Uwp\Microsoft.Xaml.Interactivity.Uwp.csproj">
+      <Project>{b1c5e139-c8df-46b5-9abc-4515bdecafa3}</Project>
+      <Name>Microsoft.Xaml.Interactivity.Uwp</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <PRIResource Include="..\Microsoft.Xaml.Interactions\Resources\de-DE\Strings.resw">
+      <Link>Resources\de-DE\Strings.resw</Link>
+    </PRIResource>
+  </ItemGroup>
+  <ItemGroup>
+    <PRIResource Include="..\Microsoft.Xaml.Interactions\Resources\en-us\Strings.resw">
+      <Link>Resources\en-US\Strings.resw</Link>
+    </PRIResource>
+  </ItemGroup>
+  <ItemGroup>
+    <PRIResource Include="..\Microsoft.Xaml.Interactions\Resources\es-ES\Strings.resw">
+      <Link>Resources\es-ES\Strings.resw</Link>
+    </PRIResource>
+  </ItemGroup>
+  <ItemGroup>
+    <PRIResource Include="..\Microsoft.Xaml.Interactions\Resources\fr-FR\Strings.resw">
+      <Link>Resources\fr-FR\Strings.resw</Link>
+    </PRIResource>
+  </ItemGroup>
+  <ItemGroup>
+    <PRIResource Include="..\Microsoft.Xaml.Interactions\Resources\it-IT\Strings.resw">
+      <Link>Resources\it-IT\Strings.resw</Link>
+    </PRIResource>
+  </ItemGroup>
+  <ItemGroup>
+    <PRIResource Include="..\Microsoft.Xaml.Interactions\Resources\ja-JP\Strings.resw">
+      <Link>Resources\ja-JP\Strings.resw</Link>
+    </PRIResource>
+  </ItemGroup>
+  <ItemGroup>
+    <PRIResource Include="..\Microsoft.Xaml.Interactions\Resources\ko-KR\Strings.resw">
+      <Link>Resources\ko-KR\Strings.resw</Link>
+    </PRIResource>
+  </ItemGroup>
+  <ItemGroup>
+    <PRIResource Include="..\Microsoft.Xaml.Interactions\Resources\pt-BR\Strings.resw">
+      <Link>Resources\pt-BR\Strings.resw</Link>
+    </PRIResource>
+  </ItemGroup>
+  <ItemGroup>
+    <PRIResource Include="..\Microsoft.Xaml.Interactions\Resources\ru-RU\Strings.resw">
+      <Link>Resources\ru-RU\Strings.resw</Link>
+    </PRIResource>
+  </ItemGroup>
+  <ItemGroup>
+    <PRIResource Include="..\Microsoft.Xaml.Interactions\Resources\uk-UA\Strings.resw">
+      <Link>Resources\uk-UA\Strings.resw</Link>
+    </PRIResource>
+  </ItemGroup>
+  <ItemGroup>
+    <PRIResource Include="..\Microsoft.Xaml.Interactions\Resources\zh-CN\Strings.resw">
+      <Link>Resources\zh-CN\Strings.resw</Link>
+    </PRIResource>
+  </ItemGroup>
+  <ItemGroup>
+    <PRIResource Include="..\Microsoft.Xaml.Interactions\Resources\zh-TW\Strings.resw">
+      <Link>Resources\zh-TW\Strings.resw</Link>
+    </PRIResource>
+  </ItemGroup>
+  <Import Project="..\Microsoft.Xaml.Interactions.Shared\Microsoft.Xaml.Interactions.Shared.projitems" Label="Shared" />
+  <PropertyGroup Condition=" '$(VisualStudioVersion)' == '' or '$(VisualStudioVersion)' &lt; '14.0' ">
+    <VisualStudioVersion>14.0</VisualStudioVersion>
+  </PropertyGroup>
+  <Import Project="..\..\..\scripts\Microsoft.Xaml.Behaviors.Signing.targets" />
+  <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
+    <DocumentationFile>..\..\..\out\Uwp\BehaviorsSDKManaged\bin\$(Platform)\Release\Microsoft.Xaml.Interactions.xml</DocumentationFile>
+  </PropertyGroup>
+  <PropertyGroup>
+    <DefineConstants>$(DefineConstants);MODERN_WINDOWS_UWP</DefineConstants>
+    <AssemblyName>Microsoft.Xaml.Interactions</AssemblyName>
+  </PropertyGroup>
 </Project>

--- a/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactions.Uwp/Microsoft.Xaml.Interactions.Uwp.csproj
+++ b/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactions.Uwp/Microsoft.Xaml.Interactions.Uwp.csproj
@@ -3,7 +3,6 @@
     <OutputType>Library</OutputType>
     <TargetFramework>net8.0-windows10.0.22621.0</TargetFramework>
     <WindowsSdkPackageVersion>10.0.22621.39</WindowsSdkPackageVersion>
-    <TargetPlatformVersion>10.0.22621.0</TargetPlatformVersion>
     <TargetPlatformMinVersion>10.0.18362.0</TargetPlatformMinVersion>
     <RootNamespace>Microsoft.Xaml.Interactions</RootNamespace>
     <UseUwp>true</UseUwp>
@@ -11,7 +10,6 @@
     <DefaultLanguage>en-US</DefaultLanguage>
     <Platforms>AnyCPU;x86;x64;arm64</Platforms>
     <RuntimeIdentifiers>win-x86;win-x64;win-arm64</RuntimeIdentifiers>
-    <SupportedOSPlatformVersion>$(TargetPlatformMinVersion)</SupportedOSPlatformVersion>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <IsAotCompatible>true</IsAotCompatible>
     <DisableRuntimeMarshalling>true</DisableRuntimeMarshalling>

--- a/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactions.Uwp/Microsoft.Xaml.Interactions.Uwp.csproj
+++ b/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactions.Uwp/Microsoft.Xaml.Interactions.Uwp.csproj
@@ -1,214 +1,214 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-	<PropertyGroup>
-		<OutputType>Library</OutputType>
-		<TargetFramework>net8.0-windows10.0.22621.0</TargetFramework>
-		<TargetPlatformVersion>10.0.22621.0</TargetPlatformVersion>
-		<TargetPlatformMinVersion>10.0.18362.0</TargetPlatformMinVersion>
-		<WindowsSdkPackageVersion>10.0.22621.37-preview</WindowsSdkPackageVersion>
-		<UseUwp>true</UseUwp>
-		<UseUwpTools>true</UseUwpTools>
-		<RootNamespace>Microsoft.Xaml.Interactions</RootNamespace>
-		<DefaultLanguage>en-US</DefaultLanguage>
-		<Platforms>AnyCPU;x86;x64;arm64</Platforms>
-		<RuntimeIdentifiers>win-x86;win-x64;win-arm64</RuntimeIdentifiers>
-		<SupportedOSPlatformVersion>$(TargetPlatformMinVersion)</SupportedOSPlatformVersion>
-		<AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
-		<IsAotCompatible>true</IsAotCompatible>
+    <PropertyGroup>
+        <OutputType>Library</OutputType>
+        <TargetFramework>net8.0-windows10.0.22621.0</TargetFramework>
+        <TargetPlatformVersion>10.0.22621.0</TargetPlatformVersion>
+        <TargetPlatformMinVersion>10.0.18362.0</TargetPlatformMinVersion>
+        <WindowsSdkPackageVersion>10.0.22621.39</WindowsSdkPackageVersion>
+        <UseUwp>true</UseUwp>
+        <UseUwpTools>true</UseUwpTools>
+        <RootNamespace>Microsoft.Xaml.Interactions</RootNamespace>
+        <DefaultLanguage>en-US</DefaultLanguage>
+        <Platforms>AnyCPU;x86;x64;arm64</Platforms>
+        <RuntimeIdentifiers>win-x86;win-x64;win-arm64</RuntimeIdentifiers>
+        <SupportedOSPlatformVersion>$(TargetPlatformMinVersion)</SupportedOSPlatformVersion>
+        <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+        <IsAotCompatible>true</IsAotCompatible>
 
-		<!-- Temporary workaround, will be fixed in VS 17.12 P1 -->
-		<AddMicrosoftVCLibsSDKReference>false</AddMicrosoftVCLibsSDKReference>
-		<AddMicrosoftUniversalCRTDebugSDKReference>false</AddMicrosoftUniversalCRTDebugSDKReference>
-	</PropertyGroup>
-	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-		<PlatformTarget>AnyCPU</PlatformTarget>
-		<DebugSymbols>true</DebugSymbols>
-		<DebugType>full</DebugType>
-		<Optimize>false</Optimize>
-		<OutputPath>..\..\..\out\Uwp\BehaviorsSDKManaged\bin\AnyCPU\Debug\</OutputPath>
-		<DefineConstants>DEBUG;TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
-		<ErrorReport>prompt</ErrorReport>
-		<WarningLevel>4</WarningLevel>
-	</PropertyGroup>
-	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-		<PlatformTarget>AnyCPU</PlatformTarget>
-		<DebugType>pdbonly</DebugType>
-		<Optimize>true</Optimize>
-		<OutputPath>..\..\..\out\Uwp\BehaviorsSDKManaged\bin\AnyCPU\Release\</OutputPath>
-		<DefineConstants>TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
-		<ErrorReport>prompt</ErrorReport>
-		<WarningLevel>4</WarningLevel>
-		<DocumentationFile>..\..\..\out\Uwp\BehaviorsSDKManaged\bin\AnyCPU\Release\Microsoft.Xaml.Interactions.xml</DocumentationFile>
-	</PropertyGroup>
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
-		<PlatformTarget>x86</PlatformTarget>
-		<DebugSymbols>true</DebugSymbols>
-		<OutputPath>..\..\..\out\Uwp\BehaviorsSDKManaged\bin\x86\Debug\</OutputPath>
-		<DefineConstants>DEBUG;TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
-		<NoWarn>;2008</NoWarn>
-		<DebugType>full</DebugType>
-		<UseVSHostingProcess>false</UseVSHostingProcess>
-		<ErrorReport>prompt</ErrorReport>
-	</PropertyGroup>
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x86'">
-		<PlatformTarget>x86</PlatformTarget>
-		<OutputPath>..\..\..\out\Uwp\BehaviorsSDKManaged\bin\x86\Release\</OutputPath>
-		<DefineConstants>TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
-		<Optimize>true</Optimize>
-		<NoWarn>;2008</NoWarn>
-		<DebugType>pdbonly</DebugType>
-		<UseVSHostingProcess>false</UseVSHostingProcess>
-		<ErrorReport>prompt</ErrorReport>
-		<DocumentationFile>..\..\..\out\Uwp\BehaviorsSDKManaged\bin\x86\Release\Microsoft.Xaml.Interactions.xml</DocumentationFile>
-	</PropertyGroup>
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|ARM'">
-		<PlatformTarget>ARM</PlatformTarget>
-		<DebugSymbols>true</DebugSymbols>
-		<OutputPath>..\..\..\out\Uwp\BehaviorsSDKManaged\bin\ARM\Debug\</OutputPath>
-		<DefineConstants>DEBUG;TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
-		<NoWarn>;2008</NoWarn>
-		<DebugType>full</DebugType>
-		<UseVSHostingProcess>false</UseVSHostingProcess>
-		<ErrorReport>prompt</ErrorReport>
-	</PropertyGroup>
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|ARM'">
-		<PlatformTarget>ARM</PlatformTarget>
-		<OutputPath>..\..\..\out\Uwp\BehaviorsSDKManaged\bin\ARM\Release\</OutputPath>
-		<DefineConstants>TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
-		<Optimize>true</Optimize>
-		<NoWarn>;2008</NoWarn>
-		<DebugType>pdbonly</DebugType>
-		<UseVSHostingProcess>false</UseVSHostingProcess>
-		<ErrorReport>prompt</ErrorReport>
-	</PropertyGroup>
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|ARM64'">
-		<PlatformTarget>ARM64</PlatformTarget>
-		<DebugSymbols>true</DebugSymbols>
-		<OutputPath>..\..\..\out\Uwp\BehaviorsSDKManaged\bin\ARM64\Debug\</OutputPath>
-		<DefineConstants>DEBUG;TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
-		<NoWarn>;2008</NoWarn>
-		<DebugType>full</DebugType>
-		<UseVSHostingProcess>false</UseVSHostingProcess>
-		<ErrorReport>prompt</ErrorReport>
-	</PropertyGroup>
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|ARM64'">
-		<PlatformTarget>ARM64</PlatformTarget>
-		<OutputPath>..\..\..\out\Uwp\BehaviorsSDKManaged\bin\ARM\Release\</OutputPath>
-		<DefineConstants>TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
-		<Optimize>true</Optimize>
-		<NoWarn>;2008</NoWarn>
-		<DebugType>pdbonly</DebugType>
-		<UseVSHostingProcess>false</UseVSHostingProcess>
-		<ErrorReport>prompt</ErrorReport>
-	</PropertyGroup>
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
-		<PlatformTarget>x64</PlatformTarget>
-		<DebugSymbols>true</DebugSymbols>
-		<OutputPath>..\..\..\out\Uwp\BehaviorsSDKManaged\bin\x64\Debug\</OutputPath>
-		<DefineConstants>DEBUG;TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
-		<NoWarn>;2008</NoWarn>
-		<DebugType>full</DebugType>
-		<UseVSHostingProcess>false</UseVSHostingProcess>
-		<ErrorReport>prompt</ErrorReport>
-	</PropertyGroup>
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
-		<PlatformTarget>x64</PlatformTarget>
-		<OutputPath>..\..\..\out\Uwp\BehaviorsSDKManaged\bin\x64\Release\</OutputPath>
-		<DefineConstants>TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
-		<Optimize>true</Optimize>
-		<NoWarn>;2008</NoWarn>
-		<DebugType>pdbonly</DebugType>
-		<UseVSHostingProcess>false</UseVSHostingProcess>
-		<ErrorReport>prompt</ErrorReport>
-		<DocumentationFile>..\..\..\out\Uwp\BehaviorsSDKManaged\bin\x64\Release\Microsoft.Xaml.Interactions.xml</DocumentationFile>
-	</PropertyGroup>
-	<PropertyGroup>
-		<RestoreProjectStyle>PackageReference</RestoreProjectStyle>
-	</PropertyGroup>
-	<ItemGroup>
-	  <Compile Include="..\Microsoft.Xaml.Interactions.WinUI\Properties\AssemblyInfo.cs" Link="Properties\AssemblyInfo.cs" />
-	</ItemGroup>
-	<ItemGroup>
-		<PackageReference Include="Microsoft.VisualStudioEng.MicroBuild.Core" Version="1.0.0">
-			<PrivateAssets>all</PrivateAssets>
-			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-		</PackageReference>
-	</ItemGroup>
-	<ItemGroup>
-		<ProjectReference Include="..\Microsoft.Xaml.Interactivity.Uwp\Microsoft.Xaml.Interactivity.Uwp.csproj">
-			<Project>{b1c5e139-c8df-46b5-9abc-4515bdecafa3}</Project>
-			<Name>Microsoft.Xaml.Interactivity.Uwp</Name>
-		</ProjectReference>
-	</ItemGroup>
-	<ItemGroup>
-		<PRIResource Include="..\Microsoft.Xaml.Interactions\Resources\de-DE\Strings.resw">
-			<Link>Resources\de-DE\Strings.resw</Link>
-		</PRIResource>
-	</ItemGroup>
-	<ItemGroup>
-		<PRIResource Include="..\Microsoft.Xaml.Interactions\Resources\en-us\Strings.resw">
-			<Link>Resources\en-US\Strings.resw</Link>
-		</PRIResource>
-	</ItemGroup>
-	<ItemGroup>
-		<PRIResource Include="..\Microsoft.Xaml.Interactions\Resources\es-ES\Strings.resw">
-			<Link>Resources\es-ES\Strings.resw</Link>
-		</PRIResource>
-	</ItemGroup>
-	<ItemGroup>
-		<PRIResource Include="..\Microsoft.Xaml.Interactions\Resources\fr-FR\Strings.resw">
-			<Link>Resources\fr-FR\Strings.resw</Link>
-		</PRIResource>
-	</ItemGroup>
-	<ItemGroup>
-		<PRIResource Include="..\Microsoft.Xaml.Interactions\Resources\it-IT\Strings.resw">
-			<Link>Resources\it-IT\Strings.resw</Link>
-		</PRIResource>
-	</ItemGroup>
-	<ItemGroup>
-		<PRIResource Include="..\Microsoft.Xaml.Interactions\Resources\ja-JP\Strings.resw">
-			<Link>Resources\ja-JP\Strings.resw</Link>
-		</PRIResource>
-	</ItemGroup>
-	<ItemGroup>
-		<PRIResource Include="..\Microsoft.Xaml.Interactions\Resources\ko-KR\Strings.resw">
-			<Link>Resources\ko-KR\Strings.resw</Link>
-		</PRIResource>
-	</ItemGroup>
-	<ItemGroup>
-		<PRIResource Include="..\Microsoft.Xaml.Interactions\Resources\pt-BR\Strings.resw">
-			<Link>Resources\pt-BR\Strings.resw</Link>
-		</PRIResource>
-	</ItemGroup>
-	<ItemGroup>
-		<PRIResource Include="..\Microsoft.Xaml.Interactions\Resources\ru-RU\Strings.resw">
-			<Link>Resources\ru-RU\Strings.resw</Link>
-		</PRIResource>
-	</ItemGroup>
-	<ItemGroup>
-		<PRIResource Include="..\Microsoft.Xaml.Interactions\Resources\uk-UA\Strings.resw">
-			<Link>Resources\uk-UA\Strings.resw</Link>
-		</PRIResource>
-	</ItemGroup>
-	<ItemGroup>
-		<PRIResource Include="..\Microsoft.Xaml.Interactions\Resources\zh-CN\Strings.resw">
-			<Link>Resources\zh-CN\Strings.resw</Link>
-		</PRIResource>
-	</ItemGroup>
-	<ItemGroup>
-		<PRIResource Include="..\Microsoft.Xaml.Interactions\Resources\zh-TW\Strings.resw">
-			<Link>Resources\zh-TW\Strings.resw</Link>
-		</PRIResource>
-	</ItemGroup>
-	<Import Project="..\Microsoft.Xaml.Interactions.Shared\Microsoft.Xaml.Interactions.Shared.projitems" Label="Shared" />
-	<PropertyGroup Condition=" '$(VisualStudioVersion)' == '' or '$(VisualStudioVersion)' &lt; '14.0' ">
-		<VisualStudioVersion>14.0</VisualStudioVersion>
-	</PropertyGroup>
-	<Import Project="..\..\..\scripts\Microsoft.Xaml.Behaviors.Signing.targets" />
-	<PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
-		<DocumentationFile>..\..\..\out\Uwp\BehaviorsSDKManaged\bin\$(Platform)\Release\Microsoft.Xaml.Interactions.xml</DocumentationFile>
-	</PropertyGroup>
-	<PropertyGroup>
-		<DefineConstants>$(DefineConstants);MODERN_WINDOWS_UWP</DefineConstants>
-		<AssemblyName>Microsoft.Xaml.Interactions</AssemblyName>
-	</PropertyGroup>
+        <!-- Temporary workaround, will be fixed in VS 17.12 P1 -->
+        <AddMicrosoftVCLibsSDKReference>false</AddMicrosoftVCLibsSDKReference>
+        <AddMicrosoftUniversalCRTDebugSDKReference>false</AddMicrosoftUniversalCRTDebugSDKReference>
+    </PropertyGroup>
+    <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+        <PlatformTarget>AnyCPU</PlatformTarget>
+        <DebugSymbols>true</DebugSymbols>
+        <DebugType>full</DebugType>
+        <Optimize>false</Optimize>
+        <OutputPath>..\..\..\out\Uwp\BehaviorsSDKManaged\bin\AnyCPU\Debug\</OutputPath>
+        <DefineConstants>DEBUG;TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
+        <ErrorReport>prompt</ErrorReport>
+        <WarningLevel>4</WarningLevel>
+    </PropertyGroup>
+    <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+        <PlatformTarget>AnyCPU</PlatformTarget>
+        <DebugType>pdbonly</DebugType>
+        <Optimize>true</Optimize>
+        <OutputPath>..\..\..\out\Uwp\BehaviorsSDKManaged\bin\AnyCPU\Release\</OutputPath>
+        <DefineConstants>TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
+        <ErrorReport>prompt</ErrorReport>
+        <WarningLevel>4</WarningLevel>
+        <DocumentationFile>..\..\..\out\Uwp\BehaviorsSDKManaged\bin\AnyCPU\Release\Microsoft.Xaml.Interactions.xml</DocumentationFile>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
+        <PlatformTarget>x86</PlatformTarget>
+        <DebugSymbols>true</DebugSymbols>
+        <OutputPath>..\..\..\out\Uwp\BehaviorsSDKManaged\bin\x86\Debug\</OutputPath>
+        <DefineConstants>DEBUG;TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
+        <NoWarn>;2008</NoWarn>
+        <DebugType>full</DebugType>
+        <UseVSHostingProcess>false</UseVSHostingProcess>
+        <ErrorReport>prompt</ErrorReport>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x86'">
+        <PlatformTarget>x86</PlatformTarget>
+        <OutputPath>..\..\..\out\Uwp\BehaviorsSDKManaged\bin\x86\Release\</OutputPath>
+        <DefineConstants>TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
+        <Optimize>true</Optimize>
+        <NoWarn>;2008</NoWarn>
+        <DebugType>pdbonly</DebugType>
+        <UseVSHostingProcess>false</UseVSHostingProcess>
+        <ErrorReport>prompt</ErrorReport>
+        <DocumentationFile>..\..\..\out\Uwp\BehaviorsSDKManaged\bin\x86\Release\Microsoft.Xaml.Interactions.xml</DocumentationFile>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|ARM'">
+        <PlatformTarget>ARM</PlatformTarget>
+        <DebugSymbols>true</DebugSymbols>
+        <OutputPath>..\..\..\out\Uwp\BehaviorsSDKManaged\bin\ARM\Debug\</OutputPath>
+        <DefineConstants>DEBUG;TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
+        <NoWarn>;2008</NoWarn>
+        <DebugType>full</DebugType>
+        <UseVSHostingProcess>false</UseVSHostingProcess>
+        <ErrorReport>prompt</ErrorReport>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|ARM'">
+        <PlatformTarget>ARM</PlatformTarget>
+        <OutputPath>..\..\..\out\Uwp\BehaviorsSDKManaged\bin\ARM\Release\</OutputPath>
+        <DefineConstants>TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
+        <Optimize>true</Optimize>
+        <NoWarn>;2008</NoWarn>
+        <DebugType>pdbonly</DebugType>
+        <UseVSHostingProcess>false</UseVSHostingProcess>
+        <ErrorReport>prompt</ErrorReport>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|ARM64'">
+        <PlatformTarget>ARM64</PlatformTarget>
+        <DebugSymbols>true</DebugSymbols>
+        <OutputPath>..\..\..\out\Uwp\BehaviorsSDKManaged\bin\ARM64\Debug\</OutputPath>
+        <DefineConstants>DEBUG;TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
+        <NoWarn>;2008</NoWarn>
+        <DebugType>full</DebugType>
+        <UseVSHostingProcess>false</UseVSHostingProcess>
+        <ErrorReport>prompt</ErrorReport>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|ARM64'">
+        <PlatformTarget>ARM64</PlatformTarget>
+        <OutputPath>..\..\..\out\Uwp\BehaviorsSDKManaged\bin\ARM\Release\</OutputPath>
+        <DefineConstants>TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
+        <Optimize>true</Optimize>
+        <NoWarn>;2008</NoWarn>
+        <DebugType>pdbonly</DebugType>
+        <UseVSHostingProcess>false</UseVSHostingProcess>
+        <ErrorReport>prompt</ErrorReport>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
+        <PlatformTarget>x64</PlatformTarget>
+        <DebugSymbols>true</DebugSymbols>
+        <OutputPath>..\..\..\out\Uwp\BehaviorsSDKManaged\bin\x64\Debug\</OutputPath>
+        <DefineConstants>DEBUG;TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
+        <NoWarn>;2008</NoWarn>
+        <DebugType>full</DebugType>
+        <UseVSHostingProcess>false</UseVSHostingProcess>
+        <ErrorReport>prompt</ErrorReport>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
+        <PlatformTarget>x64</PlatformTarget>
+        <OutputPath>..\..\..\out\Uwp\BehaviorsSDKManaged\bin\x64\Release\</OutputPath>
+        <DefineConstants>TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
+        <Optimize>true</Optimize>
+        <NoWarn>;2008</NoWarn>
+        <DebugType>pdbonly</DebugType>
+        <UseVSHostingProcess>false</UseVSHostingProcess>
+        <ErrorReport>prompt</ErrorReport>
+        <DocumentationFile>..\..\..\out\Uwp\BehaviorsSDKManaged\bin\x64\Release\Microsoft.Xaml.Interactions.xml</DocumentationFile>
+    </PropertyGroup>
+    <PropertyGroup>
+        <RestoreProjectStyle>PackageReference</RestoreProjectStyle>
+    </PropertyGroup>
+    <ItemGroup>
+      <Compile Include="..\Microsoft.Xaml.Interactions.WinUI\Properties\AssemblyInfo.cs" Link="Properties\AssemblyInfo.cs" />
+    </ItemGroup>
+    <ItemGroup>
+        <PackageReference Include="Microsoft.VisualStudioEng.MicroBuild.Core" Version="1.0.0">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+    </ItemGroup>
+    <ItemGroup>
+        <ProjectReference Include="..\Microsoft.Xaml.Interactivity.Uwp\Microsoft.Xaml.Interactivity.Uwp.csproj">
+            <Project>{b1c5e139-c8df-46b5-9abc-4515bdecafa3}</Project>
+            <Name>Microsoft.Xaml.Interactivity.Uwp</Name>
+        </ProjectReference>
+    </ItemGroup>
+    <ItemGroup>
+        <PRIResource Include="..\Microsoft.Xaml.Interactions\Resources\de-DE\Strings.resw">
+            <Link>Resources\de-DE\Strings.resw</Link>
+        </PRIResource>
+    </ItemGroup>
+    <ItemGroup>
+        <PRIResource Include="..\Microsoft.Xaml.Interactions\Resources\en-us\Strings.resw">
+            <Link>Resources\en-US\Strings.resw</Link>
+        </PRIResource>
+    </ItemGroup>
+    <ItemGroup>
+        <PRIResource Include="..\Microsoft.Xaml.Interactions\Resources\es-ES\Strings.resw">
+            <Link>Resources\es-ES\Strings.resw</Link>
+        </PRIResource>
+    </ItemGroup>
+    <ItemGroup>
+        <PRIResource Include="..\Microsoft.Xaml.Interactions\Resources\fr-FR\Strings.resw">
+            <Link>Resources\fr-FR\Strings.resw</Link>
+        </PRIResource>
+    </ItemGroup>
+    <ItemGroup>
+        <PRIResource Include="..\Microsoft.Xaml.Interactions\Resources\it-IT\Strings.resw">
+            <Link>Resources\it-IT\Strings.resw</Link>
+        </PRIResource>
+    </ItemGroup>
+    <ItemGroup>
+        <PRIResource Include="..\Microsoft.Xaml.Interactions\Resources\ja-JP\Strings.resw">
+            <Link>Resources\ja-JP\Strings.resw</Link>
+        </PRIResource>
+    </ItemGroup>
+    <ItemGroup>
+        <PRIResource Include="..\Microsoft.Xaml.Interactions\Resources\ko-KR\Strings.resw">
+            <Link>Resources\ko-KR\Strings.resw</Link>
+        </PRIResource>
+    </ItemGroup>
+    <ItemGroup>
+        <PRIResource Include="..\Microsoft.Xaml.Interactions\Resources\pt-BR\Strings.resw">
+            <Link>Resources\pt-BR\Strings.resw</Link>
+        </PRIResource>
+    </ItemGroup>
+    <ItemGroup>
+        <PRIResource Include="..\Microsoft.Xaml.Interactions\Resources\ru-RU\Strings.resw">
+            <Link>Resources\ru-RU\Strings.resw</Link>
+        </PRIResource>
+    </ItemGroup>
+    <ItemGroup>
+        <PRIResource Include="..\Microsoft.Xaml.Interactions\Resources\uk-UA\Strings.resw">
+            <Link>Resources\uk-UA\Strings.resw</Link>
+        </PRIResource>
+    </ItemGroup>
+    <ItemGroup>
+        <PRIResource Include="..\Microsoft.Xaml.Interactions\Resources\zh-CN\Strings.resw">
+            <Link>Resources\zh-CN\Strings.resw</Link>
+        </PRIResource>
+    </ItemGroup>
+    <ItemGroup>
+        <PRIResource Include="..\Microsoft.Xaml.Interactions\Resources\zh-TW\Strings.resw">
+            <Link>Resources\zh-TW\Strings.resw</Link>
+        </PRIResource>
+    </ItemGroup>
+    <Import Project="..\Microsoft.Xaml.Interactions.Shared\Microsoft.Xaml.Interactions.Shared.projitems" Label="Shared" />
+    <PropertyGroup Condition=" '$(VisualStudioVersion)' == '' or '$(VisualStudioVersion)' &lt; '14.0' ">
+        <VisualStudioVersion>14.0</VisualStudioVersion>
+    </PropertyGroup>
+    <Import Project="..\..\..\scripts\Microsoft.Xaml.Behaviors.Signing.targets" />
+    <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
+        <DocumentationFile>..\..\..\out\Uwp\BehaviorsSDKManaged\bin\$(Platform)\Release\Microsoft.Xaml.Interactions.xml</DocumentationFile>
+    </PropertyGroup>
+    <PropertyGroup>
+        <DefineConstants>$(DefineConstants);MODERN_WINDOWS_UWP</DefineConstants>
+        <AssemblyName>Microsoft.Xaml.Interactions</AssemblyName>
+    </PropertyGroup>
 </Project>

--- a/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactions.Uwp/Microsoft.Xaml.Interactions.Uwp.csproj
+++ b/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactions.Uwp/Microsoft.Xaml.Interactions.Uwp.csproj
@@ -1,12 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFramework>net8.0-windows10.0.26100.0</TargetFramework>
-    <WindowsSdkPackageVersion>10.0.26100.54</WindowsSdkPackageVersion>
+    <TargetFramework>net8.0-windows10.0.18362.0</TargetFramework>
+    <WindowsSdkPackageVersion>10.0.18362.54</WindowsSdkPackageVersion>
     <TargetPlatformMinVersion>10.0.18362.0</TargetPlatformMinVersion>
     <RootNamespace>Microsoft.Xaml.Interactions</RootNamespace>
     <UseUwp>true</UseUwp>
-    <UseUwpTools>true</UseUwpTools>    
     <DefaultLanguage>en-US</DefaultLanguage>
     <Platforms>AnyCPU;x86;x64;arm64</Platforms>
     <RuntimeIdentifiers>win-x86;win-x64;win-arm64</RuntimeIdentifiers>
@@ -15,6 +14,7 @@
     <DisableRuntimeMarshalling>true</DisableRuntimeMarshalling>
     <CsWinRTGenerateProjection>false</CsWinRTGenerateProjection>
     <CsWinRTAotWarningLevel>2</CsWinRTAotWarningLevel>
+    <EnableXamlCompilerTargetsForUwpApps>false</EnableXamlCompilerTargetsForUwpApps>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -109,8 +109,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.1.3" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.Windows.SDK.CPP" Version="10.0.26100.2161" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.1.6" PrivateAssets="all" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.Xaml.Interactivity.Uwp\Microsoft.Xaml.Interactivity.Uwp.csproj">

--- a/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactions.Uwp/Microsoft.Xaml.Interactions.Uwp.csproj
+++ b/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactions.Uwp/Microsoft.Xaml.Interactions.Uwp.csproj
@@ -99,6 +99,9 @@
     <DocumentationFile>..\..\..\out\Uwp\BehaviorsSDKManaged\bin\x64\Release\Microsoft.Xaml.Interactions.xml</DocumentationFile>
   </PropertyGroup>
   <PropertyGroup>
+    <NoWarn>$(NoWarn);NETSDK1219</NoWarn>
+  </PropertyGroup>
+  <PropertyGroup>
     <RestoreProjectStyle>PackageReference</RestoreProjectStyle>
   </PropertyGroup>
   <ItemGroup>

--- a/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactions.Uwp/Microsoft.Xaml.Interactions.Uwp.csproj
+++ b/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactions.Uwp/Microsoft.Xaml.Interactions.Uwp.csproj
@@ -3,13 +3,14 @@
 		<OutputType>Library</OutputType>
 		<TargetFramework>net8.0-windows10.0.22621.0</TargetFramework>
 		<TargetPlatformVersion>10.0.22621.0</TargetPlatformVersion>
+		<TargetPlatformMinVersion>10.0.18362.0</TargetPlatformMinVersion>
 		<WindowsSdkPackageVersion>10.0.22621.37-preview</WindowsSdkPackageVersion>
 		<UseUwp>true</UseUwp>
 		<UseUwpTools>true</UseUwpTools>
 		<RootNamespace>Microsoft.Xaml.Interactions</RootNamespace>
+		<DefaultLanguage>en-US</DefaultLanguage>
 		<Platforms>AnyCPU;x86;x64;arm64</Platforms>
 		<RuntimeIdentifiers>win-x86;win-x64;win-arm64</RuntimeIdentifiers>
-		<TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
 		<SupportedOSPlatformVersion>$(TargetPlatformMinVersion)</SupportedOSPlatformVersion>
 		<AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
 		<IsAotCompatible>true</IsAotCompatible>

--- a/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactions.WinUI/Microsoft.Xaml.Interactions.WinUI.csproj
+++ b/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactions.WinUI/Microsoft.Xaml.Interactions.WinUI.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <TargetFramework>net8.0-windows10.0.17763.0</TargetFramework>
-    <WindowsSdkPackageVersion>10.0.17763.41</WindowsSdkPackageVersion>
+    <WindowsSdkPackageVersion>10.0.17763.53</WindowsSdkPackageVersion>
     <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
     <RootNamespace>Microsoft.Xaml.Interactions</RootNamespace>
     <Platforms>AnyCPU;x86;x64;arm64</Platforms>

--- a/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactions.WinUI/Microsoft.Xaml.Interactions.WinUI.csproj
+++ b/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactions.WinUI/Microsoft.Xaml.Interactions.WinUI.csproj
@@ -3,12 +3,10 @@
     <OutputType>Library</OutputType>
     <TargetFramework>net8.0-windows10.0.17763.0</TargetFramework>
     <WindowsSdkPackageVersion>10.0.17763.41</WindowsSdkPackageVersion>
-    <TargetPlatformVersion>10.0.17763.0</TargetPlatformVersion>
+    <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
     <RootNamespace>Microsoft.Xaml.Interactions</RootNamespace>
     <Platforms>AnyCPU;x86;x64;arm64</Platforms>
     <RuntimeIdentifiers>win-x86;win-x64;win-arm64</RuntimeIdentifiers>
-    <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
-    <SupportedOSPlatformVersion>$(TargetPlatformMinVersion)</SupportedOSPlatformVersion>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <IsAotCompatible>true</IsAotCompatible>
     <DisableRuntimeMarshalling>true</DisableRuntimeMarshalling>

--- a/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactions.WinUI/Microsoft.Xaml.Interactions.WinUI.csproj
+++ b/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactions.WinUI/Microsoft.Xaml.Interactions.WinUI.csproj
@@ -109,7 +109,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.1.3" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.1.6" PrivateAssets="all" />
     <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.6.240829007" />
   </ItemGroup>
   <ItemGroup>

--- a/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactivity.Shared/ResourceHelper.cs
+++ b/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactivity.Shared/ResourceHelper.cs
@@ -6,13 +6,13 @@ namespace Microsoft.Xaml.Interactivity
 
     internal static class ResourceHelper
     {
-#if NET8_0_OR_GREATER
+#if NET8_0_OR_GREATER && !MODERN_WINDOWS_UWP
         private static ResourceLoader strings = new ResourceLoader(ResourceLoader.GetDefaultResourceFilePath(), "Microsoft.Xaml.Interactivity/Strings");
 #endif
 
         public static string GetString(string resourceName)
         {
-#if !NET8_0_OR_GREATER
+#if !NET8_0_OR_GREATER || MODERN_WINDOWS_UWP
             ResourceLoader strings = ResourceLoader.GetForCurrentView("Microsoft.Xaml.Interactivity/Strings");
 #endif
             return strings.GetString(resourceName);

--- a/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactivity.Uwp/Microsoft.Xaml.Interactivity.Uwp.csproj
+++ b/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactivity.Uwp/Microsoft.Xaml.Interactivity.Uwp.csproj
@@ -1,0 +1,9 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactivity.Uwp/Microsoft.Xaml.Interactivity.Uwp.csproj
+++ b/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactivity.Uwp/Microsoft.Xaml.Interactivity.Uwp.csproj
@@ -13,6 +13,10 @@
     <SupportedOSPlatformVersion>$(TargetPlatformMinVersion)</SupportedOSPlatformVersion>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <IsAotCompatible>true</IsAotCompatible>
+	
+	<!-- Temporary workaround, will be fixed in VS 17.12 P1 -->
+    <AddMicrosoftVCLibsSDKReference>false</AddMicrosoftVCLibsSDKReference>
+	<AddMicrosoftUniversalCRTDebugSDKReference>false</AddMicrosoftUniversalCRTDebugSDKReference>
   </PropertyGroup>
   <PropertyGroup>
     <OutputPath>..\..\..\out\Uwp\$(SolutionName)\bin\$(Platform)\$(Configuration)\</OutputPath>
@@ -198,6 +202,7 @@
     <DocumentationFile>..\..\..\out\Uwp\BehaviorsSDKManaged\bin\$(Platform)\Release\Microsoft.Xaml.Interactivity.xml</DocumentationFile>
   </PropertyGroup>
   <PropertyGroup>
+	<DefineConstants>$(DefineConstants);MODERN_WINDOWS_UWP</DefineConstants>
     <AssemblyName>Microsoft.Xaml.Interactivity</AssemblyName>
   </PropertyGroup>
 </Project>

--- a/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactivity.Uwp/Microsoft.Xaml.Interactivity.Uwp.csproj
+++ b/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactivity.Uwp/Microsoft.Xaml.Interactivity.Uwp.csproj
@@ -3,13 +3,14 @@
     <OutputType>Library</OutputType>
     <TargetFramework>net8.0-windows10.0.22621.0</TargetFramework>
     <TargetPlatformVersion>10.0.22621.0</TargetPlatformVersion>
+	<TargetPlatformMinVersion>10.0.18362.0</TargetPlatformMinVersion>
     <WindowsSdkPackageVersion>10.0.22621.37-preview</WindowsSdkPackageVersion>
     <UseUwp>true</UseUwp>
     <UseUwpTools>true</UseUwpTools>
     <RootNamespace>Microsoft.Xaml.Interactivity</RootNamespace>
+	<DefaultLanguage>en-US</DefaultLanguage>
     <Platforms>AnyCPU;x86;x64;arm64</Platforms>
     <RuntimeIdentifiers>win-x86;win-x64;win-arm64</RuntimeIdentifiers>
-    <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
     <SupportedOSPlatformVersion>$(TargetPlatformMinVersion)</SupportedOSPlatformVersion>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <IsAotCompatible>true</IsAotCompatible>

--- a/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactivity.Uwp/Microsoft.Xaml.Interactivity.Uwp.csproj
+++ b/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactivity.Uwp/Microsoft.Xaml.Interactivity.Uwp.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <TargetFramework>net8.0-windows10.0.26100.0</TargetFramework>
-    <WindowsSdkPackageVersion>10.0.26100.39</WindowsSdkPackageVersion>
+    <WindowsSdkPackageVersion>10.0.26100.54</WindowsSdkPackageVersion>
     <TargetPlatformMinVersion>10.0.18362.0</TargetPlatformMinVersion>
     <RootNamespace>Microsoft.Xaml.Interactivity</RootNamespace>
     <UseUwp>true</UseUwp>

--- a/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactivity.Uwp/Microsoft.Xaml.Interactivity.Uwp.csproj
+++ b/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactivity.Uwp/Microsoft.Xaml.Interactivity.Uwp.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFramework>net8.0-windows10.0.17763.0</TargetFramework>
+    <TargetFramework>net8.0-windows10.0.22621.0</TargetFramework>
     <TargetPlatformVersion>10.0.17763.0</TargetPlatformVersion>
-    <WindowsSdkPackageVersion>10.0.17763.37-preview</WindowsSdkPackageVersion>
+    <WindowsSdkPackageVersion>10.0.22621.37-preview</WindowsSdkPackageVersion>
     <UseUwp>true</UseUwp>
     <UseUwpTools>true</UseUwpTools>
     <RootNamespace>Microsoft.Xaml.Interactivity</RootNamespace>

--- a/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactivity.Uwp/Microsoft.Xaml.Interactivity.Uwp.csproj
+++ b/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactivity.Uwp/Microsoft.Xaml.Interactivity.Uwp.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <TargetFramework>net8.0-windows10.0.22621.0</TargetFramework>
-    <TargetPlatformVersion>10.0.17763.0</TargetPlatformVersion>
+    <TargetPlatformVersion>10.0.22621.0</TargetPlatformVersion>
     <WindowsSdkPackageVersion>10.0.22621.37-preview</WindowsSdkPackageVersion>
     <UseUwp>true</UseUwp>
     <UseUwpTools>true</UseUwpTools>

--- a/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactivity.Uwp/Microsoft.Xaml.Interactivity.Uwp.csproj
+++ b/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactivity.Uwp/Microsoft.Xaml.Interactivity.Uwp.csproj
@@ -3,7 +3,6 @@
     <OutputType>Library</OutputType>
     <TargetFramework>net8.0-windows10.0.22621.0</TargetFramework>
     <WindowsSdkPackageVersion>10.0.22621.39</WindowsSdkPackageVersion>
-    <TargetPlatformVersion>10.0.22621.0</TargetPlatformVersion>
     <TargetPlatformMinVersion>10.0.18362.0</TargetPlatformMinVersion>
     <RootNamespace>Microsoft.Xaml.Interactivity</RootNamespace>
     <UseUwp>true</UseUwp>
@@ -11,7 +10,6 @@
     <DefaultLanguage>en-US</DefaultLanguage>
     <Platforms>AnyCPU;x86;x64;arm64</Platforms>
     <RuntimeIdentifiers>win-x86;win-x64;win-arm64</RuntimeIdentifiers>
-    <SupportedOSPlatformVersion>$(TargetPlatformMinVersion)</SupportedOSPlatformVersion>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <IsAotCompatible>true</IsAotCompatible>
     <DisableRuntimeMarshalling>true</DisableRuntimeMarshalling>

--- a/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactivity.Uwp/Microsoft.Xaml.Interactivity.Uwp.csproj
+++ b/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactivity.Uwp/Microsoft.Xaml.Interactivity.Uwp.csproj
@@ -106,7 +106,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.1.1" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.1.3" PrivateAssets="all" />
   </ItemGroup>
   <ItemGroup>
     <PRIResource Include="..\Microsoft.Xaml.Interactivity\Resources\de-DE\Strings.resw">

--- a/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactivity.Uwp/Microsoft.Xaml.Interactivity.Uwp.csproj
+++ b/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactivity.Uwp/Microsoft.Xaml.Interactivity.Uwp.csproj
@@ -1,12 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFramework>net8.0-windows10.0.26100.0</TargetFramework>
-    <WindowsSdkPackageVersion>10.0.26100.54</WindowsSdkPackageVersion>
+    <TargetFramework>net8.0-windows10.0.18362.0</TargetFramework>
+    <WindowsSdkPackageVersion>10.0.18362.54</WindowsSdkPackageVersion>
     <TargetPlatformMinVersion>10.0.18362.0</TargetPlatformMinVersion>
     <RootNamespace>Microsoft.Xaml.Interactivity</RootNamespace>
     <UseUwp>true</UseUwp>
-    <UseUwpTools>true</UseUwpTools>    
     <DefaultLanguage>en-US</DefaultLanguage>
     <Platforms>AnyCPU;x86;x64;arm64</Platforms>
     <RuntimeIdentifiers>win-x86;win-x64;win-arm64</RuntimeIdentifiers>
@@ -15,6 +14,7 @@
     <DisableRuntimeMarshalling>true</DisableRuntimeMarshalling>
     <CsWinRTGenerateProjection>false</CsWinRTGenerateProjection>
     <CsWinRTAotWarningLevel>2</CsWinRTAotWarningLevel>
+    <EnableXamlCompilerTargetsForUwpApps>false</EnableXamlCompilerTargetsForUwpApps>
   </PropertyGroup>
   <PropertyGroup>
     <OutputPath>..\..\..\out\Uwp\$(SolutionName)\bin\$(Platform)\$(Configuration)\</OutputPath>
@@ -106,8 +106,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.1.3" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.Windows.SDK.CPP" Version="10.0.26100.2161" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.1.6" PrivateAssets="all" />
   </ItemGroup>
   <ItemGroup>
     <PRIResource Include="..\Microsoft.Xaml.Interactivity\Resources\de-DE\Strings.resw">

--- a/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactivity.Uwp/Microsoft.Xaml.Interactivity.Uwp.csproj
+++ b/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactivity.Uwp/Microsoft.Xaml.Interactivity.Uwp.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFramework>net8.0-windows10.0.22621.0</TargetFramework>
-    <WindowsSdkPackageVersion>10.0.22621.39</WindowsSdkPackageVersion>
+    <TargetFramework>net8.0-windows10.0.26100.0</TargetFramework>
+    <WindowsSdkPackageVersion>10.0.26100.39</WindowsSdkPackageVersion>
     <TargetPlatformMinVersion>10.0.18362.0</TargetPlatformMinVersion>
     <RootNamespace>Microsoft.Xaml.Interactivity</RootNamespace>
     <UseUwp>true</UseUwp>

--- a/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactivity.Uwp/Microsoft.Xaml.Interactivity.Uwp.csproj
+++ b/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactivity.Uwp/Microsoft.Xaml.Interactivity.Uwp.csproj
@@ -107,6 +107,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.1.3" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.Windows.SDK.CPP" Version="10.0.26100.2161" PrivateAssets="all" />
   </ItemGroup>
   <ItemGroup>
     <PRIResource Include="..\Microsoft.Xaml.Interactivity\Resources\de-DE\Strings.resw">

--- a/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactivity.Uwp/Microsoft.Xaml.Interactivity.Uwp.csproj
+++ b/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactivity.Uwp/Microsoft.Xaml.Interactivity.Uwp.csproj
@@ -96,6 +96,9 @@
     <DocumentationFile>..\..\..\out\Uwp\BehaviorsSDKManaged\bin\x64\Release\Microsoft.Xaml.Interactivity.xml</DocumentationFile>
   </PropertyGroup>
   <PropertyGroup>
+    <NoWarn>$(NoWarn);NETSDK1219</NoWarn>
+  </PropertyGroup>
+  <PropertyGroup>
     <RestoreProjectStyle>PackageReference</RestoreProjectStyle>
   </PropertyGroup>
   <ItemGroup>

--- a/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactivity.Uwp/Microsoft.Xaml.Interactivity.Uwp.csproj
+++ b/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactivity.Uwp/Microsoft.Xaml.Interactivity.Uwp.csproj
@@ -1,9 +1,200 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
+    <OutputType>Library</OutputType>
+    <TargetFramework>net8.0-windows10.0.17763.0</TargetFramework>
+    <TargetPlatformVersion>10.0.17763.0</TargetPlatformVersion>
+    <WindowsSdkPackageVersion>10.0.17763.37-preview</WindowsSdkPackageVersion>
+    <UseUwp>true</UseUwp>
+    <UseUwpTools>true</UseUwpTools>
+    <RootNamespace>Microsoft.Xaml.Interactivity</RootNamespace>
+    <Platforms>AnyCPU;x86;x64;arm64</Platforms>
+    <RuntimeIdentifiers>win-x86;win-x64;win-arm64</RuntimeIdentifiers>
+    <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
+    <SupportedOSPlatformVersion>$(TargetPlatformMinVersion)</SupportedOSPlatformVersion>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+    <IsAotCompatible>true</IsAotCompatible>
   </PropertyGroup>
-
+  <PropertyGroup>
+    <OutputPath>..\..\..\out\Uwp\$(SolutionName)\bin\$(Platform)\$(Configuration)\</OutputPath>
+    <IntermediateOutputPath>..\..\..\out\Uwp\$(SolutionName)\obj\$(Platform)\$(Configuration)\</IntermediateOutputPath>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <DefineConstants>DEBUG;TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <DefineConstants>TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <DocumentationFile>..\..\..\out\Uwp\BehaviorsSDKManaged\bin\AnyCPU\Release\Microsoft.Xaml.Interactivity.xml</DocumentationFile>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
+    <PlatformTarget>x86</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DefineConstants>DEBUG;TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
+    <NoWarn>;2008</NoWarn>
+    <DebugType>full</DebugType>
+    <UseVSHostingProcess>false</UseVSHostingProcess>
+    <ErrorReport>prompt</ErrorReport>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x86'">
+    <PlatformTarget>x86</PlatformTarget>
+    <DefineConstants>TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
+    <Optimize>true</Optimize>
+    <NoWarn>;2008</NoWarn>
+    <DebugType>pdbonly</DebugType>
+    <UseVSHostingProcess>false</UseVSHostingProcess>
+    <ErrorReport>prompt</ErrorReport>
+    <DocumentationFile>..\..\..\out\Uwp\BehaviorsSDKManaged\bin\x86\Release\Microsoft.Xaml.Interactivity.xml</DocumentationFile>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|ARM'">
+    <PlatformTarget>ARM</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DefineConstants>DEBUG;TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
+    <NoWarn>;2008</NoWarn>
+    <DebugType>full</DebugType>
+    <UseVSHostingProcess>false</UseVSHostingProcess>
+    <ErrorReport>prompt</ErrorReport>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|ARM'">
+    <PlatformTarget>ARM</PlatformTarget>
+    <DefineConstants>TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
+    <Optimize>true</Optimize>
+    <NoWarn>;2008</NoWarn>
+    <DebugType>pdbonly</DebugType>
+    <UseVSHostingProcess>false</UseVSHostingProcess>
+    <ErrorReport>prompt</ErrorReport>
+    <DocumentationFile>..\..\..\out\Uwp\BehaviorsSDKManaged\bin\ARM\Release\Microsoft.Xaml.Interactivity.xml</DocumentationFile>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|ARM64'">
+    <PlatformTarget>ARM64</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DefineConstants>DEBUG;TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
+    <NoWarn>;2008</NoWarn>
+    <DebugType>full</DebugType>
+    <UseVSHostingProcess>false</UseVSHostingProcess>
+    <ErrorReport>prompt</ErrorReport>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|ARM64'">
+    <PlatformTarget>ARM64</PlatformTarget>
+    <DefineConstants>TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
+    <Optimize>true</Optimize>
+    <NoWarn>;2008</NoWarn>
+    <DebugType>pdbonly</DebugType>
+    <UseVSHostingProcess>false</UseVSHostingProcess>
+    <ErrorReport>prompt</ErrorReport>
+    <DocumentationFile>..\..\..\out\Uwp\BehaviorsSDKManaged\bin\ARM64\Release\Microsoft.Xaml.Interactivity.xml</DocumentationFile>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
+    <PlatformTarget>x64</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DefineConstants>DEBUG;TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
+    <NoWarn>;2008</NoWarn>
+    <DebugType>full</DebugType>
+    <UseVSHostingProcess>false</UseVSHostingProcess>
+    <ErrorReport>prompt</ErrorReport>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
+    <PlatformTarget>x64</PlatformTarget>
+    <DefineConstants>TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
+    <Optimize>true</Optimize>
+    <NoWarn>;2008</NoWarn>
+    <DebugType>pdbonly</DebugType>
+    <UseVSHostingProcess>false</UseVSHostingProcess>
+    <ErrorReport>prompt</ErrorReport>
+    <DocumentationFile>..\..\..\out\Uwp\BehaviorsSDKManaged\bin\x64\Release\Microsoft.Xaml.Interactivity.xml</DocumentationFile>
+  </PropertyGroup>
+  <PropertyGroup>
+    <RestoreProjectStyle>PackageReference</RestoreProjectStyle>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.VisualStudioEng.MicroBuild.Core" Version="1.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+  <ItemGroup>
+    <PRIResource Include="..\Microsoft.Xaml.Interactivity\Resources\de-DE\Strings.resw">
+      <Link>Resources\de-DE\Strings.resw</Link>
+    </PRIResource>
+  </ItemGroup>
+  <ItemGroup>
+    <PRIResource Include="..\Microsoft.Xaml.Interactivity\Resources\en-us\Strings.resw">
+      <Link>Resources\en-us\Strings.resw</Link>
+    </PRIResource>
+  </ItemGroup>
+  <ItemGroup>
+    <PRIResource Include="..\Microsoft.Xaml.Interactivity\Resources\es-ES\Strings.resw">
+      <Link>Resources\es-ES\Strings.resw</Link>
+    </PRIResource>
+  </ItemGroup>
+  <ItemGroup>
+    <PRIResource Include="..\Microsoft.Xaml.Interactivity\Resources\fr-FR\Strings.resw">
+      <Link>Resources\fr-FR\Strings.resw</Link>
+    </PRIResource>
+  </ItemGroup>
+  <ItemGroup>
+    <PRIResource Include="..\Microsoft.Xaml.Interactivity\Resources\it-IT\Strings.resw">
+      <Link>Resources\it-IT\Strings.resw</Link>
+    </PRIResource>
+  </ItemGroup>
+  <ItemGroup>
+    <PRIResource Include="..\Microsoft.Xaml.Interactivity\Resources\ja-JP\Strings.resw">
+      <Link>Resources\ja-JP\Strings.resw</Link>
+    </PRIResource>
+  </ItemGroup>
+  <ItemGroup>
+    <PRIResource Include="..\Microsoft.Xaml.Interactivity\Resources\ko-KR\Strings.resw">
+      <Link>Resources\ko-KR\Strings.resw</Link>
+    </PRIResource>
+  </ItemGroup>
+  <ItemGroup>
+    <PRIResource Include="..\Microsoft.Xaml.Interactivity\Resources\pt-BR\Strings.resw">
+      <Link>Resources\pt-BR\Strings.resw</Link>
+    </PRIResource>
+  </ItemGroup>
+  <ItemGroup>
+    <PRIResource Include="..\Microsoft.Xaml.Interactivity\Resources\ru-RU\Strings.resw">
+      <Link>Resources\ru-RU\Strings.resw</Link>
+    </PRIResource>
+  </ItemGroup>
+  <ItemGroup>
+    <PRIResource Include="..\Microsoft.Xaml.Interactivity\Resources\uk-UA\Strings.resw">
+      <Link>Resources\uk-UA\Strings.resw</Link>
+    </PRIResource>
+  </ItemGroup>
+  <ItemGroup>
+    <PRIResource Include="..\Microsoft.Xaml.Interactivity\Resources\zh-CN\Strings.resw">
+      <Link>Resources\zh-CN\Strings.resw</Link>
+    </PRIResource>
+  </ItemGroup>
+  <ItemGroup>
+    <PRIResource Include="..\Microsoft.Xaml.Interactivity\Resources\zh-TW\Strings.resw">
+      <Link>Resources\zh-TW\Strings.resw</Link>
+    </PRIResource>
+  </ItemGroup>
+  <Import Project="..\Microsoft.Xaml.Interactivity.Shared\Microsoft.Xaml.Interactivity.Shared.projitems" Label="Shared" />
+  <PropertyGroup Condition=" '$(VisualStudioVersion)' == '' or '$(VisualStudioVersion)' &lt; '14.0' ">
+    <VisualStudioVersion>14.0</VisualStudioVersion>
+  </PropertyGroup>
+  <Import Project="..\..\..\scripts\Microsoft.Xaml.Behaviors.Signing.targets" />
+  <PropertyGroup>
+    <!-- NuGet info is not needed, this project is packed in the same package as legacy UWP -->
+  </PropertyGroup>
+  <Import Project="..\Version\NuGetPackageVersion.props" />
+  <Import Project="..\packages\NuGet.Build.Tasks.Pack.4.9.4\build\NuGet.Build.Tasks.Pack.targets" Condition="Exists('..\packages\NuGet.Build.Tasks.Pack.4.9.4\build\NuGet.Build.Tasks.Pack.targets')" />
+  <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
+    <DocumentationFile>..\..\..\out\Uwp\BehaviorsSDKManaged\bin\$(Platform)\Release\Microsoft.Xaml.Interactivity.xml</DocumentationFile>
+  </PropertyGroup>
+  <PropertyGroup>
+    <AssemblyName>Microsoft.Xaml.Interactivity</AssemblyName>
+  </PropertyGroup>
 </Project>

--- a/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactivity.Uwp/Microsoft.Xaml.Interactivity.Uwp.csproj
+++ b/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactivity.Uwp/Microsoft.Xaml.Interactivity.Uwp.csproj
@@ -116,6 +116,9 @@
     <RestoreProjectStyle>PackageReference</RestoreProjectStyle>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="..\Microsoft.Xaml.Interactivity.WinUI\Properties\AssemblyInfo.cs" Link="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
     <PackageReference Include="Microsoft.VisualStudioEng.MicroBuild.Core" Version="1.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactivity.Uwp/Microsoft.Xaml.Interactivity.Uwp.csproj
+++ b/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactivity.Uwp/Microsoft.Xaml.Interactivity.Uwp.csproj
@@ -3,21 +3,21 @@
     <OutputType>Library</OutputType>
     <TargetFramework>net8.0-windows10.0.22621.0</TargetFramework>
     <TargetPlatformVersion>10.0.22621.0</TargetPlatformVersion>
-	<TargetPlatformMinVersion>10.0.18362.0</TargetPlatformMinVersion>
-    <WindowsSdkPackageVersion>10.0.22621.37-preview</WindowsSdkPackageVersion>
+    <TargetPlatformMinVersion>10.0.18362.0</TargetPlatformMinVersion>
+    <WindowsSdkPackageVersion>10.0.22621.39</WindowsSdkPackageVersion>
     <UseUwp>true</UseUwp>
     <UseUwpTools>true</UseUwpTools>
     <RootNamespace>Microsoft.Xaml.Interactivity</RootNamespace>
-	<DefaultLanguage>en-US</DefaultLanguage>
+    <DefaultLanguage>en-US</DefaultLanguage>
     <Platforms>AnyCPU;x86;x64;arm64</Platforms>
     <RuntimeIdentifiers>win-x86;win-x64;win-arm64</RuntimeIdentifiers>
     <SupportedOSPlatformVersion>$(TargetPlatformMinVersion)</SupportedOSPlatformVersion>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <IsAotCompatible>true</IsAotCompatible>
-	
-	<!-- Temporary workaround, will be fixed in VS 17.12 P1 -->
+    
+    <!-- Temporary workaround, will be fixed in VS 17.12 P1 -->
     <AddMicrosoftVCLibsSDKReference>false</AddMicrosoftVCLibsSDKReference>
-	<AddMicrosoftUniversalCRTDebugSDKReference>false</AddMicrosoftUniversalCRTDebugSDKReference>
+    <AddMicrosoftUniversalCRTDebugSDKReference>false</AddMicrosoftUniversalCRTDebugSDKReference>
   </PropertyGroup>
   <PropertyGroup>
     <OutputPath>..\..\..\out\Uwp\$(SolutionName)\bin\$(Platform)\$(Configuration)\</OutputPath>
@@ -203,7 +203,7 @@
     <DocumentationFile>..\..\..\out\Uwp\BehaviorsSDKManaged\bin\$(Platform)\Release\Microsoft.Xaml.Interactivity.xml</DocumentationFile>
   </PropertyGroup>
   <PropertyGroup>
-	<DefineConstants>$(DefineConstants);MODERN_WINDOWS_UWP</DefineConstants>
+    <DefineConstants>$(DefineConstants);MODERN_WINDOWS_UWP</DefineConstants>
     <AssemblyName>Microsoft.Xaml.Interactivity</AssemblyName>
   </PropertyGroup>
 </Project>

--- a/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactivity.Uwp/Microsoft.Xaml.Interactivity.Uwp.csproj
+++ b/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactivity.Uwp/Microsoft.Xaml.Interactivity.Uwp.csproj
@@ -2,22 +2,21 @@
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <TargetFramework>net8.0-windows10.0.22621.0</TargetFramework>
+    <WindowsSdkPackageVersion>10.0.22621.39</WindowsSdkPackageVersion>
     <TargetPlatformVersion>10.0.22621.0</TargetPlatformVersion>
     <TargetPlatformMinVersion>10.0.18362.0</TargetPlatformMinVersion>
-    <WindowsSdkPackageVersion>10.0.22621.39</WindowsSdkPackageVersion>
-    <UseUwp>true</UseUwp>
-    <UseUwpTools>true</UseUwpTools>
     <RootNamespace>Microsoft.Xaml.Interactivity</RootNamespace>
+    <UseUwp>true</UseUwp>
+    <UseUwpTools>true</UseUwpTools>    
     <DefaultLanguage>en-US</DefaultLanguage>
     <Platforms>AnyCPU;x86;x64;arm64</Platforms>
     <RuntimeIdentifiers>win-x86;win-x64;win-arm64</RuntimeIdentifiers>
     <SupportedOSPlatformVersion>$(TargetPlatformMinVersion)</SupportedOSPlatformVersion>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <IsAotCompatible>true</IsAotCompatible>
-    
-    <!-- Temporary workaround, will be fixed in VS 17.12 P1 -->
-    <AddMicrosoftVCLibsSDKReference>false</AddMicrosoftVCLibsSDKReference>
-    <AddMicrosoftUniversalCRTDebugSDKReference>false</AddMicrosoftUniversalCRTDebugSDKReference>
+    <DisableRuntimeMarshalling>true</DisableRuntimeMarshalling>
+    <CsWinRTGenerateProjection>false</CsWinRTGenerateProjection>
+    <CsWinRTAotWarningLevel>2</CsWinRTAotWarningLevel>
   </PropertyGroup>
   <PropertyGroup>
     <OutputPath>..\..\..\out\Uwp\$(SolutionName)\bin\$(Platform)\$(Configuration)\</OutputPath>
@@ -59,25 +58,6 @@
     <UseVSHostingProcess>false</UseVSHostingProcess>
     <ErrorReport>prompt</ErrorReport>
     <DocumentationFile>..\..\..\out\Uwp\BehaviorsSDKManaged\bin\x86\Release\Microsoft.Xaml.Interactivity.xml</DocumentationFile>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|ARM'">
-    <PlatformTarget>ARM</PlatformTarget>
-    <DebugSymbols>true</DebugSymbols>
-    <DefineConstants>DEBUG;TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
-    <NoWarn>;2008</NoWarn>
-    <DebugType>full</DebugType>
-    <UseVSHostingProcess>false</UseVSHostingProcess>
-    <ErrorReport>prompt</ErrorReport>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|ARM'">
-    <PlatformTarget>ARM</PlatformTarget>
-    <DefineConstants>TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
-    <Optimize>true</Optimize>
-    <NoWarn>;2008</NoWarn>
-    <DebugType>pdbonly</DebugType>
-    <UseVSHostingProcess>false</UseVSHostingProcess>
-    <ErrorReport>prompt</ErrorReport>
-    <DocumentationFile>..\..\..\out\Uwp\BehaviorsSDKManaged\bin\ARM\Release\Microsoft.Xaml.Interactivity.xml</DocumentationFile>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|ARM64'">
     <PlatformTarget>ARM64</PlatformTarget>
@@ -128,6 +108,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.1.1" PrivateAssets="all" />
   </ItemGroup>
   <ItemGroup>
     <PRIResource Include="..\Microsoft.Xaml.Interactivity\Resources\de-DE\Strings.resw">
@@ -198,7 +179,6 @@
     <!-- NuGet info is not needed, this project is packed in the same package as legacy UWP -->
   </PropertyGroup>
   <Import Project="..\Version\NuGetPackageVersion.props" />
-  <Import Project="..\packages\NuGet.Build.Tasks.Pack.4.9.4\build\NuGet.Build.Tasks.Pack.targets" Condition="Exists('..\packages\NuGet.Build.Tasks.Pack.4.9.4\build\NuGet.Build.Tasks.Pack.targets')" />
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
     <DocumentationFile>..\..\..\out\Uwp\BehaviorsSDKManaged\bin\$(Platform)\Release\Microsoft.Xaml.Interactivity.xml</DocumentationFile>
   </PropertyGroup>

--- a/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactivity.WinUI/Microsoft.Xaml.Interactivity.WinUI.csproj
+++ b/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactivity.WinUI/Microsoft.Xaml.Interactivity.WinUI.csproj
@@ -106,7 +106,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.1.3" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.1.6" PrivateAssets="all" />
     <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.6.240829007" />
   </ItemGroup>
   <ItemGroup>

--- a/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactivity.WinUI/Microsoft.Xaml.Interactivity.WinUI.csproj
+++ b/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactivity.WinUI/Microsoft.Xaml.Interactivity.WinUI.csproj
@@ -3,12 +3,10 @@
     <OutputType>Library</OutputType>
     <TargetFramework>net8.0-windows10.0.17763.0</TargetFramework>
     <WindowsSdkPackageVersion>10.0.17763.41</WindowsSdkPackageVersion>
-    <TargetPlatformVersion>10.0.17763.0</TargetPlatformVersion>
     <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
     <RootNamespace>Microsoft.Xaml.Interactivity</RootNamespace>
     <Platforms>AnyCPU;x86;x64;arm64</Platforms>
     <RuntimeIdentifiers>win-x86;win-x64;win-arm64</RuntimeIdentifiers>
-    <SupportedOSPlatformVersion>$(TargetPlatformMinVersion)</SupportedOSPlatformVersion>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <IsAotCompatible>true</IsAotCompatible>
     <DisableRuntimeMarshalling>true</DisableRuntimeMarshalling>

--- a/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactivity.WinUI/Microsoft.Xaml.Interactivity.WinUI.csproj
+++ b/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactivity.WinUI/Microsoft.Xaml.Interactivity.WinUI.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <TargetFramework>net8.0-windows10.0.17763.0</TargetFramework>
-    <WindowsSdkPackageVersion>10.0.17763.41</WindowsSdkPackageVersion>
+    <WindowsSdkPackageVersion>10.0.17763.53</WindowsSdkPackageVersion>
     <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
     <RootNamespace>Microsoft.Xaml.Interactivity</RootNamespace>
     <Platforms>AnyCPU;x86;x64;arm64</Platforms>

--- a/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactivity.WinUI/Microsoft.Xaml.Interactivity.WinUI.csproj
+++ b/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactivity.WinUI/Microsoft.Xaml.Interactivity.WinUI.csproj
@@ -4,10 +4,10 @@
     <TargetFramework>net8.0-windows10.0.17763.0</TargetFramework>
     <WindowsSdkPackageVersion>10.0.17763.41</WindowsSdkPackageVersion>
     <TargetPlatformVersion>10.0.17763.0</TargetPlatformVersion>
+    <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
     <RootNamespace>Microsoft.Xaml.Interactivity</RootNamespace>
     <Platforms>AnyCPU;x86;x64;arm64</Platforms>
     <RuntimeIdentifiers>win-x86;win-x64;win-arm64</RuntimeIdentifiers>
-    <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
     <SupportedOSPlatformVersion>$(TargetPlatformMinVersion)</SupportedOSPlatformVersion>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <IsAotCompatible>true</IsAotCompatible>

--- a/src/BehaviorsSDKManaged/global.json
+++ b/src/BehaviorsSDKManaged/global.json
@@ -1,8 +1,9 @@
 {
   "sdk":
   {
-    "version": "8.0.400",
-    "rollForward": "latestFeature"
+    "version": "9.0.100",
+    "rollForward": "latestFeature",
+    "allowPrerelease": false
   },
   "msbuild-sdks": {
     "MSBuild.Sdk.Extras": "3.0.44"


### PR DESCRIPTION
#### Completes https://task.ms/52148967

This PR adds support for UWP on modern .NET, by adding new UWP projects targeting .NET 8 and packaging them in a new TFM folder in the `Microsoft.Xaml.Behaviors.Uwp.Managed` NuGet package. Virtually no code changes are required (and we also get all the trim/AOT support for free from #255). The .csproj files could be simplified further, but keeping them the same as the ones for WinUI so that things are easier to maintain (fewer differences between the two flavors).