### PR TITLE
Disable CsWinRT projections generation

### DIFF
--- a/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactions.WinUI/Microsoft.Xaml.Interactions.WinUI.csproj
+++ b/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactions.WinUI/Microsoft.Xaml.Interactions.WinUI.csproj
@@ -12,6 +12,7 @@
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <IsAotCompatible>true</IsAotCompatible>
     <DisableRuntimeMarshalling>true</DisableRuntimeMarshalling>
+    <CsWinRTGenerateProjection>false</CsWinRTGenerateProjection>
     <CsWinRTAotWarningLevel>2</CsWinRTAotWarningLevel>
 
     <!-- Temporary workaround for a WebView2 bug -->

--- a/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactivity.WinUI/Microsoft.Xaml.Interactivity.WinUI.csproj
+++ b/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactivity.WinUI/Microsoft.Xaml.Interactivity.WinUI.csproj
@@ -12,6 +12,7 @@
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <IsAotCompatible>true</IsAotCompatible>
     <DisableRuntimeMarshalling>true</DisableRuntimeMarshalling>
+    <CsWinRTGenerateProjection>false</CsWinRTGenerateProjection>
     <CsWinRTAotWarningLevel>2</CsWinRTAotWarningLevel>
 
     <!-- Temporary workaround for a WebView2 bug -->


### PR DESCRIPTION
This PR fixes a build issue in the CI ([see here](https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=10072694&view=logs&j=42570ebb-e4bd-5294-d2c7-37a394832214&t=dd387a88-06f9-59c8-6ef9-122476f5fff5)). We don't need to generate projections anyway.