### PR TITLE
Upload binlog from CI

### DIFF
--- a/.github/workflows/managed-build.yml
+++ b/.github/workflows/managed-build.yml
@@ -30,4 +30,11 @@ jobs:
       run: nuget restore src\BehaviorsSDKManaged\BehaviorsSDKManaged.sln
 
     - name: Build BehaviorsSDKManaged.sln
-      run: msbuild src\BehaviorsSDKManaged\BehaviorsSDKManaged.sln /p:Configuration=Release
+      run: msbuild src\BehaviorsSDKManaged\BehaviorsSDKManaged.sln /p:Configuration=Release -v:diag /bl
+    
+    - name: Upload MSBuild binary log
+      uses: actions/upload-artifact@v4
+      with:
+        name: msbuild_binlog_Release_x64
+        path: msbuild.binlog
+        if-no-files-found: error


### PR DESCRIPTION
This PR updates the GitHub Actions workflow to also upload a binlog as an artifact, to help investigate issues.