### PR TITLE
Update WindowsAppSDK and NuGet packages

### DIFF
--- a/scripts/Microsoft.Xaml.Behaviors.WinUI.Managed.nuspec
+++ b/scripts/Microsoft.Xaml.Behaviors.WinUI.Managed.nuspec
@@ -15,7 +15,7 @@
         <tags>Behavior Action Behaviors Actions Blend Managed C# Interaction Interactivity Interactions WinUI</tags>
         <dependencies>
           <group targetFramework="net8.0-windows10.0.17763.0">
-            <dependency id="Microsoft.WindowsAppSDK" version="1.6.240807006-preview1" />
+            <dependency id="Microsoft.WindowsAppSDK" version="1.6.241106002" />
           </group>
         </dependencies>
     </metadata>

--- a/src/BehaviorsSDKManaged/ManagedUnitTests/ManagedUnitTests.csproj
+++ b/src/BehaviorsSDKManaged/ManagedUnitTests/ManagedUnitTests.csproj
@@ -129,16 +129,16 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk">
-      <Version>17.11.0</Version>
+      <Version>17.11.1</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform">
       <Version>6.2.14</Version>
     </PackageReference>
     <PackageReference Include="MSTest.TestAdapter">
-      <Version>3.5.2</Version>
+      <Version>3.6.3</Version>
     </PackageReference>
     <PackageReference Include="MSTest.TestFramework">
-      <Version>3.5.2</Version>
+      <Version>3.6.3</Version>
     </PackageReference>
     <PackageReference Include="Newtonsoft.Json">
       <Version>13.0.3</Version>

--- a/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactions.WinUI/Microsoft.Xaml.Interactions.WinUI.csproj
+++ b/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactions.WinUI/Microsoft.Xaml.Interactions.WinUI.csproj
@@ -110,7 +110,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.1.6" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.6.240829007" />
+    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.6.241106002" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.Xaml.Interactivity.WinUI\Microsoft.Xaml.Interactivity.WinUI.csproj">

--- a/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactivity.WinUI/Microsoft.Xaml.Interactivity.WinUI.csproj
+++ b/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactivity.WinUI/Microsoft.Xaml.Interactivity.WinUI.csproj
@@ -107,7 +107,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.1.6" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.6.240829007" />
+    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.6.241106002" />
   </ItemGroup>
   <ItemGroup>
     <PRIResource Include="..\Microsoft.Xaml.Interactivity\Resources\de-DE\Strings.resw">


### PR DESCRIPTION
This PR includes a couple maintenance items:
- Bump WASDK to latest stable
- Fix the WASDK dep in the .nuspec file
- Bump some NuGet packages to latest stable