### PR TITLE
Actions are not fired when navigated back to a cached Page in EventTriggerBehavior

### DIFF
--- a/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactions.Shared/Core/EventTriggerBehavior.cs
+++ b/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactions.Shared/Core/EventTriggerBehavior.cs
@@ -212,6 +212,7 @@ namespace Microsoft.Xaml.Interactions.Core
 #else
                 if (this._isWindowsRuntimeEvent)
                 {
+                    this._removeEventHandlerMethod = token => info.RemoveMethod.Invoke(this._resolvedSource, new object[] { token });
                     WindowsRuntimeMarshal.RemoveEventHandler(this._removeEventHandlerMethod, this._eventHandler);
                 }
                 else


### PR DESCRIPTION
In Uwp project. Actions could no longer be tiggered after navigated to a cached Page. Setting the field _removeEventHandlerMethod again in UnregisterEvent Method works for me.