### PR TITLE
Switch all files to file-scoped namespaces

### DIFF
--- a/scripts/Microsoft.Xaml.Behaviors.Uwp.Managed.nuspec
+++ b/scripts/Microsoft.Xaml.Behaviors.Uwp.Managed.nuspec
@@ -47,10 +47,6 @@
 
         <file target="lib\net8.0-windows10.0.19041.0\Design\Microsoft.Xaml.Interactivity.DesignTools.dll"   src="..\out\BehaviorsSDKManaged\bin\AnyCPU\Release\Microsoft.Xaml.Interactivity.DesignTools.dll" />
         <file target="lib\net8.0-windows10.0.19041.0\Design\Microsoft.Xaml.Interactivity.DesignTools.pdb"   src="..\out\BehaviorsSDKManaged\bin\AnyCPU\Release\Microsoft.Xaml.Interactivity.DesignTools.pdb" />
-
-        <file target="src\BehaviorsSDKManaged\Microsoft.Xaml.Interactivity"                  src="..\src\BehaviorsSDKManaged\Microsoft.Xaml.Interactivity\**\*.cs" />
-        <file target="src\BehaviorsSDKManaged\Microsoft.Xaml.Interactivity.Design"           src="..\src\BehaviorsSDKManaged\Microsoft.Xaml.Interactivity.Design\**\*.cs" />
-        <file target="src\BehaviorsSDKManaged\Microsoft.Xaml.Interactivity.DesignTools"      src="..\src\BehaviorsSDKManaged\Microsoft.Xaml.Interactivity.DesignTools\**\*.cs" />
     </files>
 
 </package>

--- a/scripts/Microsoft.Xaml.Behaviors.WinUI.Managed.nuspec
+++ b/scripts/Microsoft.Xaml.Behaviors.WinUI.Managed.nuspec
@@ -34,14 +34,6 @@
       
         <file target="lib\net8.0-windows10.0.17763.0\Design\Microsoft.Xaml.Interactivity.DesignTools.dll"   src="..\out\BehaviorsSDKManaged\bin\AnyCPU\Release\Microsoft.Xaml.Interactivity.DesignTools.dll" />
         <file target="lib\net8.0-windows10.0.17763.0\Design\Microsoft.Xaml.Interactivity.DesignTools.pdb"   src="..\out\BehaviorsSDKManaged\bin\AnyCPU\Release\Microsoft.Xaml.Interactivity.DesignTools.pdb" />
-
-        <file target="src\BehaviorsSDKManaged\Microsoft.Xaml.Interactivity.WinUI"             src="..\src\BehaviorsSDKManaged\Microsoft.Xaml.Interactivity.Shared\**\*.cs" />
-
-        <!--
-        <file target="src\BehaviorsSDKManaged\Microsoft.Xaml.Interactivity.Design"      src="..\src\BehaviorsSDKManaged\Microsoft.Xaml.Interactivity.Design\**\*.cs" />
-        -->
-
-        <file target="src\BehaviorsSDKManaged\Microsoft.Xaml.Interactivity.DesignTools"      src="..\src\BehaviorsSDKManaged\Microsoft.Xaml.Interactivity.DesignTools\**\*.cs" />
     </files>
 
 </package>

--- a/src/BehaviorsSDKManaged/Directory.Build.props
+++ b/src/BehaviorsSDKManaged/Directory.Build.props
@@ -1,0 +1,41 @@
+<Project>
+
+  <!--
+    Set the $(SolutionDir) property if needed. This is referenced in other projects as well.
+    This property is only set automatically by MSBuild when building from the IDE. For more info, see:
+    https://docs.microsoft.com/en-us/cpp/build/reference/common-macros-for-build-commands-and-properties#list-of-common-macros.
+    To work around this and enable individual projects to build correctly, it is defined manually if needed.
+    That is, if empty, the solution path is computed by moving upwards until the solution file is found.
+  -->
+  <PropertyGroup Label="Globals">
+    <BehaviorsSDKManagedSolutionPath>$([MSBuild]::EnsureTrailingSlash($([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), BehaviorsSDKManaged.sln))))</BehaviorsSDKManagedSolutionPath>
+    <SolutionDir Condition="'$(SolutionDir)' == ''">$(BehaviorsSDKManagedSolutionPath)</SolutionDir>
+  </PropertyGroup>
+
+  <!--
+    Set the C# version to 12, enable nullability annotations and unsafe blocks.
+    Note that the <Nullable> tag will only work when used in SDK-style projects.
+    In other project types, it is just ignored, and invidual files need #nullable enable.
+  -->
+  <PropertyGroup Condition="$(MSBuildProjectFile.EndsWith('.csproj'))">
+    <LangVersion>13.0</LangVersion>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+
+    <!--
+      Enable the compiler strict mode (see https://www.meziantou.net/csharp-compiler-strict-mode.htm).
+      This (poorly documented) mode enables additional warnings for incorrect usages of some features.
+      For instance, this will warn when using the == operator to compare a struct with a null literal.
+    -->
+    <Features>strict</Features>
+
+    <!--
+      Generate documentation files. In theory this should only be abled for published, non source generator projects.
+      However, this is always enabled to work around https://github.com/dotnet/roslyn/issues/41640. Until that's fixed,
+      source generators will also produce an .xml file with their documentation. Note that this doesn't really impact
+      NuGet packages, since the analyzer binaries are packed manually after build, so the .xml files aren't included.
+      When this workaround is no longer needed, the same property should also removed for the \samples directory.
+      Once that issue is fixed, this should be moved down to the src\ specific .props file again, and otherwise disabled.
+    -->
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+  </PropertyGroup>
+</Project>

--- a/src/BehaviorsSDKManaged/Directory.Build.props
+++ b/src/BehaviorsSDKManaged/Directory.Build.props
@@ -12,13 +12,9 @@
     <SolutionDir Condition="'$(SolutionDir)' == ''">$(BehaviorsSDKManagedSolutionPath)</SolutionDir>
   </PropertyGroup>
 
-  <!--
-    Set the C# version to 12, enable nullability annotations and unsafe blocks.
-    Note that the <Nullable> tag will only work when used in SDK-style projects.
-    In other project types, it is just ignored, and invidual files need #nullable enable.
-  -->
+  <!-- Set the C# version and other common properties -->
   <PropertyGroup Condition="$(MSBuildProjectFile.EndsWith('.csproj'))">
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 
     <!--

--- a/src/BehaviorsSDKManaged/ManagedUnitTests/ActionCollectionTest.cs
+++ b/src/BehaviorsSDKManaged/ManagedUnitTests/ActionCollectionTest.cs
@@ -5,45 +5,44 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Microsoft.VisualStudio.TestTools.UnitTesting.AppContainer;
 using Microsoft.Xaml.Interactivity;
 
-namespace ManagedUnitTests
+namespace ManagedUnitTests;
+
+[TestClass]
+public class ActionCollectionTest
 {
-    [TestClass]
-    public class ActionCollectionTest
+    [UITestMethod]
+    public void Constructor_DefaultConstructor_SetsVolumeCorrectly()
     {
-        [UITestMethod]
-        public void Constructor_DefaultConstructor_SetsVolumeCorrectly()
-        {
-            PlaySoundAction playSoundAction = new PlaySoundAction();
-            Assert.AreEqual(0.5, playSoundAction.Volume, "Volume should be initialized to 0.5");
-        }
+        PlaySoundAction playSoundAction = new PlaySoundAction();
+        Assert.AreEqual(0.5, playSoundAction.Volume, "Volume should be initialized to 0.5");
+    }
 
-        [UITestMethod]
-        public void Invoke_RelativeSource_Invokes()
-        {
-            PlaySoundAction playSoundAction = new PlaySoundAction();
+    [UITestMethod]
+    public void Invoke_RelativeSource_Invokes()
+    {
+        PlaySoundAction playSoundAction = new PlaySoundAction();
 
-            playSoundAction.Source = "foo.wav";
-            bool result = (bool)playSoundAction.Execute(null, null);
-            Assert.IsTrue(result);
-        }
+        playSoundAction.Source = "foo.wav";
+        bool result = (bool)playSoundAction.Execute(null, null);
+        Assert.IsTrue(result);
+    }
 
-        [UITestMethod]
-        public void Invoke_AbsoluteSource_Invokes()
-        {
-            PlaySoundAction playSoundAction = new PlaySoundAction();
+    [UITestMethod]
+    public void Invoke_AbsoluteSource_Invokes()
+    {
+        PlaySoundAction playSoundAction = new PlaySoundAction();
 
-            playSoundAction.Source = "ms-appx:///foo.wav";
-            bool result = (bool)playSoundAction.Execute(null, null);
-            Assert.IsTrue(result);
-        }
+        playSoundAction.Source = "ms-appx:///foo.wav";
+        bool result = (bool)playSoundAction.Execute(null, null);
+        Assert.IsTrue(result);
+    }
 
-        [UITestMethod]
-        public void Invoke_InvalidSource_ReturnsFalse()
-        {
-            PlaySoundAction playSoundAction = new PlaySoundAction();
+    [UITestMethod]
+    public void Invoke_InvalidSource_ReturnsFalse()
+    {
+        PlaySoundAction playSoundAction = new PlaySoundAction();
 
-            Assert.IsFalse((bool)playSoundAction.Execute(null, null),
-                "PlaySoundAction.Execute should return false with a null source path.");
-        }
+        Assert.IsFalse((bool)playSoundAction.Execute(null, null),
+            "PlaySoundAction.Execute should return false with a null source path.");
     }
 }

--- a/src/BehaviorsSDKManaged/ManagedUnitTests/BehaviorCollectionTest.cs
+++ b/src/BehaviorsSDKManaged/ManagedUnitTests/BehaviorCollectionTest.cs
@@ -6,246 +6,245 @@ using Microsoft.VisualStudio.TestTools.UnitTesting.AppContainer;
 using Microsoft.Xaml.Interactivity;
 using Windows.UI.Xaml.Controls;
 
-namespace ManagedUnitTests
+namespace ManagedUnitTests;
+
+[TestClass]
+public class BehaviorCollectionTest
 {
-    [TestClass]
-    public class BehaviorCollectionTest
+    [UITestMethod]
+    public void VectorChanged_NonBehaviorAdded_ExceptionThrown()
     {
-        [UITestMethod]
-        public void VectorChanged_NonBehaviorAdded_ExceptionThrown()
-        {
-            BehaviorCollection behaviorCollection = new BehaviorCollection();
-            behaviorCollection.Add(new StubBehavior());
+        BehaviorCollection behaviorCollection = new BehaviorCollection();
+        behaviorCollection.Add(new StubBehavior());
 
-            TestUtilities.AssertThrowsInvalidOperationException(() => behaviorCollection.Add(new TextBlock()));
+        TestUtilities.AssertThrowsInvalidOperationException(() => behaviorCollection.Add(new TextBlock()));
+    }
+
+    [UITestMethod]
+    public void VectorChanged_BehaviorChangedToNonBehavior_ExceptionThrown()
+    {
+        BehaviorCollection behaviorCollection = new BehaviorCollection();
+        behaviorCollection.Add(new StubBehavior());
+
+        TestUtilities.AssertThrowsInvalidOperationException(() => behaviorCollection[0] = new ToggleSwitch());
+    }
+
+    [UITestMethod]
+    public void VectorChanged_DuplicateAdd_ExceptionThrown()
+    {
+        BehaviorCollection behaviorCollection = new BehaviorCollection();
+        StubBehavior stub = new StubBehavior();
+        behaviorCollection.Add(stub);
+
+        TestUtilities.AssertThrowsInvalidOperationException(() => behaviorCollection.Add(stub));
+
+    }
+
+    [UITestMethod]
+    public void VectorChanged_AddWhileNotAttached_AttachNotCalled()
+    {
+        BehaviorCollection behaviorCollection = new BehaviorCollection();
+        StubBehavior stub = new StubBehavior();
+        behaviorCollection.Add(stub);
+
+        TestUtilities.AssertNotAttached(stub);
+    }
+
+    [UITestMethod]
+    public void VectorChanged_AddWhileAttached_AllAttached()
+    {
+        BehaviorCollection behaviorCollection = new BehaviorCollection();
+        behaviorCollection.Attach(new Button());
+
+        behaviorCollection.Add(new StubBehavior());
+        behaviorCollection.Add(new StubBehavior());
+        behaviorCollection.Add(new StubBehavior());
+
+        foreach (StubBehavior stub in behaviorCollection)
+        {
+            TestUtilities.AssertAttached(stub, behaviorCollection.AssociatedObject);
         }
+    }
 
-        [UITestMethod]
-        public void VectorChanged_BehaviorChangedToNonBehavior_ExceptionThrown()
+    [UITestMethod]
+    public void VectorChanged_ReplaceWhileAttached_OldDetachedNewAttached()
+    {
+        BehaviorCollection behaviorCollection = new BehaviorCollection();
+        behaviorCollection.Attach(new Button());
+
+        StubBehavior first = new StubBehavior();
+        behaviorCollection.Add(first);
+
+        StubBehavior second = new StubBehavior();
+
+        behaviorCollection[0] = second;
+
+        TestUtilities.AssertDetached(first);
+
+        TestUtilities.AssertAttached(second, behaviorCollection.AssociatedObject);
+    }
+
+
+    [UITestMethod]
+    public void VectorChanged_RemoveWhileNotAttached_DetachNotCalled()
+    {
+        BehaviorCollection behaviorCollection = new BehaviorCollection();
+
+        StubBehavior behavior = new StubBehavior();
+        behaviorCollection.Add(behavior);
+        behaviorCollection.Remove(behavior);
+
+        TestUtilities.AssertNotDetached(behavior);
+    }
+
+    [UITestMethod]
+    public void VectorChanged_RemoveWhileAttached_Detached()
+    {
+        BehaviorCollection behaviorCollection = new BehaviorCollection();
+        behaviorCollection.Attach(new ToggleSwitch());
+
+        StubBehavior behavior = new StubBehavior();
+        behaviorCollection.Add(behavior);
+        behaviorCollection.Remove(behavior);
+
+        TestUtilities.AssertDetached(behavior);
+    }
+
+    [UITestMethod]
+    public void VectorChanged_ResetWhileNotAttached_DetachNotCalled()
+    {
+        StubBehavior[] behaviorArray = { new StubBehavior(), new StubBehavior(), new StubBehavior() };
+
+        BehaviorCollection behaviorCollection = new BehaviorCollection();
+        foreach (StubBehavior behavior in behaviorArray)
         {
-            BehaviorCollection behaviorCollection = new BehaviorCollection();
-            behaviorCollection.Add(new StubBehavior());
-
-            TestUtilities.AssertThrowsInvalidOperationException(() => behaviorCollection[0] = new ToggleSwitch());
-        }
-
-        [UITestMethod]
-        public void VectorChanged_DuplicateAdd_ExceptionThrown()
-        {
-            BehaviorCollection behaviorCollection = new BehaviorCollection();
-            StubBehavior stub = new StubBehavior();
-            behaviorCollection.Add(stub);
-
-            TestUtilities.AssertThrowsInvalidOperationException(() => behaviorCollection.Add(stub));
-
-        }
-
-        [UITestMethod]
-        public void VectorChanged_AddWhileNotAttached_AttachNotCalled()
-        {
-            BehaviorCollection behaviorCollection = new BehaviorCollection();
-            StubBehavior stub = new StubBehavior();
-            behaviorCollection.Add(stub);
-
-            TestUtilities.AssertNotAttached(stub);
-        }
-
-        [UITestMethod]
-        public void VectorChanged_AddWhileAttached_AllAttached()
-        {
-            BehaviorCollection behaviorCollection = new BehaviorCollection();
-            behaviorCollection.Attach(new Button());
-
-            behaviorCollection.Add(new StubBehavior());
-            behaviorCollection.Add(new StubBehavior());
-            behaviorCollection.Add(new StubBehavior());
-
-            foreach (StubBehavior stub in behaviorCollection)
-            {
-                TestUtilities.AssertAttached(stub, behaviorCollection.AssociatedObject);
-            }
-        }
-
-        [UITestMethod]
-        public void VectorChanged_ReplaceWhileAttached_OldDetachedNewAttached()
-        {
-            BehaviorCollection behaviorCollection = new BehaviorCollection();
-            behaviorCollection.Attach(new Button());
-
-            StubBehavior first = new StubBehavior();
-            behaviorCollection.Add(first);
-
-            StubBehavior second = new StubBehavior();
-
-            behaviorCollection[0] = second;
-
-            TestUtilities.AssertDetached(first);
-
-            TestUtilities.AssertAttached(second, behaviorCollection.AssociatedObject);
-        }
-
-
-        [UITestMethod]
-        public void VectorChanged_RemoveWhileNotAttached_DetachNotCalled()
-        {
-            BehaviorCollection behaviorCollection = new BehaviorCollection();
-
-            StubBehavior behavior = new StubBehavior();
             behaviorCollection.Add(behavior);
-            behaviorCollection.Remove(behavior);
+        }
 
+        behaviorCollection.Clear();
+
+        foreach (StubBehavior behavior in behaviorArray)
+        {
             TestUtilities.AssertNotDetached(behavior);
         }
+    }
 
-        [UITestMethod]
-        public void VectorChanged_RemoveWhileAttached_Detached()
+    [UITestMethod]
+    public void VectorChanged_ResetWhileAttached_AllDetached()
+    {
+        StubBehavior[] behaviorArray = { new StubBehavior(), new StubBehavior(), new StubBehavior() };
+
+        BehaviorCollection behaviorCollection = new BehaviorCollection();
+        behaviorCollection.Attach(new Button());
+
+        foreach (StubBehavior behavior in behaviorArray)
         {
-            BehaviorCollection behaviorCollection = new BehaviorCollection();
-            behaviorCollection.Attach(new ToggleSwitch());
-
-            StubBehavior behavior = new StubBehavior();
             behaviorCollection.Add(behavior);
-            behaviorCollection.Remove(behavior);
+        }
 
+        behaviorCollection.Clear();
+
+        foreach (StubBehavior behavior in behaviorArray)
+        {
             TestUtilities.AssertDetached(behavior);
         }
+    }
 
-        [UITestMethod]
-        public void VectorChanged_ResetWhileNotAttached_DetachNotCalled()
+    [UITestMethod]
+    public void Attach_MultipleBehaviors_AllAttached()
+    {
+        BehaviorCollection behaviorCollection = new BehaviorCollection();
+        behaviorCollection.Add(new StubBehavior());
+        behaviorCollection.Add(new StubBehavior());
+        behaviorCollection.Add(new StubBehavior());
+
+        Button button = new Button();
+        behaviorCollection.Attach(button);
+
+        Assert.AreEqual(button, behaviorCollection.AssociatedObject, "Attach should set the AssociatedObject to the given parameter.");
+
+        foreach (StubBehavior stub in behaviorCollection)
         {
-            StubBehavior[] behaviorArray = { new StubBehavior(), new StubBehavior(), new StubBehavior() };
-
-            BehaviorCollection behaviorCollection = new BehaviorCollection();
-            foreach (StubBehavior behavior in behaviorArray)
-            {
-                behaviorCollection.Add(behavior);
-            }
-
-            behaviorCollection.Clear();
-
-            foreach (StubBehavior behavior in behaviorArray)
-            {
-                TestUtilities.AssertNotDetached(behavior);
-            }
+            TestUtilities.AssertAttached(stub, button);
         }
+    }
 
-        [UITestMethod]
-        public void VectorChanged_ResetWhileAttached_AllDetached()
+    [UITestMethod]
+    public void Attach_Null_AttachNotCalledOnItems()
+    {
+        BehaviorCollection behaviorCollection = new BehaviorCollection();
+        behaviorCollection.Add(new StubBehavior());
+        behaviorCollection.Add(new StubBehavior());
+        behaviorCollection.Add(new StubBehavior());
+
+        behaviorCollection.Attach(null);
+
+        foreach (StubBehavior stub in behaviorCollection)
         {
-            StubBehavior[] behaviorArray = { new StubBehavior(), new StubBehavior(), new StubBehavior() };
-
-            BehaviorCollection behaviorCollection = new BehaviorCollection();
-            behaviorCollection.Attach(new Button());
-
-            foreach (StubBehavior behavior in behaviorArray)
-            {
-                behaviorCollection.Add(behavior);
-            }
-
-            behaviorCollection.Clear();
-
-            foreach (StubBehavior behavior in behaviorArray)
-            {
-                TestUtilities.AssertDetached(behavior);
-            }
+            TestUtilities.AssertNotAttached(stub);
         }
+    }
 
-        [UITestMethod]
-        public void Attach_MultipleBehaviors_AllAttached()
+    [UITestMethod]
+    public void Attach_MultipleObjects_ExceptionThrown()
+    {
+        BehaviorCollection behaviorCollection = new BehaviorCollection();
+        StubBehavior stub = new StubBehavior();
+        behaviorCollection.Attach(new Button());
+
+        TestUtilities.AssertThrowsInvalidOperationException(() => behaviorCollection.Attach(new StackPanel()));
+    }
+
+    [UITestMethod]
+    public void Attach_NonNullThenNull_ExceptionThrown()
+    {
+        BehaviorCollection behaviorCollection = new BehaviorCollection();
+        behaviorCollection.Add(new StubBehavior());
+
+        behaviorCollection.Attach(new Button());
+
+        TestUtilities.AssertThrowsInvalidOperationException(() => behaviorCollection.Attach(null));
+    }
+
+    [UITestMethod]
+    public void Attach_MultipleTimeSameObject_AttachCalledOnce()
+    {
+        BehaviorCollection behaviorCollection = new BehaviorCollection() { new StubBehavior() };
+
+        Button button = new Button();
+        behaviorCollection.Attach(button);
+        behaviorCollection.Attach(button);
+
+        // This method hard codes AttachCount == 1.
+        TestUtilities.AssertAttached((StubBehavior)behaviorCollection[0], button);
+    }
+
+    [UITestMethod]
+    public void Detach_NotAttached_DetachNotCalledOnItems()
+    {
+        BehaviorCollection behaviorCollection = new BehaviorCollection() { new StubBehavior() };
+
+        behaviorCollection.Detach();
+
+        TestUtilities.AssertNotDetached((StubBehavior)behaviorCollection[0]);
+    }
+
+    [UITestMethod]
+    public void Detach_Attached_AllItemsDetached()
+    {
+        BehaviorCollection behaviorCollection = new BehaviorCollection();
+        behaviorCollection.Add(new StubBehavior());
+        behaviorCollection.Add(new StubBehavior());
+        behaviorCollection.Add(new StubBehavior());
+
+        behaviorCollection.Attach(new Button());
+        behaviorCollection.Detach();
+
+        Assert.IsNull(behaviorCollection.AssociatedObject, "The AssociatedObject should be null after Detach.");
+
+        foreach (StubBehavior behavior in behaviorCollection)
         {
-            BehaviorCollection behaviorCollection = new BehaviorCollection();
-            behaviorCollection.Add(new StubBehavior());
-            behaviorCollection.Add(new StubBehavior());
-            behaviorCollection.Add(new StubBehavior());
-
-            Button button = new Button();
-            behaviorCollection.Attach(button);
-
-            Assert.AreEqual(button, behaviorCollection.AssociatedObject, "Attach should set the AssociatedObject to the given parameter.");
-
-            foreach (StubBehavior stub in behaviorCollection)
-            {
-                TestUtilities.AssertAttached(stub, button);
-            }
-        }
-
-        [UITestMethod]
-        public void Attach_Null_AttachNotCalledOnItems()
-        {
-            BehaviorCollection behaviorCollection = new BehaviorCollection();
-            behaviorCollection.Add(new StubBehavior());
-            behaviorCollection.Add(new StubBehavior());
-            behaviorCollection.Add(new StubBehavior());
-
-            behaviorCollection.Attach(null);
-
-            foreach (StubBehavior stub in behaviorCollection)
-            {
-                TestUtilities.AssertNotAttached(stub);
-            }
-        }
-
-        [UITestMethod]
-        public void Attach_MultipleObjects_ExceptionThrown()
-        {
-            BehaviorCollection behaviorCollection = new BehaviorCollection();
-            StubBehavior stub = new StubBehavior();
-            behaviorCollection.Attach(new Button());
-
-            TestUtilities.AssertThrowsInvalidOperationException(() => behaviorCollection.Attach(new StackPanel()));
-        }
-
-        [UITestMethod]
-        public void Attach_NonNullThenNull_ExceptionThrown()
-        {
-            BehaviorCollection behaviorCollection = new BehaviorCollection();
-            behaviorCollection.Add(new StubBehavior());
-
-            behaviorCollection.Attach(new Button());
-
-            TestUtilities.AssertThrowsInvalidOperationException(() => behaviorCollection.Attach(null));
-        }
-
-        [UITestMethod]
-        public void Attach_MultipleTimeSameObject_AttachCalledOnce()
-        {
-            BehaviorCollection behaviorCollection = new BehaviorCollection() { new StubBehavior() };
-
-            Button button = new Button();
-            behaviorCollection.Attach(button);
-            behaviorCollection.Attach(button);
-
-            // This method hard codes AttachCount == 1.
-            TestUtilities.AssertAttached((StubBehavior)behaviorCollection[0], button);
-        }
-
-        [UITestMethod]
-        public void Detach_NotAttached_DetachNotCalledOnItems()
-        {
-            BehaviorCollection behaviorCollection = new BehaviorCollection() { new StubBehavior() };
-
-            behaviorCollection.Detach();
-
-            TestUtilities.AssertNotDetached((StubBehavior)behaviorCollection[0]);
-        }
-
-        [UITestMethod]
-        public void Detach_Attached_AllItemsDetached()
-        {
-            BehaviorCollection behaviorCollection = new BehaviorCollection();
-            behaviorCollection.Add(new StubBehavior());
-            behaviorCollection.Add(new StubBehavior());
-            behaviorCollection.Add(new StubBehavior());
-
-            behaviorCollection.Attach(new Button());
-            behaviorCollection.Detach();
-
-            Assert.IsNull(behaviorCollection.AssociatedObject, "The AssociatedObject should be null after Detach.");
-
-            foreach (StubBehavior behavior in behaviorCollection)
-            {
-                TestUtilities.AssertDetached(behavior);
-            }
+            TestUtilities.AssertDetached(behavior);
         }
     }
 }

--- a/src/BehaviorsSDKManaged/ManagedUnitTests/BlankPage.xaml.cs
+++ b/src/BehaviorsSDKManaged/ManagedUnitTests/BlankPage.xaml.cs
@@ -1,21 +1,20 @@
 ﻿using Windows.UI.Xaml.Controls;
 
-namespace ManagedUnitTests
+namespace ManagedUnitTests;
+
+/// <summary>
+/// This page serves two purposes:
+/// 
+/// 1. Its existence causes the XAML compiler to implement IXamlMetadataProvider
+/// on the App class.  IXamlMetadataProvider is used by NavigateToPageAction and will
+/// only be implemented on App if there are XAML types defined in the project.
+/// 
+/// 2. It provides a target for the NavigateToPageAction to navigate to in tests.
+/// </summary>
+public sealed partial class BlankPage : Page
 {
-    /// <summary>
-    /// This page serves two purposes:
-    /// 
-    /// 1. Its existence causes the XAML compiler to implement IXamlMetadataProvider
-    /// on the App class.  IXamlMetadataProvider is used by NavigateToPageAction and will
-    /// only be implemented on App if there are XAML types defined in the project.
-    /// 
-    /// 2. It provides a target for the NavigateToPageAction to navigate to in tests.
-    /// </summary>
-    public sealed partial class BlankPage : Page
+    public BlankPage()
     {
-        public BlankPage()
-        {
-            this.InitializeComponent();
-        }
+        this.InitializeComponent();
     }
 }

--- a/src/BehaviorsSDKManaged/ManagedUnitTests/InteractionTest.cs
+++ b/src/BehaviorsSDKManaged/ManagedUnitTests/InteractionTest.cs
@@ -9,149 +9,148 @@ using Microsoft.VisualStudio.TestTools.UnitTesting.AppContainer;
 using Microsoft.Xaml.Interactivity;
 using Windows.UI.Xaml.Controls;
 
-namespace ManagedUnitTests
+namespace ManagedUnitTests;
+
+[TestClass]
+public class InteractionTest
 {
-    [TestClass]
-    public class InteractionTest
+    [UITestMethod]
+    public void SetBehaviors_MultipleBehaviors_AllAttached()
     {
-        [UITestMethod]
-        public void SetBehaviors_MultipleBehaviors_AllAttached()
+        BehaviorCollection behaviorCollection = new BehaviorCollection();
+        behaviorCollection.Add(new StubBehavior());
+        behaviorCollection.Add(new StubBehavior());
+        behaviorCollection.Add(new StubBehavior());
+
+        Button button = new Button();
+        Interaction.SetBehaviors(button, behaviorCollection);
+
+        foreach (StubBehavior behavior in behaviorCollection)
         {
-            BehaviorCollection behaviorCollection = new BehaviorCollection();
-            behaviorCollection.Add(new StubBehavior());
-            behaviorCollection.Add(new StubBehavior());
-            behaviorCollection.Add(new StubBehavior());
+            Assert.AreEqual(1, behavior.AttachCount, "Should only have called Attach once.");
+            Assert.AreEqual(0, behavior.DetachCount, "Should not have called Detach.");
+            Assert.AreEqual(button, behavior.AssociatedObject, "Should be attached to the host of the BehaviorCollection.");
+        }
+    }
 
-            Button button = new Button();
-            Interaction.SetBehaviors(button, behaviorCollection);
+    [UITestMethod]
+    public void SetBehaviors_MultipleSets_DoesNotReattach()
+    {
+        BehaviorCollection behaviorCollection = new BehaviorCollection() { new StubBehavior() };
 
-            foreach (StubBehavior behavior in behaviorCollection)
-            {
-                Assert.AreEqual(1, behavior.AttachCount, "Should only have called Attach once.");
-                Assert.AreEqual(0, behavior.DetachCount, "Should not have called Detach.");
-                Assert.AreEqual(button, behavior.AssociatedObject, "Should be attached to the host of the BehaviorCollection.");
-            }
+        Button button = new Button();
+        Interaction.SetBehaviors(button, behaviorCollection);
+        Interaction.SetBehaviors(button, behaviorCollection);
+
+        foreach (StubBehavior behavior in behaviorCollection)
+        {
+            Assert.AreEqual(1, behavior.AttachCount, "Should only have called Attach once.");
+        }
+    }
+
+    [UITestMethod]
+    public void SetBehaviors_CollectionThenNull_DeatchCollection()
+    {
+        BehaviorCollection behaviorCollection = new BehaviorCollection() { new StubBehavior() };
+
+        Button button = new Button();
+        Interaction.SetBehaviors(button, behaviorCollection);
+        Interaction.SetBehaviors(button, null);
+
+        foreach (StubBehavior behavior in behaviorCollection)
+        {
+            Assert.AreEqual(1, behavior.DetachCount, "Should only have called Detach once.");
+            Assert.IsNull(behavior.AssociatedObject, "AssociatedObject should be null after Detach.");
+        }
+    }
+
+    [UITestMethod]
+    public void SetBehaviors_NullThenNull_NoOp()
+    {
+        // As long as this doesn't crash/assert, we're good.
+
+        Button button = new Button();
+        Interaction.SetBehaviors(button, null);
+        Interaction.SetBehaviors(button, null);
+        Interaction.SetBehaviors(button, null);
+    }
+
+    [UITestMethod]
+
+    public void SetBehaviors_ManualDetachThenNull_DoesNotDoubleDetach()
+    {
+        BehaviorCollection behaviorCollection = new BehaviorCollection();
+        behaviorCollection.Add(new StubBehavior());
+        behaviorCollection.Add(new StubBehavior());
+        behaviorCollection.Add(new StubBehavior());
+
+        Button button = new Button();
+        Interaction.SetBehaviors(button, behaviorCollection);
+
+        foreach (StubBehavior behavior in behaviorCollection)
+        {
+            behavior.Detach();
         }
 
-        [UITestMethod]
-        public void SetBehaviors_MultipleSets_DoesNotReattach()
+        Interaction.SetBehaviors(button, null);
+
+        foreach (StubBehavior behavior in behaviorCollection)
         {
-            BehaviorCollection behaviorCollection = new BehaviorCollection() { new StubBehavior() };
+            Assert.AreEqual(1, behavior.DetachCount, "Setting BehaviorCollection to null should not call Detach on already Detached Behaviors.");
+            Assert.IsNull(behavior.AssociatedObject, "AssociatedObject should be null after Detach.");
+        }
+    }
 
-            Button button = new Button();
-            Interaction.SetBehaviors(button, behaviorCollection);
-            Interaction.SetBehaviors(button, behaviorCollection);
+    [UITestMethod]
+    public void ExecuteActions_NullParameters_ReturnsEmptyEnumerable()
+    {
+        // Mostly just want to test that this doesn't throw any exceptions.
+        IEnumerable<object> result = Interaction.ExecuteActions(null, null, null);
 
-            foreach (StubBehavior behavior in behaviorCollection)
-            {
-                Assert.AreEqual(1, behavior.AttachCount, "Should only have called Attach once.");
-            }
+        Assert.IsNotNull(result);
+        Assert.AreEqual(0, result.Count(), "Calling ExecuteActions with a null ActionCollection should return an empty enumerable.");
+    }
+
+    [UITestMethod]
+    public void ExecuteActions_MultipleActions_AllActionsExecuted()
+    {
+        ActionCollection actions = new ActionCollection();
+        actions.Add(new StubAction());
+        actions.Add(new StubAction());
+        actions.Add(new StubAction());
+
+        Button sender = new Button();
+        string parameterString = "TestString";
+
+        Interaction.ExecuteActions(sender, actions, parameterString);
+
+        foreach (StubAction action in actions)
+        {
+            Assert.AreEqual(1, action.ExecuteCount, "Each IAction should be executed once.");
+            Assert.AreEqual(sender, action.Sender, "Sender is passed to the actions.");
+            Assert.AreEqual(parameterString, action.Parameter, "Parameter is passed to the actions.");
+        }
+    }
+
+    [UITestMethod]
+    public void ExecuteActions_ActionsWithResults_ResultsInActionOrder()
+    {
+        string[] expectedReturnValues = { "A", "B", "C" };
+
+        ActionCollection actions = new ActionCollection();
+
+        foreach (string returnValue in expectedReturnValues)
+        {
+            actions.Add(new StubAction(returnValue));
         }
 
-        [UITestMethod]
-        public void SetBehaviors_CollectionThenNull_DeatchCollection()
+        List<object> results = Interaction.ExecuteActions(null, actions, null).ToList();
+
+        Assert.AreEqual(expectedReturnValues.Length, results.Count, "Should have the same number of results as IActions.");
+
+        for (int resultIndex = 0; resultIndex < results.Count; resultIndex++)
         {
-            BehaviorCollection behaviorCollection = new BehaviorCollection() { new StubBehavior() };
-
-            Button button = new Button();
-            Interaction.SetBehaviors(button, behaviorCollection);
-            Interaction.SetBehaviors(button, null);
-
-            foreach (StubBehavior behavior in behaviorCollection)
-            {
-                Assert.AreEqual(1, behavior.DetachCount, "Should only have called Detach once.");
-                Assert.IsNull(behavior.AssociatedObject, "AssociatedObject should be null after Detach.");
-            }
-        }
-
-        [UITestMethod]
-        public void SetBehaviors_NullThenNull_NoOp()
-        {
-            // As long as this doesn't crash/assert, we're good.
-
-            Button button = new Button();
-            Interaction.SetBehaviors(button, null);
-            Interaction.SetBehaviors(button, null);
-            Interaction.SetBehaviors(button, null);
-        }
-
-        [UITestMethod]
-
-        public void SetBehaviors_ManualDetachThenNull_DoesNotDoubleDetach()
-        {
-            BehaviorCollection behaviorCollection = new BehaviorCollection();
-            behaviorCollection.Add(new StubBehavior());
-            behaviorCollection.Add(new StubBehavior());
-            behaviorCollection.Add(new StubBehavior());
-
-            Button button = new Button();
-            Interaction.SetBehaviors(button, behaviorCollection);
-
-            foreach (StubBehavior behavior in behaviorCollection)
-            {
-                behavior.Detach();
-            }
-
-            Interaction.SetBehaviors(button, null);
-
-            foreach (StubBehavior behavior in behaviorCollection)
-            {
-                Assert.AreEqual(1, behavior.DetachCount, "Setting BehaviorCollection to null should not call Detach on already Detached Behaviors.");
-                Assert.IsNull(behavior.AssociatedObject, "AssociatedObject should be null after Detach.");
-            }
-        }
-
-        [UITestMethod]
-        public void ExecuteActions_NullParameters_ReturnsEmptyEnumerable()
-        {
-            // Mostly just want to test that this doesn't throw any exceptions.
-            IEnumerable<object> result = Interaction.ExecuteActions(null, null, null);
-
-            Assert.IsNotNull(result);
-            Assert.AreEqual(0, result.Count(), "Calling ExecuteActions with a null ActionCollection should return an empty enumerable.");
-        }
-
-        [UITestMethod]
-        public void ExecuteActions_MultipleActions_AllActionsExecuted()
-        {
-            ActionCollection actions = new ActionCollection();
-            actions.Add(new StubAction());
-            actions.Add(new StubAction());
-            actions.Add(new StubAction());
-
-            Button sender = new Button();
-            string parameterString = "TestString";
-
-            Interaction.ExecuteActions(sender, actions, parameterString);
-
-            foreach (StubAction action in actions)
-            {
-                Assert.AreEqual(1, action.ExecuteCount, "Each IAction should be executed once.");
-                Assert.AreEqual(sender, action.Sender, "Sender is passed to the actions.");
-                Assert.AreEqual(parameterString, action.Parameter, "Parameter is passed to the actions.");
-            }
-        }
-
-        [UITestMethod]
-        public void ExecuteActions_ActionsWithResults_ResultsInActionOrder()
-        {
-            string[] expectedReturnValues = { "A", "B", "C" };
-
-            ActionCollection actions = new ActionCollection();
-
-            foreach (string returnValue in expectedReturnValues)
-            {
-                actions.Add(new StubAction(returnValue));
-            }
-
-            List<object> results = Interaction.ExecuteActions(null, actions, null).ToList();
-
-            Assert.AreEqual(expectedReturnValues.Length, results.Count, "Should have the same number of results as IActions.");
-
-            for (int resultIndex = 0; resultIndex < results.Count; resultIndex++)
-            {
-                Assert.AreEqual(expectedReturnValues[resultIndex], results[resultIndex], "Results should be returned in the order of the actions in the ActionCollection.");
-            }
+            Assert.AreEqual(expectedReturnValues[resultIndex], results[resultIndex], "Results should be returned in the order of the actions in the ActionCollection.");
         }
     }
 }

--- a/src/BehaviorsSDKManaged/ManagedUnitTests/NavigateToPageActionTest.cs
+++ b/src/BehaviorsSDKManaged/ManagedUnitTests/NavigateToPageActionTest.cs
@@ -6,69 +6,68 @@ using Microsoft.VisualStudio.TestTools.UnitTesting.AppContainer;
 using Microsoft.Xaml.Interactivity;
 using Windows.UI.Xaml;
 
-namespace ManagedUnitTests
+namespace ManagedUnitTests;
+
+[TestClass]
+public class NavigateToPageActionTest
 {
-    [TestClass]
-    public class NavigateToPageActionTest
+    private static readonly string TestPageName = typeof(BlankPage).FullName;
+
+    [UITestMethod]
+    public void Execute_SenderImplementsINavigate_NavigatesToSender()
     {
-        private static readonly string TestPageName = typeof(BlankPage).FullName;
+        // Arrange
+        TestVisualTreeHelper visualTreeHelper = new TestVisualTreeHelper();
+        NavigateToPageAction action = new NavigateToPageAction(visualTreeHelper);
+        action.TargetPage = NavigateToPageActionTest.TestPageName;
+        NavigableStub navigateTarget = new NavigableStub();
 
-        [UITestMethod]
-        public void Execute_SenderImplementsINavigate_NavigatesToSender()
-        {
-            // Arrange
-            TestVisualTreeHelper visualTreeHelper = new TestVisualTreeHelper();
-            NavigateToPageAction action = new NavigateToPageAction(visualTreeHelper);
-            action.TargetPage = NavigateToPageActionTest.TestPageName;
-            NavigableStub navigateTarget = new NavigableStub();
+        // Act
+        bool success = (bool)action.Execute(navigateTarget, null);
 
-            // Act
-            bool success = (bool)action.Execute(navigateTarget, null);
+        // Assert
+        Assert.IsTrue(success);
+        Assert.AreEqual(NavigateToPageActionTest.TestPageName, navigateTarget.NavigatedTypeFullName);
+    }
 
-            // Assert
-            Assert.IsTrue(success);
-            Assert.AreEqual(NavigateToPageActionTest.TestPageName, navigateTarget.NavigatedTypeFullName);
-        }
+    [UITestMethod]
+    public void Execute_SenderDoesNotImplementINavigate_NavigatesToAncestor()
+    {
+        // Arrange
+        TestVisualTreeHelper visualTreeHelper = new TestVisualTreeHelper();
+        NavigateToPageAction action = new NavigateToPageAction(visualTreeHelper);
+        action.TargetPage = NavigateToPageActionTest.TestPageName;
+        DependencyObject sender = new SimpleDependencyObject();
+        NavigableStub navigateTarget = new NavigableStub();
+        visualTreeHelper.AddChild(navigateTarget, sender);
 
-        [UITestMethod]
-        public void Execute_SenderDoesNotImplementINavigate_NavigatesToAncestor()
-        {
-            // Arrange
-            TestVisualTreeHelper visualTreeHelper = new TestVisualTreeHelper();
-            NavigateToPageAction action = new NavigateToPageAction(visualTreeHelper);
-            action.TargetPage = NavigateToPageActionTest.TestPageName;
-            DependencyObject sender = new SimpleDependencyObject();
-            NavigableStub navigateTarget = new NavigableStub();
-            visualTreeHelper.AddChild(navigateTarget, sender);
+        // Act
+        bool success = (bool)action.Execute(sender, null);
 
-            // Act
-            bool success = (bool)action.Execute(sender, null);
+        // Assert
+        Assert.IsTrue(success);
+        Assert.AreEqual(NavigateToPageActionTest.TestPageName, navigateTarget.NavigatedTypeFullName);
+    }
 
-            // Assert
-            Assert.IsTrue(success);
-            Assert.AreEqual(NavigateToPageActionTest.TestPageName, navigateTarget.NavigatedTypeFullName);
-        }
+    [UITestMethod]
+    public void Execute_NoAncestorImplementsINavigate_Fails()
+    {
+        // Arrange
+        TestVisualTreeHelper visualTreeHelper = new TestVisualTreeHelper();
+        NavigateToPageAction action = new NavigateToPageAction(visualTreeHelper);
+        action.TargetPage = NavigateToPageActionTest.TestPageName;
+        DependencyObject sender = new SimpleDependencyObject();
+        DependencyObject parent = new SimpleDependencyObject();
+        visualTreeHelper.AddChild(parent, sender);
 
-        [UITestMethod]
-        public void Execute_NoAncestorImplementsINavigate_Fails()
-        {
-            // Arrange
-            TestVisualTreeHelper visualTreeHelper = new TestVisualTreeHelper();
-            NavigateToPageAction action = new NavigateToPageAction(visualTreeHelper);
-            action.TargetPage = NavigateToPageActionTest.TestPageName;
-            DependencyObject sender = new SimpleDependencyObject();
-            DependencyObject parent = new SimpleDependencyObject();
-            visualTreeHelper.AddChild(parent, sender);
+        // Act
+        bool success = (bool)action.Execute(sender, null);
 
-            // Act
-            bool success = (bool)action.Execute(sender, null);
+        // Assert
+        Assert.IsFalse(success);
+    }
 
-            // Assert
-            Assert.IsFalse(success);
-        }
-
-        private class SimpleDependencyObject : DependencyObject
-        {
-        }
+    private class SimpleDependencyObject : DependencyObject
+    {
     }
 }

--- a/src/BehaviorsSDKManaged/ManagedUnitTests/Stubs.cs
+++ b/src/BehaviorsSDKManaged/ManagedUnitTests/Stubs.cs
@@ -7,414 +7,413 @@ using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Data;
 using Windows.UI.Xaml.Navigation;
 
-namespace ManagedUnitTests
+namespace ManagedUnitTests;
+
+public class StubBehavior : DependencyObject, IBehavior
 {
-    public class StubBehavior : DependencyObject, IBehavior
+    public int AttachCount
     {
-        public int AttachCount
-        {
-            get;
-            private set;
-        }
+        get;
+        private set;
+    }
 
-        public int DetachCount
-        {
-            get;
-            private set;
-        }
+    public int DetachCount
+    {
+        get;
+        private set;
+    }
 
-        public ActionCollection Actions
-        {
-            get;
-            private set;
-        }
+    public ActionCollection Actions
+    {
+        get;
+        private set;
+    }
 
-        public StubBehavior()
-        {
-            this.Actions = new ActionCollection();
-        }
+    public StubBehavior()
+    {
+        this.Actions = new ActionCollection();
+    }
 
-        public DependencyObject AssociatedObject
-        {
-            get;
-            private set;
-        }
+    public DependencyObject AssociatedObject
+    {
+        get;
+        private set;
+    }
 
-        public void Attach(DependencyObject dependencyObject)
-        {
-            this.AssociatedObject = dependencyObject;
-            this.AttachCount++;
-        }
+    public void Attach(DependencyObject dependencyObject)
+    {
+        this.AssociatedObject = dependencyObject;
+        this.AttachCount++;
+    }
 
-        public void Detach()
-        {
-            this.AssociatedObject = null;
-            this.DetachCount++;
-        }
+    public void Detach()
+    {
+        this.AssociatedObject = null;
+        this.DetachCount++;
+    }
 
-        public IEnumerable<object> Execute(object sender, object parameter)
+    public IEnumerable<object> Execute(object sender, object parameter)
+    {
+        return Interaction.ExecuteActions(sender, this.Actions, parameter);
+    }
+}
+
+public class StubAction : DependencyObject, IAction
+{
+    private readonly object _returnValue;
+
+    public StubAction()
+    {
+        this._returnValue = null;
+    }
+
+    public StubAction(object returnValue)
+    {
+        this._returnValue = returnValue;
+    }
+
+    public object Sender
+    {
+        get;
+        private set;
+    }
+
+    public object Parameter
+    {
+        get;
+        private set;
+    }
+
+    public int ExecuteCount
+    {
+        get;
+        private set;
+    }
+
+    public object Execute(object sender, object parameter)
+    {
+        this.ExecuteCount++;
+        this.Sender = sender;
+        this.Parameter = parameter;
+        return this._returnValue;
+    }
+}
+
+public class EventObjectStub : DependencyObject
+{
+    public string Name;
+
+    public delegate void IntEventHandler(int i);
+
+    public event EventHandler StubEvent;
+    public event EventHandler StubEvent2;
+    public event IntEventHandler IntEvent;
+    public event EventHandler Click;
+
+    public EventObjectStub(string name = null)
+    {
+        this.Name = name;
+    }
+
+    public void FireStubEvent()
+    {
+        if (this.StubEvent != null)
         {
-            return Interaction.ExecuteActions(sender, this.Actions, parameter);
+            this.StubEvent.Invoke(this, new EventArgs());
         }
     }
 
-    public class StubAction : DependencyObject, IAction
+    public void FireClickEvent()
     {
-        private readonly object _returnValue;
-
-        public StubAction()
+        if (this.Click != null)
         {
-            this._returnValue = null;
-        }
-
-        public StubAction(object returnValue)
-        {
-            this._returnValue = returnValue;
-        }
-
-        public object Sender
-        {
-            get;
-            private set;
-        }
-
-        public object Parameter
-        {
-            get;
-            private set;
-        }
-
-        public int ExecuteCount
-        {
-            get;
-            private set;
-        }
-
-        public object Execute(object sender, object parameter)
-        {
-            this.ExecuteCount++;
-            this.Sender = sender;
-            this.Parameter = parameter;
-            return this._returnValue;
+            this.Click.Invoke(this, new EventArgs());
         }
     }
 
-    public class EventObjectStub : DependencyObject
+    public void FireStubEvent2()
     {
-        public string Name;
-
-        public delegate void IntEventHandler(int i);
-
-        public event EventHandler StubEvent;
-        public event EventHandler StubEvent2;
-        public event IntEventHandler IntEvent;
-        public event EventHandler Click;
-
-        public EventObjectStub(string name = null)
+        if (this.StubEvent2 != null)
         {
-            this.Name = name;
-        }
-
-        public void FireStubEvent()
-        {
-            if (this.StubEvent != null)
-            {
-                this.StubEvent.Invoke(this, new EventArgs());
-            }
-        }
-
-        public void FireClickEvent()
-        {
-            if (this.Click != null)
-            {
-                this.Click.Invoke(this, new EventArgs());
-            }
-        }
-
-        public void FireStubEvent2()
-        {
-            if (this.StubEvent2 != null)
-            {
-                this.StubEvent2(this, new EventArgs());
-            }
-        }
-
-        public void FireIntEvent()
-        {
-            if (this.IntEvent != null)
-            {
-                this.IntEvent(0);
-            }
+            this.StubEvent2(this, new EventArgs());
         }
     }
 
-    public class ClrEventClassStub
+    public void FireIntEvent()
     {
-        public event EventHandler Event;
-        public static readonly string EventName = "Event";
-
-        public void Fire()
+        if (this.IntEvent != null)
         {
-            if (this.Event != null)
-            {
-                this.Event(this, EventArgs.Empty);
-            }
+            this.IntEvent(0);
         }
     }
+}
 
-    public class ChangePropertyActionTargetStub
+public class ClrEventClassStub
+{
+    public event EventHandler Event;
+    public static readonly string EventName = "Event";
+
+    public void Fire()
     {
-        public const string DoublePropertyName = "DoubleProperty";
-        public const string StringPropertyName = "StringProperty";
-        public const string ObjectPropertyName = "ObjectProperty";
-        public const string AdditivePropertyName = "AdditiveProperty";
-        public const string WriteOnlyPropertyName = "WriteOnlyProperty";
-
-        public double DoubleProperty
+        if (this.Event != null)
         {
-            get;
-            set;
-        }
-
-        public string StringProperty
-        {
-            get;
-            set;
-        }
-
-        public object ObjectProperty
-        {
-            get;
-            set;
-        }
-
-        public object WriteOnlyProperty
-        {
-            set
-            {
-            }
+            this.Event(this, EventArgs.Empty);
         }
     }
+}
 
-    public class NavigateToPageActionTargetStub : Frame
+public class ChangePropertyActionTargetStub
+{
+    public const string DoublePropertyName = "DoubleProperty";
+    public const string StringPropertyName = "StringProperty";
+    public const string ObjectPropertyName = "ObjectProperty";
+    public const string AdditivePropertyName = "AdditiveProperty";
+    public const string WriteOnlyPropertyName = "WriteOnlyProperty";
+
+    public double DoubleProperty
     {
-        public bool HasNavigated
-        {
-            get;
-            private set;
-        }
-
-        public object LastParameter
-        {
-            get;
-            private set;
-        }
-
-        public new bool Navigate(Type sourcePageType)
-        {
-            this.HasNavigated = true;
-            return true;
-        }
-
-        public new bool Navigate(Type sourcePageType, object parameter)
-        {
-            this.HasNavigated = true;
-            this.LastParameter = parameter;
-
-            return true;
-        }
+        get;
+        set;
     }
 
-    public class MethodObjectStub : DependencyObject
+    public string StringProperty
     {
-        public string LastMethodCalled
-        {
-            get;
-            private set;
-        }
-
-        public MethodObjectStub()
-        {
-            this.LastMethodCalled = "None";
-        }
-
-        public void UniqueMethodWithNoParameters()
-        {
-            this.LastMethodCalled = "UniqueMethodWithNoParameters";
-        }
-
-        public void DuplicatedMethod()
-        {
-            this.LastMethodCalled = "DuplicatedMethodWithNoParameters";
-        }
-
-        public void DuplicatedMethod(object sender, EventArgs args)
-        {
-            this.LastMethodCalled = "DuplicatedMethodWithEventHandlerSignature";
-        }
-
-        public void DuplicatedMethod(object sender, StubEventArgs args)
-        {
-            this.LastMethodCalled = "DuplicatedMethodWithStubEventArgsSignature";
-        }
-
-        private void AnotherDuplicateMethod()
-        {
-            this.LastMethodCalled = "HiddenAnotherDuplicateMethod";
-        }
-
-        public void AnotherDuplicateMethod(object sender, object args)
-        {
-            this.LastMethodCalled = "AnotherDuplicateMethod";
-        }
-
-        public void AnotherDuplicateMethod(object sender, int args)
-        {
-            this.LastMethodCalled = "AnotherDuplicateMethodWithValueType";
-        }
-
-        public void IndistinguishableWithNullMethod(object sender, Nullable<bool> args)
-        {
-            this.LastMethodCalled = "NullableIndistinguishableWithNullMethod";
-        }
-
-        public void IndistinguishableWithNullMethod(object sender, Button args)
-        {
-            this.LastMethodCalled = "ButtonIndistinguishableWithNullMethod";
-        }
-
-        public void IndistinguishableWithNullMethod(object sender, bool args)
-        {
-            this.LastMethodCalled = "BoolIndistinguishableWithNullMethod";
-        }
-
-        public int IncompatibleReturnType()
-        {
-            this.LastMethodCalled = "IncompatibleReturnType";
-            return 0;
-        }
-
-        public void IncompatibleParameters(double d)
-        {
-            this.LastMethodCalled = "IncompatibleParameters";
-        }
+        get;
+        set;
     }
 
-    public class StubEventArgs : EventArgs
+    public object ObjectProperty
     {
+        get;
+        set;
     }
 
-    public class StubCommand : ICommand
+    public object WriteOnlyProperty
     {
-        public event EventHandler CanExecuteChanged;
-
-        protected virtual void OnCanExecuteChanged(EventArgs e)
+        set
         {
-            CanExecuteChanged?.Invoke(this, e);
-        }
-
-        public int ExecutionCount
-        {
-            get;
-            private set;
-        }
-
-        public object LastParameter
-        {
-            get;
-            private set;
-        }
-
-        public bool CanExecute(object parameter)
-        {
-            return true;
-        }
-
-        public void Execute(object parameter)
-        {
-            this.ExecutionCount++;
-            string stringParam = parameter as string;
-            this.LastParameter = parameter;
         }
     }
+}
 
-    public class BoolToTestParameterConverter : IValueConverter
+public class NavigateToPageActionTargetStub : Frame
+{
+    public bool HasNavigated
     {
-        public object Convert(object value, Type targetType, object parameter, string language)
-        {
-            bool boolValue;
-            bool boolParameter;
-            if (value == null ||
-                !bool.TryParse(value.ToString(), out boolValue) ||
-                !bool.TryParse(parameter.ToString(), out boolParameter))
-            {
-                return null;
-            }
-
-            string convertedValue = boolValue && boolParameter ? "TrueParameter" : "FalseParameter";
-            return convertedValue + language;
-        }
-
-        public object ConvertBack(object value, Type targetType, object parameter, string language)
-        {
-            throw new NotImplementedException();
-        }
+        get;
+        private set;
     }
 
-    public class StubFrame : Frame
+    public object LastParameter
     {
-        public bool NavigatedTo
-        {
-            get;
-            private set;
-        }
-
-        public object Parameter
-        {
-            get;
-            private set;
-        }
-
-        public StubFrame()
-        {
-            this.Navigated += this.OnNavigated;
-        }
-
-        private void OnNavigated(object sender, NavigationEventArgs e)
-        {
-            this.NavigatedTo = true;
-            this.Parameter = e.Parameter;
-        }
+        get;
+        private set;
     }
 
-    public class StubPage : Page
+    public new bool Navigate(Type sourcePageType)
     {
+        this.HasNavigated = true;
+        return true;
     }
 
-    public class NavigableStub : DependencyObject, INavigate
+    public new bool Navigate(Type sourcePageType, object parameter)
     {
-        public string NavigatedTypeFullName
-        {
-            get;
-            private set;
-        }
+        this.HasNavigated = true;
+        this.LastParameter = parameter;
 
-        public bool Navigate(Type sourcePageType)
-        {
-            this.NavigatedTypeFullName = sourcePageType.FullName;
-            return true;
-        }
+        return true;
+    }
+}
+
+public class MethodObjectStub : DependencyObject
+{
+    public string LastMethodCalled
+    {
+        get;
+        private set;
     }
 
-    public static class BehaviorTestHelper
+    public MethodObjectStub()
     {
-        public static T CreateNamedElement<T>(string name) where T : FrameworkElement, new()
+        this.LastMethodCalled = "None";
+    }
+
+    public void UniqueMethodWithNoParameters()
+    {
+        this.LastMethodCalled = "UniqueMethodWithNoParameters";
+    }
+
+    public void DuplicatedMethod()
+    {
+        this.LastMethodCalled = "DuplicatedMethodWithNoParameters";
+    }
+
+    public void DuplicatedMethod(object sender, EventArgs args)
+    {
+        this.LastMethodCalled = "DuplicatedMethodWithEventHandlerSignature";
+    }
+
+    public void DuplicatedMethod(object sender, StubEventArgs args)
+    {
+        this.LastMethodCalled = "DuplicatedMethodWithStubEventArgsSignature";
+    }
+
+    private void AnotherDuplicateMethod()
+    {
+        this.LastMethodCalled = "HiddenAnotherDuplicateMethod";
+    }
+
+    public void AnotherDuplicateMethod(object sender, object args)
+    {
+        this.LastMethodCalled = "AnotherDuplicateMethod";
+    }
+
+    public void AnotherDuplicateMethod(object sender, int args)
+    {
+        this.LastMethodCalled = "AnotherDuplicateMethodWithValueType";
+    }
+
+    public void IndistinguishableWithNullMethod(object sender, Nullable<bool> args)
+    {
+        this.LastMethodCalled = "NullableIndistinguishableWithNullMethod";
+    }
+
+    public void IndistinguishableWithNullMethod(object sender, Button args)
+    {
+        this.LastMethodCalled = "ButtonIndistinguishableWithNullMethod";
+    }
+
+    public void IndistinguishableWithNullMethod(object sender, bool args)
+    {
+        this.LastMethodCalled = "BoolIndistinguishableWithNullMethod";
+    }
+
+    public int IncompatibleReturnType()
+    {
+        this.LastMethodCalled = "IncompatibleReturnType";
+        return 0;
+    }
+
+    public void IncompatibleParameters(double d)
+    {
+        this.LastMethodCalled = "IncompatibleParameters";
+    }
+}
+
+public class StubEventArgs : EventArgs
+{
+}
+
+public class StubCommand : ICommand
+{
+    public event EventHandler CanExecuteChanged;
+
+    protected virtual void OnCanExecuteChanged(EventArgs e)
+    {
+        CanExecuteChanged?.Invoke(this, e);
+    }
+
+    public int ExecutionCount
+    {
+        get;
+        private set;
+    }
+
+    public object LastParameter
+    {
+        get;
+        private set;
+    }
+
+    public bool CanExecute(object parameter)
+    {
+        return true;
+    }
+
+    public void Execute(object parameter)
+    {
+        this.ExecutionCount++;
+        string stringParam = parameter as string;
+        this.LastParameter = parameter;
+    }
+}
+
+public class BoolToTestParameterConverter : IValueConverter
+{
+    public object Convert(object value, Type targetType, object parameter, string language)
+    {
+        bool boolValue;
+        bool boolParameter;
+        if (value == null ||
+            !bool.TryParse(value.ToString(), out boolValue) ||
+            !bool.TryParse(parameter.ToString(), out boolParameter))
         {
-            T frameworkElement = new T()
-            {
-                Name = name
-            };
-            return frameworkElement;
+            return null;
         }
+
+        string convertedValue = boolValue && boolParameter ? "TrueParameter" : "FalseParameter";
+        return convertedValue + language;
+    }
+
+    public object ConvertBack(object value, Type targetType, object parameter, string language)
+    {
+        throw new NotImplementedException();
+    }
+}
+
+public class StubFrame : Frame
+{
+    public bool NavigatedTo
+    {
+        get;
+        private set;
+    }
+
+    public object Parameter
+    {
+        get;
+        private set;
+    }
+
+    public StubFrame()
+    {
+        this.Navigated += this.OnNavigated;
+    }
+
+    private void OnNavigated(object sender, NavigationEventArgs e)
+    {
+        this.NavigatedTo = true;
+        this.Parameter = e.Parameter;
+    }
+}
+
+public class StubPage : Page
+{
+}
+
+public class NavigableStub : DependencyObject, INavigate
+{
+    public string NavigatedTypeFullName
+    {
+        get;
+        private set;
+    }
+
+    public bool Navigate(Type sourcePageType)
+    {
+        this.NavigatedTypeFullName = sourcePageType.FullName;
+        return true;
+    }
+}
+
+public static class BehaviorTestHelper
+{
+    public static T CreateNamedElement<T>(string name) where T : FrameworkElement, new()
+    {
+        T frameworkElement = new T()
+        {
+            Name = name
+        };
+        return frameworkElement;
     }
 }

--- a/src/BehaviorsSDKManaged/ManagedUnitTests/TestUitilties.cs
+++ b/src/BehaviorsSDKManaged/ManagedUnitTests/TestUitilties.cs
@@ -5,44 +5,43 @@ using System;
 using Windows.UI.Xaml;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-namespace ManagedUnitTests
+namespace ManagedUnitTests;
+
+public static class TestUtilities
 {
-    public static class TestUtilities
+    /// <summary>
+    /// Handles the difference between InvalidOperationException in managed and native.
+    /// </summary>
+    public static void AssertThrowsInvalidOperationException(Action action)
     {
-        /// <summary>
-        /// Handles the difference between InvalidOperationException in managed and native.
-        /// </summary>
-        public static void AssertThrowsInvalidOperationException(Action action)
-        {
-            Assert.ThrowsException<InvalidOperationException>(action);
-        }
+        Assert.ThrowsException<InvalidOperationException>(action);
+    }
 
-        public static void AssertThrowsArgumentException(Action action)
-        {
-            Assert.ThrowsException<ArgumentException>(action);
-        }
+    public static void AssertThrowsArgumentException(Action action)
+    {
+        Assert.ThrowsException<ArgumentException>(action);
+    }
 
-        public static void AssertDetached(StubBehavior behavior)
-        {
-            Assert.AreEqual(1, behavior.DetachCount, "The Behavior should be detached.");
-            Assert.IsNull(behavior.AssociatedObject, "A Detached Behavior should have a null AssociatedObject.");
-        }
+    public static void AssertDetached(StubBehavior behavior)
+    {
+        Assert.AreEqual(1, behavior.DetachCount, "The Behavior should be detached.");
+        Assert.IsNull(behavior.AssociatedObject, "A Detached Behavior should have a null AssociatedObject.");
+    }
 
-        public static void AssertNotDetached(StubBehavior behavior)
-        {
-            Assert.AreEqual(0, behavior.DetachCount, "The Behavior should not be detached.");
-        }
+    public static void AssertNotDetached(StubBehavior behavior)
+    {
+        Assert.AreEqual(0, behavior.DetachCount, "The Behavior should not be detached.");
+    }
 
-        public static void AssertAttached(StubBehavior behavior, DependencyObject associatedObject)
-        {
-            Assert.AreEqual(1, behavior.AttachCount, "The behavior should be attached.");
-            Assert.AreEqual(associatedObject, behavior.AssociatedObject, "The AssociatedObject of the Behavior should be what it was attached to.");
-        }
+    public static void AssertAttached(StubBehavior behavior, DependencyObject associatedObject)
+    {
+        Assert.AreEqual(1, behavior.AttachCount, "The behavior should be attached.");
+        Assert.AreEqual(associatedObject, behavior.AssociatedObject, "The AssociatedObject of the Behavior should be what it was attached to.");
+    }
 
-        public static void AssertNotAttached(StubBehavior behavior)
-        {
-            Assert.AreEqual(0, behavior.AttachCount, "The behavior should not be attached.");
-            Assert.IsNull(behavior.AssociatedObject, "The AssociatedObject should be null for a non-attached Behavior.");
-        }
+    public static void AssertNotAttached(StubBehavior behavior)
+    {
+        Assert.AreEqual(0, behavior.AttachCount, "The behavior should not be attached.");
+        Assert.IsNull(behavior.AssociatedObject, "The AssociatedObject should be null for a non-attached Behavior.");
     }
 }

--- a/src/BehaviorsSDKManaged/ManagedUnitTests/TestVisualTreeHelper.cs
+++ b/src/BehaviorsSDKManaged/ManagedUnitTests/TestVisualTreeHelper.cs
@@ -2,30 +2,29 @@
 using Microsoft.Xaml.Interactivity.Utility;
 using Windows.UI.Xaml;
 
-namespace ManagedUnitTests
+namespace ManagedUnitTests;
+
+/// <summary>
+/// Test impementation of VisualTreeHelper.  Enables unit testing of code that
+/// uses VisualTreeHelper without needing a real visual tree.
+/// </summary>
+internal class TestVisualTreeHelper : IVisualTreeHelper
 {
-    /// <summary>
-    /// Test impementation of VisualTreeHelper.  Enables unit testing of code that
-    /// uses VisualTreeHelper without needing a real visual tree.
-    /// </summary>
-    internal class TestVisualTreeHelper : IVisualTreeHelper
+    private Dictionary<DependencyObject, DependencyObject> _parents = new Dictionary<DependencyObject, DependencyObject>();
+
+    public void AddChild(DependencyObject parent, DependencyObject child)
     {
-        private Dictionary<DependencyObject, DependencyObject> _parents = new Dictionary<DependencyObject, DependencyObject>();
-
-        public void AddChild(DependencyObject parent, DependencyObject child)
-        {
-            this._parents[child] = parent;
-        }
-
-        #region IVisualTreeHelper implementation
-
-        public DependencyObject GetParent(DependencyObject child)
-        {
-            DependencyObject parent;
-            this._parents.TryGetValue(child, out parent);
-            return parent;
-        }
-
-        #endregion
+        this._parents[child] = parent;
     }
+
+    #region IVisualTreeHelper implementation
+
+    public DependencyObject GetParent(DependencyObject child)
+    {
+        DependencyObject parent;
+        this._parents.TryGetValue(child, out parent);
+        return parent;
+    }
+
+    #endregion
 }

--- a/src/BehaviorsSDKManaged/ManagedUnitTests/UnitTestApp.xaml.cs
+++ b/src/BehaviorsSDKManaged/ManagedUnitTests/UnitTestApp.xaml.cs
@@ -15,88 +15,87 @@ using Windows.UI.Xaml.Input;
 using Windows.UI.Xaml.Media;
 using Windows.UI.Xaml.Navigation;
 
-namespace ManagedUnitTests
+namespace ManagedUnitTests;
+
+/// <summary>
+/// Provides application-specific behavior to supplement the default Application class.
+/// </summary>
+sealed partial class App : Application
 {
     /// <summary>
-    /// Provides application-specific behavior to supplement the default Application class.
+    /// Initializes the singleton application object.  This is the first line of authored code
+    /// executed, and as such is the logical equivalent of main() or WinMain().
     /// </summary>
-    sealed partial class App : Application
+    public App()
     {
-        /// <summary>
-        /// Initializes the singleton application object.  This is the first line of authored code
-        /// executed, and as such is the logical equivalent of main() or WinMain().
-        /// </summary>
-        public App()
-        {
-            this.InitializeComponent();
-            this.Suspending += OnSuspending;
-        }
+        this.InitializeComponent();
+        this.Suspending += OnSuspending;
+    }
 
-        /// <summary>
-        /// Invoked when the application is launched normally by the end user.  Other entry points
-        /// will be used such as when the application is launched to open a specific file.
-        /// </summary>
-        /// <param name="e">Details about the launch request and process.</param>
-        protected override void OnLaunched(LaunchActivatedEventArgs e)
-        {
+    /// <summary>
+    /// Invoked when the application is launched normally by the end user.  Other entry points
+    /// will be used such as when the application is launched to open a specific file.
+    /// </summary>
+    /// <param name="e">Details about the launch request and process.</param>
+    protected override void OnLaunched(LaunchActivatedEventArgs e)
+    {
 
 #if DEBUG
-            if (System.Diagnostics.Debugger.IsAttached)
-            {
-                this.DebugSettings.EnableFrameRateCounter = true;
-            }
+        if (System.Diagnostics.Debugger.IsAttached)
+        {
+            this.DebugSettings.EnableFrameRateCounter = true;
+        }
 #endif
 
-            Frame rootFrame = Window.Current.Content as Frame;
+        Frame rootFrame = Window.Current.Content as Frame;
 
-            // Do not repeat app initialization when the Window already has content,
-            // just ensure that the window is active
-            if (rootFrame == null)
+        // Do not repeat app initialization when the Window already has content,
+        // just ensure that the window is active
+        if (rootFrame == null)
+        {
+            // Create a Frame to act as the navigation context and navigate to the first page
+            rootFrame = new Frame();
+
+            rootFrame.NavigationFailed += OnNavigationFailed;
+
+            if (e.PreviousExecutionState == ApplicationExecutionState.Terminated)
             {
-                // Create a Frame to act as the navigation context and navigate to the first page
-                rootFrame = new Frame();
-
-                rootFrame.NavigationFailed += OnNavigationFailed;
-
-                if (e.PreviousExecutionState == ApplicationExecutionState.Terminated)
-                {
-                    //TODO: Load state from previously suspended application
-                }
-
-                // Place the frame in the current Window
-                Window.Current.Content = rootFrame;
+                //TODO: Load state from previously suspended application
             }
-            
-            Microsoft.VisualStudio.TestPlatform.TestExecutor.UnitTestClient.CreateDefaultUI();
 
-            // Ensure the current window is active
-            Window.Current.Activate();
-
-            Microsoft.VisualStudio.TestPlatform.TestExecutor.UnitTestClient.Run(e.Arguments);
+            // Place the frame in the current Window
+            Window.Current.Content = rootFrame;
         }
+        
+        Microsoft.VisualStudio.TestPlatform.TestExecutor.UnitTestClient.CreateDefaultUI();
 
-        /// <summary>
-        /// Invoked when Navigation to a certain page fails
-        /// </summary>
-        /// <param name="sender">The Frame which failed navigation</param>
-        /// <param name="e">Details about the navigation failure</param>
-        void OnNavigationFailed(object sender, NavigationFailedEventArgs e)
-        {
-            throw new Exception("Failed to load Page " + e.SourcePageType.FullName);
-        }
+        // Ensure the current window is active
+        Window.Current.Activate();
 
-        /// <summary>
-        /// Invoked when application execution is being suspended.  Application state is saved
-        /// without knowing whether the application will be terminated or resumed with the contents
-        /// of memory still intact.
-        /// </summary>
-        /// <param name="sender">The source of the suspend request.</param>
-        /// <param name="e">Details about the suspend request.</param>
-        private void OnSuspending(object sender, SuspendingEventArgs e)
-        {
-            var deferral = e.SuspendingOperation.GetDeferral();
-            //TODO: Save application state and stop any background activity
-            deferral.Complete();
-        }
+        Microsoft.VisualStudio.TestPlatform.TestExecutor.UnitTestClient.Run(e.Arguments);
+    }
+
+    /// <summary>
+    /// Invoked when Navigation to a certain page fails
+    /// </summary>
+    /// <param name="sender">The Frame which failed navigation</param>
+    /// <param name="e">Details about the navigation failure</param>
+    void OnNavigationFailed(object sender, NavigationFailedEventArgs e)
+    {
+        throw new Exception("Failed to load Page " + e.SourcePageType.FullName);
+    }
+
+    /// <summary>
+    /// Invoked when application execution is being suspended.  Application state is saved
+    /// without knowing whether the application will be terminated or resumed with the contents
+    /// of memory still intact.
+    /// </summary>
+    /// <param name="sender">The source of the suspend request.</param>
+    /// <param name="e">Details about the suspend request.</param>
+    private void OnSuspending(object sender, SuspendingEventArgs e)
+    {
+        var deferral = e.SuspendingOperation.GetDeferral();
+        //TODO: Save application state and stop any background activity
+        deferral.Complete();
     }
 }

--- a/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactivity.Design/MetadataTableProvider.DesignerIsolation.cs
+++ b/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactivity.Design/MetadataTableProvider.DesignerIsolation.cs
@@ -4,53 +4,52 @@
 using System;
 using Microsoft.Xaml.Interactivity;
 
-namespace Microsoft.Xaml.Interactivity.Design
+namespace Microsoft.Xaml.Interactivity.Design;
+
+partial class MetadataTableProvider
 {
-    partial class MetadataTableProvider
+    private void AddAttribute(Type type, Attribute attribute)
     {
-        private void AddAttribute(Type type, Attribute attribute)
-        {
-            _attributeTableBuilder.AddCustomAttributes(type, attribute);
-        }
+        _attributeTableBuilder.AddCustomAttributes(type, attribute);
+    }
 
-        private void AddAttributes(Type type, params Attribute[] attributes)
+    private void AddAttributes(Type type, params Attribute[] attributes)
+    {
+        foreach (Attribute attribute in attributes)
         {
-            foreach (Attribute attribute in attributes)
-            {
-                AddAttribute(type, attribute);
-            }
+            AddAttribute(type, attribute);
         }
+    }
 
-        private void AddAttribute(Type type, string propertyName, Attribute attribute)
-        {
-            _attributeTableBuilder.AddCustomAttributes(type, propertyName, attribute);
-        }
+    private void AddAttribute(Type type, string propertyName, Attribute attribute)
+    {
+        _attributeTableBuilder.AddCustomAttributes(type, propertyName, attribute);
+    }
 
-        private void AddAttributes(Type type, string propertyName, params Attribute[] attributes)
+    private void AddAttributes(Type type, string propertyName, params Attribute[] attributes)
+    {
+        foreach (Attribute attribute in attributes)
         {
-            foreach (Attribute attribute in attributes)
-            {
-                AddAttribute(type, propertyName, attribute);
-            }
+            AddAttribute(type, propertyName, attribute);
         }
+    }
 
-        /// <summary>
-        /// This class contains the types used by the older Extensibility APIs.
-        /// </summary>
-        private static class Targets
-        {
-            internal static readonly Type IncrementalUpdateBehavior = typeof(IncrementalUpdateBehavior);
-            internal static readonly Type EventTriggerBehavior = typeof(EventTriggerBehavior);
-            internal static readonly Type DataTriggerBehavior = typeof(DataTriggerBehavior);
-            internal static readonly Type ChangePropertyAction = typeof(ChangePropertyAction);
-            internal static readonly Type InvokeCommandAction = typeof(InvokeCommandAction);
-            internal static readonly Type ControlStoryboardAction = typeof(ControlStoryboardAction);
-            internal static readonly Type GoToStateAction = typeof(GoToStateAction);
-            internal static readonly Type NavigateToPageAction = typeof(NavigateToPageAction);
-            internal static readonly Type PlaySoundAction = typeof(PlaySoundAction);
-            internal static readonly Type CallMethodAction = typeof(CallMethodAction);
-            internal static readonly Type ActionCollection = typeof(ActionCollection);
-            internal static readonly Type BehaviorCollection = typeof(BehaviorCollection);
-        }
+    /// <summary>
+    /// This class contains the types used by the older Extensibility APIs.
+    /// </summary>
+    private static class Targets
+    {
+        internal static readonly Type IncrementalUpdateBehavior = typeof(IncrementalUpdateBehavior);
+        internal static readonly Type EventTriggerBehavior = typeof(EventTriggerBehavior);
+        internal static readonly Type DataTriggerBehavior = typeof(DataTriggerBehavior);
+        internal static readonly Type ChangePropertyAction = typeof(ChangePropertyAction);
+        internal static readonly Type InvokeCommandAction = typeof(InvokeCommandAction);
+        internal static readonly Type ControlStoryboardAction = typeof(ControlStoryboardAction);
+        internal static readonly Type GoToStateAction = typeof(GoToStateAction);
+        internal static readonly Type NavigateToPageAction = typeof(NavigateToPageAction);
+        internal static readonly Type PlaySoundAction = typeof(PlaySoundAction);
+        internal static readonly Type CallMethodAction = typeof(CallMethodAction);
+        internal static readonly Type ActionCollection = typeof(ActionCollection);
+        internal static readonly Type BehaviorCollection = typeof(BehaviorCollection);
     }
 }

--- a/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactivity.Design/MetadataTableProvider.cs
+++ b/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactivity.Design/MetadataTableProvider.cs
@@ -20,212 +20,211 @@ using Editors = Microsoft.Windows.Design.PropertyEditing.Editors;
 
 // Please note that both the .Design and .DesignTools project
 // use the same namespace: Microsoft.Xaml.Interactivity.Design
-namespace Microsoft.Xaml.Interactivity.Design
+namespace Microsoft.Xaml.Interactivity.Design;
+
+partial class MetadataTableProvider : IProvideAttributeTable
 {
-    partial class MetadataTableProvider : IProvideAttributeTable
+    private AttributeTableBuilder _attributeTableBuilder;
+
+    public AttributeTable AttributeTable
     {
-        private AttributeTableBuilder _attributeTableBuilder;
-
-        public AttributeTable AttributeTable
+        get
         {
-            get
+            if (_attributeTableBuilder == null)
             {
-                if (_attributeTableBuilder == null)
-                {
-                    _attributeTableBuilder = new AttributeTableBuilder();
-                }
-
-                #region IncrementalUpdateBehavior
-                AddAttributes(Targets.IncrementalUpdateBehavior, new DescriptionAttribute(Resources.Description_IncrementalUpdateBehavior));
-
-                AddAttributes(Targets.IncrementalUpdateBehavior, "Phase",
-                    new DescriptionAttribute(Resources.Description_IncrementalUpdateBehavior_Phase),
-                    new CategoryAttribute(Resources.Category_Common_Properties));
-                #endregion
-
-                #region EventTriggerBehavior
-                AddAttributes(Targets.EventTriggerBehavior, new DescriptionAttribute(Resources.Description_EventTriggerBehavior));
-
-                AddAttributes(Targets.EventTriggerBehavior, "EventName",
-                    new DescriptionAttribute(Resources.Description_EventTriggerBehavior_EventName),
-                    CreateEditorAttribute<Editors.EventPickerPropertyValueEditor>(),
-                    new CategoryAttribute(Resources.Category_Common_Properties));
-
-                AddAttributes(Targets.EventTriggerBehavior, "SourceObject",
-                    new DescriptionAttribute(Resources.Description_EventTriggerBehavior_SourceObject),
-                    CreateEditorAttribute<Editors.ElementBindingPickerPropertyValueEditor>(),
-                    new CategoryAttribute(Resources.Category_Common_Properties));
-
-                AddAttributes(Targets.EventTriggerBehavior, "Actions",
-                    new DescriptionAttribute(Resources.Description_EventTriggerBehavior_Actions));
-                #endregion
-
-                #region DataTriggerBehavior
-                AddAttributes(Targets.DataTriggerBehavior, new DefaultBindingPropertyAttribute("Binding"));
-
-                AddAttributes(Targets.DataTriggerBehavior, "Binding",
-                    new DescriptionAttribute(Resources.Description_DataTriggerBehavior_Binding),
-                    CreateEditorAttribute<Editors.PropertyBindingPickerPropertyValueEditor>(),
-                    new CategoryAttribute(Resources.Category_Common_Properties));
-
-                AddAttributes(Targets.DataTriggerBehavior, "ComparisonCondition",
-                    new DescriptionAttribute(Resources.Description_DataTriggerBehavior_ComparisonCondition),
-                    new CategoryAttribute(Resources.Category_Common_Properties));
-
-                AddAttributes(Targets.DataTriggerBehavior, "Value",
-                    new DescriptionAttribute(Resources.Description_DataTriggerBehavior_Value),
-                    new CategoryAttribute(Resources.Category_Common_Properties),
-                    new TypeConverterAttribute(typeof(StringConverter)));
-
-                AddAttributes(Targets.DataTriggerBehavior, "Actions",
-                    new DescriptionAttribute(Resources.Description_DataTriggerBehavior_Actions));
-                #endregion
-
-                #region ChangePropertyAction
-                AddAttributes(Targets.ChangePropertyAction, new DescriptionAttribute(Resources.Description_ChangePropertyAction));
-
-                AddAttributes(Targets.ChangePropertyAction, "PropertyName",
-                    CreateEditorAttribute<Editors.PropertyPickerPropertyValueEditor>(),
-                    new CategoryAttribute(Resources.Category_Common_Properties),
-                    new DescriptionAttribute(Resources.Description_ChangePropertyAction_PropertyName));
-
-                AddAttributes(Targets.ChangePropertyAction, "TargetObject",
-                    new DescriptionAttribute(Resources.Description_ChangePropertyAction_TargetObject),
-                    CreateEditorAttribute<Editors.ElementBindingPickerPropertyValueEditor>(),
-                    new CategoryAttribute(Resources.Category_Common_Properties));
-
-                AddAttributes(Targets.ChangePropertyAction, "Value",
-                    new DescriptionAttribute(Resources.Description_ChangePropertyAction_Value),
-                    new CategoryAttribute(Resources.Category_Common_Properties),
-                    new BrowsableAttribute(false));
-
-                #endregion ChangePropertyAction
-
-                #region InvokeCommandAction
-                AddAttributes(Targets.InvokeCommandAction,
-                    new DescriptionAttribute(Resources.Description_InvokeCommandAction),
-                    new DefaultBindingPropertyAttribute("Command"));
-
-                AddAttributes(Targets.InvokeCommandAction, "Command",
-                    new CategoryAttribute(Resources.Category_Common_Properties),
-                    CreateEditorAttribute<Editors.PropertyBindingPickerPropertyValueEditor>(),
-                    new DescriptionAttribute(Resources.Description_InvokeCommandAction_Command));
-
-                AddAttributes(Targets.InvokeCommandAction, "CommandParameter",
-                    new TypeConverterAttribute(typeof(StringConverter)),
-                    new CategoryAttribute(Resources.Category_Common_Properties),
-                    new DescriptionAttribute(Resources.Description_InvokeCommandAction_CommandParameter),
-                    new EditorBrowsableAttribute(EditorBrowsableState.Advanced));
-
-                AddAttributes(Targets.InvokeCommandAction, "InputConverter",
-                    new CategoryAttribute(Resources.Category_Common_Properties),
-                    new DescriptionAttribute(Resources.Description_InvokeCommandAction_InputConverter),
-                    new EditorBrowsableAttribute(EditorBrowsableState.Advanced));
-
-                AddAttributes(Targets.InvokeCommandAction, "InputConverterParameter",
-                    new TypeConverterAttribute(typeof(StringConverter)),
-                    new CategoryAttribute(Resources.Category_Common_Properties),
-                    new DescriptionAttribute(Resources.Description_InvokeCommandAction_InputConverterParameter),
-                    new EditorBrowsableAttribute(EditorBrowsableState.Advanced));
-
-                AddAttributes(Targets.InvokeCommandAction, "InputConverterLanguage",
-                    new CategoryAttribute(Resources.Category_Common_Properties),
-                    new DescriptionAttribute(Resources.Description_InvokeCommandAction_InputConverterLanguage),
-                    new TypeConverterAttribute(typeof(CultureInfoNamesConverter)),
-                    new EditorBrowsableAttribute(EditorBrowsableState.Advanced));
-                #endregion
-
-                #region ControlStoryboardAction
-                AddAttributes(Targets.ControlStoryboardAction, new DescriptionAttribute(Resources.Description_ControlStoryboardAction));
-
-                AddAttributes(Targets.ControlStoryboardAction, "ControlStoryboardOption",
-                    new DescriptionAttribute(Resources.Description_ControlStoryboardAction_ControlStoryboardOption),
-                    new CategoryAttribute(Resources.Category_Common_Properties));
-
-                AddAttributes(Targets.ControlStoryboardAction, "Storyboard",
-                    new DescriptionAttribute(Resources.Description_ControlStoryboardAction_Storyboard),
-                    new CategoryAttribute(Resources.Category_Common_Properties),
-                    CreateEditorAttribute<Editors.StoryboardPickerPropertyValueEditor>(),
-                    new TypeConverterAttribute(typeof(TypeConverter)));
-                #endregion
-
-                #region GotoStateAction
-                AddAttributes(Targets.GoToStateAction, new DescriptionAttribute(Resources.Description_GoToStateAction));
-
-                AddAttributes(Targets.GoToStateAction, "StateName",
-                    CreateEditorAttribute<Editors.StatePickerPropertyValueEditor>(),
-                    new DescriptionAttribute(Resources.Description_GoToStateAction_StateName),
-                    new CategoryAttribute(Resources.Category_Common_Properties));
-
-                AddAttributes(Targets.GoToStateAction, "UseTransitions",
-                    new DescriptionAttribute(Resources.Description_GoToStateAction_UseTransitions),
-                    new CategoryAttribute(Resources.Category_Common_Properties));
-
-                AddAttributes(Targets.GoToStateAction, "TargetObject",
-                    new CategoryAttribute(Resources.Category_Common_Properties),
-                    new DescriptionAttribute(Resources.Description_GoToStateAction_TargetObject),
-                    CreateEditorAttribute<Editors.ElementBindingPickerPropertyValueEditor>());
-                #endregion
-
-                #region NavigateToPageAction
-                AddAttributes(Targets.NavigateToPageAction, new DescriptionAttribute(Resources.Description_NavigateToPageAction));
-
-                AddAttributes(Targets.NavigateToPageAction, "TargetPage",
-                    CreateEditorAttribute<Editors.PagePickerPropertyValueEditor>(),
-                    new DescriptionAttribute(Resources.Description_NavigateToPageAction_TargetPage),
-                    new CategoryAttribute(Resources.Category_Common_Properties));
-
-                AddAttributes(Targets.NavigateToPageAction, "Parameter",
-                    new DescriptionAttribute(Resources.Description_NavigateToPageAction_Parameter),
-                    new CategoryAttribute(Resources.Category_Common_Properties),
-                    new TypeConverterAttribute(typeof(StringConverter)));
-                #endregion
-
-                #region PlaySoundAction
-                AddAttributes(Targets.PlaySoundAction, new DescriptionAttribute(Resources.Description_PlaySoundAction));
-
-                AddAttributes(Targets.PlaySoundAction, "Source",
-                    CreateEditorAttribute<Editors.UriPropertyValueEditor>(),
-                    new DescriptionAttribute(Resources.Description_PlaySoundAction_Source),
-                    new CategoryAttribute(Resources.Category_Common_Properties));
-
-                AddAttributes(Targets.PlaySoundAction, "Volume",
-                    new NumberRangesAttribute(0, 0, 1, 1, canBeAuto: false),
-                    new NumberIncrementsAttribute(0.001, 0.01, 0.1),
-                    new DescriptionAttribute(Resources.Description_PlaySoundAction_Volume),
-                    new CategoryAttribute(Resources.Category_Common_Properties));
-                #endregion
-
-                #region CallMethodAction
-                PropertyOrder order = PropertyOrder.Default;
-
-                AddAttributes(Targets.CallMethodAction, new DescriptionAttribute(Resources.Description_CallMethodAction),
-                    new DefaultBindingPropertyAttribute("TargetObject"));
-
-                AddAttributes(Targets.CallMethodAction, "TargetObject",
-                    new PropertyOrderAttribute(order = PropertyOrder.CreateAfter(order)),
-                    new DescriptionAttribute(Resources.Description_CallMethodAction_TargetObject),
-                    CreateEditorAttribute<Editors.ElementBindingPickerPropertyValueEditor>(),
-                    new CategoryAttribute(Resources.Category_Common_Properties));
-
-                AddAttributes(Targets.CallMethodAction, "MethodName",
-                    new PropertyOrderAttribute(order = PropertyOrder.CreateAfter(order)),
-                    new DescriptionAttribute(Resources.Description_CallMethodAction_MethodName),
-                    new CategoryAttribute(Resources.Category_Common_Properties));
-                #endregion
-
-                #region Collections
-                AddAttributes(Targets.ActionCollection, new CategoryAttribute(Resources.Category_Name_Actions));
-                AddAttributes(Targets.BehaviorCollection, new ToolboxBrowsableAttribute(false));
-                #endregion
-
-                return _attributeTableBuilder.CreateTable();
+                _attributeTableBuilder = new AttributeTableBuilder();
             }
-        }
 
-        private static EditorAttribute CreateEditorAttribute<T>() where T : PropertyValueEditor
-        {
-            return PropertyValueEditor.CreateEditorAttribute(typeof(T));
+            #region IncrementalUpdateBehavior
+            AddAttributes(Targets.IncrementalUpdateBehavior, new DescriptionAttribute(Resources.Description_IncrementalUpdateBehavior));
+
+            AddAttributes(Targets.IncrementalUpdateBehavior, "Phase",
+                new DescriptionAttribute(Resources.Description_IncrementalUpdateBehavior_Phase),
+                new CategoryAttribute(Resources.Category_Common_Properties));
+            #endregion
+
+            #region EventTriggerBehavior
+            AddAttributes(Targets.EventTriggerBehavior, new DescriptionAttribute(Resources.Description_EventTriggerBehavior));
+
+            AddAttributes(Targets.EventTriggerBehavior, "EventName",
+                new DescriptionAttribute(Resources.Description_EventTriggerBehavior_EventName),
+                CreateEditorAttribute<Editors.EventPickerPropertyValueEditor>(),
+                new CategoryAttribute(Resources.Category_Common_Properties));
+
+            AddAttributes(Targets.EventTriggerBehavior, "SourceObject",
+                new DescriptionAttribute(Resources.Description_EventTriggerBehavior_SourceObject),
+                CreateEditorAttribute<Editors.ElementBindingPickerPropertyValueEditor>(),
+                new CategoryAttribute(Resources.Category_Common_Properties));
+
+            AddAttributes(Targets.EventTriggerBehavior, "Actions",
+                new DescriptionAttribute(Resources.Description_EventTriggerBehavior_Actions));
+            #endregion
+
+            #region DataTriggerBehavior
+            AddAttributes(Targets.DataTriggerBehavior, new DefaultBindingPropertyAttribute("Binding"));
+
+            AddAttributes(Targets.DataTriggerBehavior, "Binding",
+                new DescriptionAttribute(Resources.Description_DataTriggerBehavior_Binding),
+                CreateEditorAttribute<Editors.PropertyBindingPickerPropertyValueEditor>(),
+                new CategoryAttribute(Resources.Category_Common_Properties));
+
+            AddAttributes(Targets.DataTriggerBehavior, "ComparisonCondition",
+                new DescriptionAttribute(Resources.Description_DataTriggerBehavior_ComparisonCondition),
+                new CategoryAttribute(Resources.Category_Common_Properties));
+
+            AddAttributes(Targets.DataTriggerBehavior, "Value",
+                new DescriptionAttribute(Resources.Description_DataTriggerBehavior_Value),
+                new CategoryAttribute(Resources.Category_Common_Properties),
+                new TypeConverterAttribute(typeof(StringConverter)));
+
+            AddAttributes(Targets.DataTriggerBehavior, "Actions",
+                new DescriptionAttribute(Resources.Description_DataTriggerBehavior_Actions));
+            #endregion
+
+            #region ChangePropertyAction
+            AddAttributes(Targets.ChangePropertyAction, new DescriptionAttribute(Resources.Description_ChangePropertyAction));
+
+            AddAttributes(Targets.ChangePropertyAction, "PropertyName",
+                CreateEditorAttribute<Editors.PropertyPickerPropertyValueEditor>(),
+                new CategoryAttribute(Resources.Category_Common_Properties),
+                new DescriptionAttribute(Resources.Description_ChangePropertyAction_PropertyName));
+
+            AddAttributes(Targets.ChangePropertyAction, "TargetObject",
+                new DescriptionAttribute(Resources.Description_ChangePropertyAction_TargetObject),
+                CreateEditorAttribute<Editors.ElementBindingPickerPropertyValueEditor>(),
+                new CategoryAttribute(Resources.Category_Common_Properties));
+
+            AddAttributes(Targets.ChangePropertyAction, "Value",
+                new DescriptionAttribute(Resources.Description_ChangePropertyAction_Value),
+                new CategoryAttribute(Resources.Category_Common_Properties),
+                new BrowsableAttribute(false));
+
+            #endregion ChangePropertyAction
+
+            #region InvokeCommandAction
+            AddAttributes(Targets.InvokeCommandAction,
+                new DescriptionAttribute(Resources.Description_InvokeCommandAction),
+                new DefaultBindingPropertyAttribute("Command"));
+
+            AddAttributes(Targets.InvokeCommandAction, "Command",
+                new CategoryAttribute(Resources.Category_Common_Properties),
+                CreateEditorAttribute<Editors.PropertyBindingPickerPropertyValueEditor>(),
+                new DescriptionAttribute(Resources.Description_InvokeCommandAction_Command));
+
+            AddAttributes(Targets.InvokeCommandAction, "CommandParameter",
+                new TypeConverterAttribute(typeof(StringConverter)),
+                new CategoryAttribute(Resources.Category_Common_Properties),
+                new DescriptionAttribute(Resources.Description_InvokeCommandAction_CommandParameter),
+                new EditorBrowsableAttribute(EditorBrowsableState.Advanced));
+
+            AddAttributes(Targets.InvokeCommandAction, "InputConverter",
+                new CategoryAttribute(Resources.Category_Common_Properties),
+                new DescriptionAttribute(Resources.Description_InvokeCommandAction_InputConverter),
+                new EditorBrowsableAttribute(EditorBrowsableState.Advanced));
+
+            AddAttributes(Targets.InvokeCommandAction, "InputConverterParameter",
+                new TypeConverterAttribute(typeof(StringConverter)),
+                new CategoryAttribute(Resources.Category_Common_Properties),
+                new DescriptionAttribute(Resources.Description_InvokeCommandAction_InputConverterParameter),
+                new EditorBrowsableAttribute(EditorBrowsableState.Advanced));
+
+            AddAttributes(Targets.InvokeCommandAction, "InputConverterLanguage",
+                new CategoryAttribute(Resources.Category_Common_Properties),
+                new DescriptionAttribute(Resources.Description_InvokeCommandAction_InputConverterLanguage),
+                new TypeConverterAttribute(typeof(CultureInfoNamesConverter)),
+                new EditorBrowsableAttribute(EditorBrowsableState.Advanced));
+            #endregion
+
+            #region ControlStoryboardAction
+            AddAttributes(Targets.ControlStoryboardAction, new DescriptionAttribute(Resources.Description_ControlStoryboardAction));
+
+            AddAttributes(Targets.ControlStoryboardAction, "ControlStoryboardOption",
+                new DescriptionAttribute(Resources.Description_ControlStoryboardAction_ControlStoryboardOption),
+                new CategoryAttribute(Resources.Category_Common_Properties));
+
+            AddAttributes(Targets.ControlStoryboardAction, "Storyboard",
+                new DescriptionAttribute(Resources.Description_ControlStoryboardAction_Storyboard),
+                new CategoryAttribute(Resources.Category_Common_Properties),
+                CreateEditorAttribute<Editors.StoryboardPickerPropertyValueEditor>(),
+                new TypeConverterAttribute(typeof(TypeConverter)));
+            #endregion
+
+            #region GotoStateAction
+            AddAttributes(Targets.GoToStateAction, new DescriptionAttribute(Resources.Description_GoToStateAction));
+
+            AddAttributes(Targets.GoToStateAction, "StateName",
+                CreateEditorAttribute<Editors.StatePickerPropertyValueEditor>(),
+                new DescriptionAttribute(Resources.Description_GoToStateAction_StateName),
+                new CategoryAttribute(Resources.Category_Common_Properties));
+
+            AddAttributes(Targets.GoToStateAction, "UseTransitions",
+                new DescriptionAttribute(Resources.Description_GoToStateAction_UseTransitions),
+                new CategoryAttribute(Resources.Category_Common_Properties));
+
+            AddAttributes(Targets.GoToStateAction, "TargetObject",
+                new CategoryAttribute(Resources.Category_Common_Properties),
+                new DescriptionAttribute(Resources.Description_GoToStateAction_TargetObject),
+                CreateEditorAttribute<Editors.ElementBindingPickerPropertyValueEditor>());
+            #endregion
+
+            #region NavigateToPageAction
+            AddAttributes(Targets.NavigateToPageAction, new DescriptionAttribute(Resources.Description_NavigateToPageAction));
+
+            AddAttributes(Targets.NavigateToPageAction, "TargetPage",
+                CreateEditorAttribute<Editors.PagePickerPropertyValueEditor>(),
+                new DescriptionAttribute(Resources.Description_NavigateToPageAction_TargetPage),
+                new CategoryAttribute(Resources.Category_Common_Properties));
+
+            AddAttributes(Targets.NavigateToPageAction, "Parameter",
+                new DescriptionAttribute(Resources.Description_NavigateToPageAction_Parameter),
+                new CategoryAttribute(Resources.Category_Common_Properties),
+                new TypeConverterAttribute(typeof(StringConverter)));
+            #endregion
+
+            #region PlaySoundAction
+            AddAttributes(Targets.PlaySoundAction, new DescriptionAttribute(Resources.Description_PlaySoundAction));
+
+            AddAttributes(Targets.PlaySoundAction, "Source",
+                CreateEditorAttribute<Editors.UriPropertyValueEditor>(),
+                new DescriptionAttribute(Resources.Description_PlaySoundAction_Source),
+                new CategoryAttribute(Resources.Category_Common_Properties));
+
+            AddAttributes(Targets.PlaySoundAction, "Volume",
+                new NumberRangesAttribute(0, 0, 1, 1, canBeAuto: false),
+                new NumberIncrementsAttribute(0.001, 0.01, 0.1),
+                new DescriptionAttribute(Resources.Description_PlaySoundAction_Volume),
+                new CategoryAttribute(Resources.Category_Common_Properties));
+            #endregion
+
+            #region CallMethodAction
+            PropertyOrder order = PropertyOrder.Default;
+
+            AddAttributes(Targets.CallMethodAction, new DescriptionAttribute(Resources.Description_CallMethodAction),
+                new DefaultBindingPropertyAttribute("TargetObject"));
+
+            AddAttributes(Targets.CallMethodAction, "TargetObject",
+                new PropertyOrderAttribute(order = PropertyOrder.CreateAfter(order)),
+                new DescriptionAttribute(Resources.Description_CallMethodAction_TargetObject),
+                CreateEditorAttribute<Editors.ElementBindingPickerPropertyValueEditor>(),
+                new CategoryAttribute(Resources.Category_Common_Properties));
+
+            AddAttributes(Targets.CallMethodAction, "MethodName",
+                new PropertyOrderAttribute(order = PropertyOrder.CreateAfter(order)),
+                new DescriptionAttribute(Resources.Description_CallMethodAction_MethodName),
+                new CategoryAttribute(Resources.Category_Common_Properties));
+            #endregion
+
+            #region Collections
+            AddAttributes(Targets.ActionCollection, new CategoryAttribute(Resources.Category_Name_Actions));
+            AddAttributes(Targets.BehaviorCollection, new ToolboxBrowsableAttribute(false));
+            #endregion
+
+            return _attributeTableBuilder.CreateTable();
         }
+    }
+
+    private static EditorAttribute CreateEditorAttribute<T>() where T : PropertyValueEditor
+    {
+        return PropertyValueEditor.CreateEditorAttribute(typeof(T));
     }
 }

--- a/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactivity.DesignTools/MetadataTableProvider.SurfaceIsolation.cs
+++ b/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactivity.DesignTools/MetadataTableProvider.SurfaceIsolation.cs
@@ -3,39 +3,38 @@
 
 using System;
 
-namespace Microsoft.Xaml.Interactivity.Design
+namespace Microsoft.Xaml.Interactivity.Design;
+
+partial class MetadataTableProvider
 {
-    partial class MetadataTableProvider
+    private void AddAttributes(string typeIdentifier, params Attribute[] attributes)
     {
-        private void AddAttributes(string typeIdentifier, params Attribute[] attributes)
-        {
-            _attributeTableBuilder.AddCustomAttributes(typeIdentifier, attributes);
-        }
+        _attributeTableBuilder.AddCustomAttributes(typeIdentifier, attributes);
+    }
 
-        private void AddAttributes(string typeIdentifier, string propertyName, params Attribute[] attributes)
-        {
-            _attributeTableBuilder.AddCustomAttributes(typeIdentifier, propertyName, attributes);
-        }
+    private void AddAttributes(string typeIdentifier, string propertyName, params Attribute[] attributes)
+    {
+        _attributeTableBuilder.AddCustomAttributes(typeIdentifier, propertyName, attributes);
+    }
 
-        /// <summary>
-        /// This class contains the type names required by the new Extensibility APIs.
-        /// </summary>
-        private static class Targets
-        {
-            private const string rootNamespace = "Microsoft.Xaml.Interactivity.";
+    /// <summary>
+    /// This class contains the type names required by the new Extensibility APIs.
+    /// </summary>
+    private static class Targets
+    {
+        private const string rootNamespace = "Microsoft.Xaml.Interactivity.";
 
-            internal const string CallMethodAction          = rootNamespace + "CallMethodAction";
-            internal const string ChangePropertyAction      = rootNamespace + "ChangePropertyAction";
-            internal const string ControlStoryboardAction   = rootNamespace + "ControlStoryboardAction";
-            internal const string DataTriggerBehavior       = rootNamespace + "DataTriggerBehavior";
-            internal const string IncrementalUpdateBehavior = rootNamespace + "IncrementalUpdateBehavior";
-            internal const string EventTriggerBehavior      = rootNamespace + "EventTriggerBehavior";
-            internal const string GoToStateAction           = rootNamespace + "GoToStateAction";
-            internal const string InvokeCommandAction       = rootNamespace + "InvokeCommandAction";
-            internal const string NavigateToPageAction      = rootNamespace + "NavigateToPageAction";
-            internal const string PlaySoundAction           = rootNamespace + "PlaySoundAction";
-            internal const string ActionCollection          = rootNamespace + "ActionCollection";
-            internal const string BehaviorCollection        = rootNamespace + "BehaviorCollection";
-        }
+        internal const string CallMethodAction          = rootNamespace + "CallMethodAction";
+        internal const string ChangePropertyAction      = rootNamespace + "ChangePropertyAction";
+        internal const string ControlStoryboardAction   = rootNamespace + "ControlStoryboardAction";
+        internal const string DataTriggerBehavior       = rootNamespace + "DataTriggerBehavior";
+        internal const string IncrementalUpdateBehavior = rootNamespace + "IncrementalUpdateBehavior";
+        internal const string EventTriggerBehavior      = rootNamespace + "EventTriggerBehavior";
+        internal const string GoToStateAction           = rootNamespace + "GoToStateAction";
+        internal const string InvokeCommandAction       = rootNamespace + "InvokeCommandAction";
+        internal const string NavigateToPageAction      = rootNamespace + "NavigateToPageAction";
+        internal const string PlaySoundAction           = rootNamespace + "PlaySoundAction";
+        internal const string ActionCollection          = rootNamespace + "ActionCollection";
+        internal const string BehaviorCollection        = rootNamespace + "BehaviorCollection";
     }
 }

--- a/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactivity.Shared/ActionCollection.cs
+++ b/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactivity.Shared/ActionCollection.cs
@@ -10,45 +10,44 @@ using Microsoft.UI.Xaml;
 using Windows.UI.Xaml;
 #endif
 
-namespace Microsoft.Xaml.Interactivity
+namespace Microsoft.Xaml.Interactivity;
+
+/// <summary>
+/// Represents a collection of IActions.
+/// </summary>
+public sealed partial class ActionCollection : DependencyObjectCollection
 {
     /// <summary>
-    /// Represents a collection of IActions.
+    /// Initializes a new instance of the <see cref="ActionCollection"/> class.
     /// </summary>
-    public sealed partial class ActionCollection : DependencyObjectCollection
+    public ActionCollection()
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="ActionCollection"/> class.
-        /// </summary>
-        public ActionCollection()
-        {
-            this.VectorChanged += this.ActionCollection_VectorChanged;
-        }
+        this.VectorChanged += this.ActionCollection_VectorChanged;
+    }
 
-        private void ActionCollection_VectorChanged(IObservableVector<DependencyObject> sender, IVectorChangedEventArgs eventArgs)
-        {
-            CollectionChange collectionChange = eventArgs.CollectionChange;
+    private void ActionCollection_VectorChanged(IObservableVector<DependencyObject> sender, IVectorChangedEventArgs eventArgs)
+    {
+        CollectionChange collectionChange = eventArgs.CollectionChange;
 
-            if (collectionChange == CollectionChange.Reset)
+        if (collectionChange == CollectionChange.Reset)
+        {
+            foreach (DependencyObject item in this)
             {
-                foreach (DependencyObject item in this)
-                {
-                    ActionCollection.VerifyType(item);
-                }
-            }
-            else if (collectionChange == CollectionChange.ItemInserted || collectionChange == CollectionChange.ItemChanged)
-            {
-                DependencyObject changedItem = this[(int)eventArgs.Index];
-                ActionCollection.VerifyType(changedItem);
+                ActionCollection.VerifyType(item);
             }
         }
-
-        private static void VerifyType(DependencyObject item)
+        else if (collectionChange == CollectionChange.ItemInserted || collectionChange == CollectionChange.ItemChanged)
         {
-            if (!(item is IAction))
-            {
-                throw new InvalidOperationException(ResourceHelper.GetString("NonActionAddedToActionCollectionExceptionMessage"));
-            }
+            DependencyObject changedItem = this[(int)eventArgs.Index];
+            ActionCollection.VerifyType(changedItem);
+        }
+    }
+
+    private static void VerifyType(DependencyObject item)
+    {
+        if (!(item is IAction))
+        {
+            throw new InvalidOperationException(ResourceHelper.GetString("NonActionAddedToActionCollectionExceptionMessage"));
         }
     }
 }

--- a/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactivity.Shared/Behavior.cs
+++ b/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactivity.Shared/Behavior.cs
@@ -11,74 +11,73 @@ using Microsoft.UI.Xaml;
 using Windows.UI.Xaml;
 #endif
 
-namespace Microsoft.Xaml.Interactivity
+namespace Microsoft.Xaml.Interactivity;
+
+/// <summary>
+/// A base class for behaviors, implementing the basic plumbing of IBehavior
+/// </summary>
+public abstract class Behavior : DependencyObject, IBehavior
 {
     /// <summary>
-    /// A base class for behaviors, implementing the basic plumbing of IBehavior
+    /// Gets the <see cref="DependencyObject"/> to which the behavior is attached.
     /// </summary>
-    public abstract class Behavior : DependencyObject, IBehavior
+    public DependencyObject AssociatedObject { get; private set; }
+
+    /// <summary>
+    /// Attaches the behavior to the specified <see cref="DependencyObject"/>.
+    /// </summary>
+    /// <param name="associatedObject">The <see cref="DependencyObject"/> to which to attach.</param>
+    /// <exception cref="global::System.ArgumentNullException"><paramref name="associatedObject"/> is null.</exception>
+    public void Attach(DependencyObject associatedObject)
     {
-        /// <summary>
-        /// Gets the <see cref="DependencyObject"/> to which the behavior is attached.
-        /// </summary>
-        public DependencyObject AssociatedObject { get; private set; }
-
-        /// <summary>
-        /// Attaches the behavior to the specified <see cref="DependencyObject"/>.
-        /// </summary>
-        /// <param name="associatedObject">The <see cref="DependencyObject"/> to which to attach.</param>
-        /// <exception cref="global::System.ArgumentNullException"><paramref name="associatedObject"/> is null.</exception>
-        public void Attach(DependencyObject associatedObject)
+        if (associatedObject == this.AssociatedObject || global::Windows.ApplicationModel.DesignMode.DesignModeEnabled)
         {
-            if (associatedObject == this.AssociatedObject || global::Windows.ApplicationModel.DesignMode.DesignModeEnabled)
-            {
-                return;
-            }
-
-            if (this.AssociatedObject != null)
-            {
-                throw new InvalidOperationException(string.Format(
-                    CultureInfo.CurrentCulture,
-                    ResourceHelper.CannotAttachBehaviorMultipleTimesExceptionMessage,
-                    associatedObject,
-                    this.AssociatedObject));
-            }
-
-            Debug.Assert(associatedObject != null, "Cannot attach the behavior to a null object.");
-
-            if (associatedObject == null) throw new ArgumentNullException(nameof(associatedObject));
-
-            AssociatedObject = associatedObject;
-            OnAttached();
+            return;
         }
 
-        /// <summary>
-        /// Detaches the behaviors from the <see cref="Microsoft.Xaml.Interactivity.Behavior.AssociatedObject"/>.
-        /// </summary>
-        public void Detach()
+        if (this.AssociatedObject != null)
         {
-            OnDetaching();
-            AssociatedObject = null;
+            throw new InvalidOperationException(string.Format(
+                CultureInfo.CurrentCulture,
+                ResourceHelper.CannotAttachBehaviorMultipleTimesExceptionMessage,
+                associatedObject,
+                this.AssociatedObject));
         }
 
-        /// <summary>
-        /// Called after the behavior is attached to the <see cref="Microsoft.Xaml.Interactivity.Behavior.AssociatedObject"/>.
-        /// </summary>
-        /// <remarks>
-        /// Override this to hook up functionality to the <see cref="Microsoft.Xaml.Interactivity.Behavior.AssociatedObject"/>
-        /// </remarks>
-        protected virtual void OnAttached()
-        {
-        }
+        Debug.Assert(associatedObject != null, "Cannot attach the behavior to a null object.");
 
-        /// <summary>
-        /// Called when the behavior is being detached from its <see cref="Microsoft.Xaml.Interactivity.Behavior.AssociatedObject"/>.
-        /// </summary>
-        /// <remarks>
-        /// Override this to unhook functionality from the <see cref="Microsoft.Xaml.Interactivity.Behavior.AssociatedObject"/>
-        /// </remarks>
-        protected virtual void OnDetaching()
-        {
-        }
+        if (associatedObject == null) throw new ArgumentNullException(nameof(associatedObject));
+
+        AssociatedObject = associatedObject;
+        OnAttached();
+    }
+
+    /// <summary>
+    /// Detaches the behaviors from the <see cref="Microsoft.Xaml.Interactivity.Behavior.AssociatedObject"/>.
+    /// </summary>
+    public void Detach()
+    {
+        OnDetaching();
+        AssociatedObject = null;
+    }
+
+    /// <summary>
+    /// Called after the behavior is attached to the <see cref="Microsoft.Xaml.Interactivity.Behavior.AssociatedObject"/>.
+    /// </summary>
+    /// <remarks>
+    /// Override this to hook up functionality to the <see cref="Microsoft.Xaml.Interactivity.Behavior.AssociatedObject"/>
+    /// </remarks>
+    protected virtual void OnAttached()
+    {
+    }
+
+    /// <summary>
+    /// Called when the behavior is being detached from its <see cref="Microsoft.Xaml.Interactivity.Behavior.AssociatedObject"/>.
+    /// </summary>
+    /// <remarks>
+    /// Override this to unhook functionality from the <see cref="Microsoft.Xaml.Interactivity.Behavior.AssociatedObject"/>
+    /// </remarks>
+    protected virtual void OnDetaching()
+    {
     }
 }

--- a/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactivity.Shared/BehaviorCollection.cs
+++ b/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactivity.Shared/BehaviorCollection.cs
@@ -12,191 +12,190 @@ using Microsoft.UI.Xaml;
 using Windows.UI.Xaml;
 #endif
 
-namespace Microsoft.Xaml.Interactivity
+namespace Microsoft.Xaml.Interactivity;
+
+/// <summary>
+/// Represents a collection of IBehaviors with a shared <see cref="Microsoft.Xaml.Interactivity.BehaviorCollection.AssociatedObject"/>.
+/// </summary>
+public sealed partial class BehaviorCollection : DependencyObjectCollection
 {
+    // After a VectorChanged event we need to compare the current state of the collection
+    // with the old collection so that we can call Detach on all removed items.
+    private readonly List<IBehavior> _oldCollection = new List<IBehavior>();
+
     /// <summary>
-    /// Represents a collection of IBehaviors with a shared <see cref="Microsoft.Xaml.Interactivity.BehaviorCollection.AssociatedObject"/>.
+    /// Initializes a new instance of the <see cref="BehaviorCollection"/> class.
     /// </summary>
-    public sealed partial class BehaviorCollection : DependencyObjectCollection
+    public BehaviorCollection()
     {
-        // After a VectorChanged event we need to compare the current state of the collection
-        // with the old collection so that we can call Detach on all removed items.
-        private readonly List<IBehavior> _oldCollection = new List<IBehavior>();
+        this.VectorChanged += this.BehaviorCollection_VectorChanged;
+    }
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="BehaviorCollection"/> class.
-        /// </summary>
-        public BehaviorCollection()
+    /// <summary>
+    /// Gets the <see cref="DependencyObject"/> to which the <see cref="BehaviorCollection"/> is attached.
+    /// </summary>
+    public DependencyObject AssociatedObject {
+        get;
+        private set;
+    }
+
+    /// <summary>
+    /// Attaches the collection of behaviors to the specified <see cref="DependencyObject"/>.
+    /// </summary>
+    /// <param name="associatedObject">The <see cref="DependencyObject"/> to which to attach.</param>
+    /// <exception cref="InvalidOperationException">
+    /// The <see cref="BehaviorCollection"/> is already attached to a different <see cref="DependencyObject"/>.
+    /// </exception>
+    public void Attach(DependencyObject associatedObject)
+    {
+        if (associatedObject == this.AssociatedObject)
         {
-            this.VectorChanged += this.BehaviorCollection_VectorChanged;
+            return;
         }
 
-        /// <summary>
-        /// Gets the <see cref="DependencyObject"/> to which the <see cref="BehaviorCollection"/> is attached.
-        /// </summary>
-        public DependencyObject AssociatedObject {
-            get;
-            private set;
+        if (global::Windows.ApplicationModel.DesignMode.DesignModeEnabled)
+        {
+            return;
         }
 
-        /// <summary>
-        /// Attaches the collection of behaviors to the specified <see cref="DependencyObject"/>.
-        /// </summary>
-        /// <param name="associatedObject">The <see cref="DependencyObject"/> to which to attach.</param>
-        /// <exception cref="InvalidOperationException">
-        /// The <see cref="BehaviorCollection"/> is already attached to a different <see cref="DependencyObject"/>.
-        /// </exception>
-        public void Attach(DependencyObject associatedObject)
+        if (this.AssociatedObject != null)
         {
-            if (associatedObject == this.AssociatedObject)
-            {
-                return;
-            }
+            throw new InvalidOperationException(ResourceHelper.GetString("CannotAttachBehaviorMultipleTimesExceptionMessage"));
+        }
 
-            if (global::Windows.ApplicationModel.DesignMode.DesignModeEnabled)
-            {
-                return;
-            }
+        Debug.Assert(associatedObject != null, "The previous checks should keep us from ever setting null here.");
+        this.AssociatedObject = associatedObject;
 
-            if (this.AssociatedObject != null)
-            {
-                throw new InvalidOperationException(ResourceHelper.GetString("CannotAttachBehaviorMultipleTimesExceptionMessage"));
-            }
+        foreach (DependencyObject item in this)
+        {
+            IBehavior behavior = (IBehavior)item;
+            behavior.Attach(this.AssociatedObject);
+        }
+    }
 
-            Debug.Assert(associatedObject != null, "The previous checks should keep us from ever setting null here.");
-            this.AssociatedObject = associatedObject;
-
-            foreach (DependencyObject item in this)
+    /// <summary>
+    /// Detaches the collection of behaviors from the <see cref="Microsoft.Xaml.Interactivity.BehaviorCollection.AssociatedObject"/>.
+    /// </summary>
+    public void Detach()
+    {
+        foreach (DependencyObject item in this)
+        {
+            IBehavior behaviorItem = (IBehavior)item;
+            if (behaviorItem.AssociatedObject != null)
             {
-                IBehavior behavior = (IBehavior)item;
-                behavior.Attach(this.AssociatedObject);
+                behaviorItem.Detach();
             }
         }
 
-        /// <summary>
-        /// Detaches the collection of behaviors from the <see cref="Microsoft.Xaml.Interactivity.BehaviorCollection.AssociatedObject"/>.
-        /// </summary>
-        public void Detach()
+        this.AssociatedObject = null;
+        this._oldCollection.Clear();
+    }
+
+    private void BehaviorCollection_VectorChanged(IObservableVector<DependencyObject> sender, IVectorChangedEventArgs eventArgs)
+    {
+        if (eventArgs.CollectionChange == CollectionChange.Reset)
         {
-            foreach (DependencyObject item in this)
+            foreach (IBehavior behavior in this._oldCollection)
             {
-                IBehavior behaviorItem = (IBehavior)item;
-                if (behaviorItem.AssociatedObject != null)
+                if (behavior.AssociatedObject != null)
                 {
-                    behaviorItem.Detach();
+                    behavior.Detach();
                 }
             }
 
-            this.AssociatedObject = null;
             this._oldCollection.Clear();
-        }
 
-        private void BehaviorCollection_VectorChanged(IObservableVector<DependencyObject> sender, IVectorChangedEventArgs eventArgs)
-        {
-            if (eventArgs.CollectionChange == CollectionChange.Reset)
+            foreach (DependencyObject newItem in this)
             {
-                foreach (IBehavior behavior in this._oldCollection)
-                {
-                    if (behavior.AssociatedObject != null)
-                    {
-                        behavior.Detach();
-                    }
-                }
-
-                this._oldCollection.Clear();
-
-                foreach (DependencyObject newItem in this)
-                {
-                    this._oldCollection.Add(this.VerifiedAttach(newItem));
-                }
-
-#if DEBUG
-                this.VerifyOldCollectionIntegrity();
-#endif
-                return;
-            }
-
-            int eventIndex = (int)eventArgs.Index;
-            DependencyObject changedItem = this[eventIndex];
-
-            switch (eventArgs.CollectionChange)
-            {
-                case CollectionChange.ItemInserted:
-                    this._oldCollection.Insert(eventIndex, this.VerifiedAttach(changedItem));
-
-                    break;
-
-                case CollectionChange.ItemChanged:
-                    IBehavior oldItem = this._oldCollection[eventIndex];
-                    if (oldItem.AssociatedObject != null)
-                    {
-                        oldItem.Detach();
-                    }
-
-                    this._oldCollection[eventIndex] = this.VerifiedAttach(changedItem);
-
-                    break;
-
-                case CollectionChange.ItemRemoved:
-                    oldItem = this._oldCollection[eventIndex];
-                    if (oldItem.AssociatedObject != null)
-                    {
-                        oldItem.Detach();
-                    }
-
-                    this._oldCollection.RemoveAt(eventIndex);
-                    break;
-
-                default:
-                    Debug.Assert(false, "Unsupported collection operation attempted.");
-                    break;
+                this._oldCollection.Add(this.VerifiedAttach(newItem));
             }
 
 #if DEBUG
             this.VerifyOldCollectionIntegrity();
 #endif
+            return;
         }
 
-        private IBehavior VerifiedAttach(DependencyObject item)
+        int eventIndex = (int)eventArgs.Index;
+        DependencyObject changedItem = this[eventIndex];
+
+        switch (eventArgs.CollectionChange)
         {
-            IBehavior behavior = item as IBehavior;
-            if (behavior == null)
-            {
-                throw new InvalidOperationException(ResourceHelper.GetString("NonBehaviorAddedToBehaviorCollectionExceptionMessage"));
-            }
+            case CollectionChange.ItemInserted:
+                this._oldCollection.Insert(eventIndex, this.VerifiedAttach(changedItem));
 
-            if (this._oldCollection.Contains(behavior))
-            {
-                throw new InvalidOperationException(ResourceHelper.GetString("DuplicateBehaviorInCollectionExceptionMessage"));
-            }
+                break;
 
-            if (this.AssociatedObject != null)
-            {
-                behavior.Attach(this.AssociatedObject);
-            }
+            case CollectionChange.ItemChanged:
+                IBehavior oldItem = this._oldCollection[eventIndex];
+                if (oldItem.AssociatedObject != null)
+                {
+                    oldItem.Detach();
+                }
 
-            return behavior;
+                this._oldCollection[eventIndex] = this.VerifiedAttach(changedItem);
+
+                break;
+
+            case CollectionChange.ItemRemoved:
+                oldItem = this._oldCollection[eventIndex];
+                if (oldItem.AssociatedObject != null)
+                {
+                    oldItem.Detach();
+                }
+
+                this._oldCollection.RemoveAt(eventIndex);
+                break;
+
+            default:
+                Debug.Assert(false, "Unsupported collection operation attempted.");
+                break;
         }
 
 #if DEBUG
-        [Conditional("DEBUG")]
-        private void VerifyOldCollectionIntegrity()
-        {
-            bool isValid = (this.Count == this._oldCollection.Count);
-            if (isValid)
-            {
-                for (int i = 0; i < this.Count; i++)
-                {
-                    if (!ReferenceEquals(this[i], this._oldCollection[i]))
-                    {
-                        isValid = false;
-                        break;
-                    }
-                }
-            }
-
-            Debug.Assert(isValid, "Referential integrity of the collection has been compromised.");
-        }
+        this.VerifyOldCollectionIntegrity();
 #endif
     }
+
+    private IBehavior VerifiedAttach(DependencyObject item)
+    {
+        IBehavior behavior = item as IBehavior;
+        if (behavior == null)
+        {
+            throw new InvalidOperationException(ResourceHelper.GetString("NonBehaviorAddedToBehaviorCollectionExceptionMessage"));
+        }
+
+        if (this._oldCollection.Contains(behavior))
+        {
+            throw new InvalidOperationException(ResourceHelper.GetString("DuplicateBehaviorInCollectionExceptionMessage"));
+        }
+
+        if (this.AssociatedObject != null)
+        {
+            behavior.Attach(this.AssociatedObject);
+        }
+
+        return behavior;
+    }
+
+#if DEBUG
+    [Conditional("DEBUG")]
+    private void VerifyOldCollectionIntegrity()
+    {
+        bool isValid = (this.Count == this._oldCollection.Count);
+        if (isValid)
+        {
+            for (int i = 0; i < this.Count; i++)
+            {
+                if (!ReferenceEquals(this[i], this._oldCollection[i]))
+                {
+                    isValid = false;
+                    break;
+                }
+            }
+        }
+
+        Debug.Assert(isValid, "Referential integrity of the collection has been compromised.");
+    }
+#endif
 }

--- a/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactivity.Shared/BehaviorOfT.cs
+++ b/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactivity.Shared/BehaviorOfT.cs
@@ -9,40 +9,39 @@ using Microsoft.UI.Xaml;
 using Windows.UI.Xaml;
 #endif
 
-namespace Microsoft.Xaml.Interactivity
+namespace Microsoft.Xaml.Interactivity;
+
+/// <summary>
+/// A base class for behaviors making them code compatible with older frameworks,
+/// and allow for typed associtated objects.
+/// </summary>
+/// <typeparam name="T">The object type to attach to</typeparam>
+public abstract class Behavior<T> : Behavior where T : DependencyObject
 {
     /// <summary>
-    /// A base class for behaviors making them code compatible with older frameworks,
-    /// and allow for typed associtated objects.
+    /// Gets the object to which this behavior is attached.
     /// </summary>
-    /// <typeparam name="T">The object type to attach to</typeparam>
-    public abstract class Behavior<T> : Behavior where T : DependencyObject
+    public new T AssociatedObject
     {
-        /// <summary>
-        /// Gets the object to which this behavior is attached.
-        /// </summary>
-        public new T AssociatedObject
-        {
-            get { return base.AssociatedObject as T; }
-        }
+        get { return base.AssociatedObject as T; }
+    }
 
-        /// <summary>
-        /// Called after the behavior is attached to the <see cref="Microsoft.Xaml.Interactivity.Behavior.AssociatedObject"/>.
-        /// </summary>
-        /// <remarks>
-        /// Override this to hook up functionality to the <see cref="Microsoft.Xaml.Interactivity.Behavior.AssociatedObject"/>
-        /// </remarks>
-        protected override void OnAttached()
-        {
-            base.OnAttached();
+    /// <summary>
+    /// Called after the behavior is attached to the <see cref="Microsoft.Xaml.Interactivity.Behavior.AssociatedObject"/>.
+    /// </summary>
+    /// <remarks>
+    /// Override this to hook up functionality to the <see cref="Microsoft.Xaml.Interactivity.Behavior.AssociatedObject"/>
+    /// </remarks>
+    protected override void OnAttached()
+    {
+        base.OnAttached();
 
-            if (this.AssociatedObject == null)
-            {
-                string actualType = base.AssociatedObject.GetType().FullName;
-                string expectedType = typeof (T).FullName;
-                string message = string.Format(ResourceHelper.GetString("InvalidAssociatedObjectExceptionMessage"), actualType, expectedType);
-                throw new InvalidOperationException(message);
-            }
+        if (this.AssociatedObject == null)
+        {
+            string actualType = base.AssociatedObject.GetType().FullName;
+            string expectedType = typeof (T).FullName;
+            string message = string.Format(ResourceHelper.GetString("InvalidAssociatedObjectExceptionMessage"), actualType, expectedType);
+            throw new InvalidOperationException(message);
         }
     }
 }

--- a/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactivity.Shared/Core/CallMethodAction.cs
+++ b/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactivity.Shared/Core/CallMethodAction.cs
@@ -14,276 +14,275 @@ using Microsoft.UI.Xaml;
 using Windows.UI.Xaml;
 #endif
 
-namespace Microsoft.Xaml.Interactivity
+namespace Microsoft.Xaml.Interactivity;
+
+/// <summary>
+/// An action that calls a method on a specified object when invoked.
+/// </summary>
+#if NET8_0_OR_GREATER
+[RequiresUnreferencedCode("This action is not trim-safe.")]
+#endif
+public sealed class CallMethodAction : DependencyObject, IAction
 {
     /// <summary>
-    /// An action that calls a method on a specified object when invoked.
+    /// Identifies the <seealso cref="MethodName"/> dependency property.
     /// </summary>
-#if NET8_0_OR_GREATER
-    [RequiresUnreferencedCode("This action is not trim-safe.")]
-#endif
-    public sealed class CallMethodAction : DependencyObject, IAction
+    [SuppressMessage("Microsoft.Security", "CA2104:DoNotDeclareReadOnlyMutableReferenceTypes")]
+    public static readonly DependencyProperty MethodNameProperty = DependencyProperty.Register(
+        "MethodName",
+        typeof(string),
+        typeof(CallMethodAction),
+        new PropertyMetadata(null, new PropertyChangedCallback(CallMethodAction.OnMethodNameChanged)));
+
+    /// <summary>
+    /// Identifies the <seealso cref="TargetObject"/> dependency property.
+    /// </summary>
+    [SuppressMessage("Microsoft.Security", "CA2104:DoNotDeclareReadOnlyMutableReferenceTypes")]
+    public static readonly DependencyProperty TargetObjectProperty = DependencyProperty.Register(
+        "TargetObject",
+        typeof(object),
+        typeof(CallMethodAction),
+        new PropertyMetadata(null, new PropertyChangedCallback(CallMethodAction.OnTargetObjectChanged)));
+
+    private Type _targetObjectType;
+    private List<MethodDescriptor> _methodDescriptors = new List<MethodDescriptor>();
+    private MethodDescriptor _cachedMethodDescriptor;
+
+    /// <summary>
+    /// Gets or sets the name of the method to invoke. This is a dependency property.
+    /// </summary>
+    public string MethodName
     {
-        /// <summary>
-        /// Identifies the <seealso cref="MethodName"/> dependency property.
-        /// </summary>
-        [SuppressMessage("Microsoft.Security", "CA2104:DoNotDeclareReadOnlyMutableReferenceTypes")]
-        public static readonly DependencyProperty MethodNameProperty = DependencyProperty.Register(
-            "MethodName",
-            typeof(string),
-            typeof(CallMethodAction),
-            new PropertyMetadata(null, new PropertyChangedCallback(CallMethodAction.OnMethodNameChanged)));
-
-        /// <summary>
-        /// Identifies the <seealso cref="TargetObject"/> dependency property.
-        /// </summary>
-        [SuppressMessage("Microsoft.Security", "CA2104:DoNotDeclareReadOnlyMutableReferenceTypes")]
-        public static readonly DependencyProperty TargetObjectProperty = DependencyProperty.Register(
-            "TargetObject",
-            typeof(object),
-            typeof(CallMethodAction),
-            new PropertyMetadata(null, new PropertyChangedCallback(CallMethodAction.OnTargetObjectChanged)));
-
-        private Type _targetObjectType;
-        private List<MethodDescriptor> _methodDescriptors = new List<MethodDescriptor>();
-        private MethodDescriptor _cachedMethodDescriptor;
-
-        /// <summary>
-        /// Gets or sets the name of the method to invoke. This is a dependency property.
-        /// </summary>
-        public string MethodName
+        get
         {
-            get
-            {
-                return (string)this.GetValue(CallMethodAction.MethodNameProperty);
-            }
-
-            set
-            {
-                this.SetValue(CallMethodAction.MethodNameProperty, value);
-            }
+            return (string)this.GetValue(CallMethodAction.MethodNameProperty);
         }
 
-        /// <summary>
-        /// Gets or sets the object that exposes the method of interest. This is a dependency property.
-        /// </summary>
-        public object TargetObject
+        set
         {
-            get
-            {
-                return this.GetValue(CallMethodAction.TargetObjectProperty);
-            }
+            this.SetValue(CallMethodAction.MethodNameProperty, value);
+        }
+    }
 
-            set
-            {
-                this.SetValue(CallMethodAction.TargetObjectProperty, value);
-            }
+    /// <summary>
+    /// Gets or sets the object that exposes the method of interest. This is a dependency property.
+    /// </summary>
+    public object TargetObject
+    {
+        get
+        {
+            return this.GetValue(CallMethodAction.TargetObjectProperty);
         }
 
-        /// <summary>
-        /// Executes the action.
-        /// </summary>
-        /// <param name="sender">The <see cref="object"/> that is passed to the action by the behavior. Generally this is <seealso cref="Microsoft.Xaml.Interactivity.IBehavior.AssociatedObject"/> or a target object.</param>
-        /// <param name="parameter">The value of this parameter is determined by the caller.</param>
-        /// <returns>True if the method is called; else false.</returns>
-        public object Execute(object sender, object parameter)
+        set
         {
-            object target;
-            if (this.ReadLocalValue(CallMethodAction.TargetObjectProperty) != DependencyProperty.UnsetValue)
-            {
-                target = this.TargetObject;
-            }
-            else
-            {
-                target = sender;
-            }
+            this.SetValue(CallMethodAction.TargetObjectProperty, value);
+        }
+    }
 
-            if (target == null || string.IsNullOrEmpty(this.MethodName))
-            {
-                return false;
-            }
+    /// <summary>
+    /// Executes the action.
+    /// </summary>
+    /// <param name="sender">The <see cref="object"/> that is passed to the action by the behavior. Generally this is <seealso cref="Microsoft.Xaml.Interactivity.IBehavior.AssociatedObject"/> or a target object.</param>
+    /// <param name="parameter">The value of this parameter is determined by the caller.</param>
+    /// <returns>True if the method is called; else false.</returns>
+    public object Execute(object sender, object parameter)
+    {
+        object target;
+        if (this.ReadLocalValue(CallMethodAction.TargetObjectProperty) != DependencyProperty.UnsetValue)
+        {
+            target = this.TargetObject;
+        }
+        else
+        {
+            target = sender;
+        }
 
-            this.UpdateTargetType(target.GetType());
+        if (target == null || string.IsNullOrEmpty(this.MethodName))
+        {
+            return false;
+        }
 
-            MethodDescriptor methodDescriptor = this.FindBestMethod(parameter);
-            if (methodDescriptor == null)
-            {
-                if (this.TargetObject != null)
-                {
-                    throw new ArgumentException(string.Format(
-                        CultureInfo.CurrentCulture,
-                        ResourceHelper.CallMethodActionValidMethodNotFoundExceptionMessage,
-                        this.MethodName,
-                        this._targetObjectType));
-                }
+        this.UpdateTargetType(target.GetType());
 
-                return false;
-            }
-
-            ParameterInfo[] parameters = methodDescriptor.Parameters;
-            if (parameters.Length == 0)
+        MethodDescriptor methodDescriptor = this.FindBestMethod(parameter);
+        if (methodDescriptor == null)
+        {
+            if (this.TargetObject != null)
             {
-                methodDescriptor.MethodInfo.Invoke(target, parameters: null);
-                return true;
-            }
-            else if (parameters.Length == 2)
-            {
-                methodDescriptor.MethodInfo.Invoke(target, new object[] { target, parameter });
-                return true;
+                throw new ArgumentException(string.Format(
+                    CultureInfo.CurrentCulture,
+                    ResourceHelper.CallMethodActionValidMethodNotFoundExceptionMessage,
+                    this.MethodName,
+                    this._targetObjectType));
             }
 
             return false;
         }
 
-        private MethodDescriptor FindBestMethod(object parameter)
+        ParameterInfo[] parameters = methodDescriptor.Parameters;
+        if (parameters.Length == 0)
         {
-            TypeInfo parameterTypeInfo = parameter == null ? null : parameter.GetType().GetTypeInfo();
-
-            if (parameterTypeInfo == null)
-            {
-                return this._cachedMethodDescriptor;
-            }
-
-            MethodDescriptor mostDerivedMethod = null;
-
-            // Loop over the methods looking for the one whose type is closest to the type of the given parameter.
-            foreach (MethodDescriptor currentMethod in this._methodDescriptors)
-            {
-                TypeInfo currentTypeInfo = currentMethod.SecondParameterTypeInfo;
-
-                if (currentTypeInfo.IsAssignableFrom(parameterTypeInfo))
-                {
-                    if (mostDerivedMethod == null || !currentTypeInfo.IsAssignableFrom(mostDerivedMethod.SecondParameterTypeInfo))
-                    {
-                        mostDerivedMethod = currentMethod;
-                    }
-                }
-            }
-
-            return mostDerivedMethod ?? this._cachedMethodDescriptor;
+            methodDescriptor.MethodInfo.Invoke(target, parameters: null);
+            return true;
+        }
+        else if (parameters.Length == 2)
+        {
+            methodDescriptor.MethodInfo.Invoke(target, new object[] { target, parameter });
+            return true;
         }
 
-        private void UpdateTargetType(Type newTargetType)
+        return false;
+    }
+
+    private MethodDescriptor FindBestMethod(object parameter)
+    {
+        TypeInfo parameterTypeInfo = parameter == null ? null : parameter.GetType().GetTypeInfo();
+
+        if (parameterTypeInfo == null)
         {
-            if (newTargetType == this._targetObjectType)
-            {
-                return;
-            }
-
-            this._targetObjectType = newTargetType;
-
-            this.UpdateMethodDescriptors();
+            return this._cachedMethodDescriptor;
         }
 
-        private void UpdateMethodDescriptors()
+        MethodDescriptor mostDerivedMethod = null;
+
+        // Loop over the methods looking for the one whose type is closest to the type of the given parameter.
+        foreach (MethodDescriptor currentMethod in this._methodDescriptors)
         {
-            this._methodDescriptors.Clear();
-            this._cachedMethodDescriptor = null;
+            TypeInfo currentTypeInfo = currentMethod.SecondParameterTypeInfo;
 
-            if (string.IsNullOrEmpty(this.MethodName) || this._targetObjectType == null)
+            if (currentTypeInfo.IsAssignableFrom(parameterTypeInfo))
             {
-                return;
-            }
-
-            // Find all public methods that match the given name  and have either no parameters,
-            // or two parameters where the first is of type Object.
-            foreach (MethodInfo method in this._targetObjectType.GetRuntimeMethods())
-            {
-                if (string.Equals(method.Name, this.MethodName, StringComparison.Ordinal)
-                    && method.ReturnType == typeof(void)
-                    && method.IsPublic)
+                if (mostDerivedMethod == null || !currentTypeInfo.IsAssignableFrom(mostDerivedMethod.SecondParameterTypeInfo))
                 {
-                    ParameterInfo[] parameters = method.GetParameters();
-                    if (parameters.Length == 0)
-                    {
-                        // There can be only one parameterless method of the given name.
-                        this._cachedMethodDescriptor = new MethodDescriptor(method, parameters);
-                    }
-                    else if (parameters.Length == 2 && parameters[0].ParameterType == typeof(object))
-                    {
-                        this._methodDescriptors.Add(new MethodDescriptor(method, parameters));
-                    }
-                }
-            }
-
-            // We didn't find a parameterless method, so we want to find a method that accepts null
-            // as a second parameter, but if we have more than one of these it is ambigious which
-            // we should call, so we do nothing.
-            if (this._cachedMethodDescriptor == null)
-            {
-                foreach (MethodDescriptor method in this._methodDescriptors)
-                {
-                    TypeInfo typeInfo = method.SecondParameterTypeInfo;
-                    if (!typeInfo.IsValueType || (typeInfo.IsGenericType && typeInfo.GetGenericTypeDefinition() == typeof(Nullable<>)))
-                    {
-                        if (this._cachedMethodDescriptor != null)
-                        {
-                            this._cachedMethodDescriptor = null;
-                            return;
-                        }
-                        else
-                        {
-                            this._cachedMethodDescriptor = method;
-                        }
-                    }
+                    mostDerivedMethod = currentMethod;
                 }
             }
         }
 
-        private static void OnMethodNameChanged(DependencyObject sender, DependencyPropertyChangedEventArgs args)
+        return mostDerivedMethod ?? this._cachedMethodDescriptor;
+    }
+
+    private void UpdateTargetType(Type newTargetType)
+    {
+        if (newTargetType == this._targetObjectType)
         {
-            CallMethodAction callMethodAction = (CallMethodAction)sender;
-            callMethodAction.UpdateMethodDescriptors();
+            return;
         }
 
-        private static void OnTargetObjectChanged(DependencyObject sender, DependencyPropertyChangedEventArgs args)
-        {
-            CallMethodAction callMethodAction = (CallMethodAction)sender;
+        this._targetObjectType = newTargetType;
 
-            Type newType = args.NewValue != null ? args.NewValue.GetType() : null;
-            callMethodAction.UpdateTargetType(newType);
+        this.UpdateMethodDescriptors();
+    }
+
+    private void UpdateMethodDescriptors()
+    {
+        this._methodDescriptors.Clear();
+        this._cachedMethodDescriptor = null;
+
+        if (string.IsNullOrEmpty(this.MethodName) || this._targetObjectType == null)
+        {
+            return;
         }
 
-        [DebuggerDisplay("{MethodInfo}")]
-        private class MethodDescriptor
+        // Find all public methods that match the given name  and have either no parameters,
+        // or two parameters where the first is of type Object.
+        foreach (MethodInfo method in this._targetObjectType.GetRuntimeMethods())
         {
-            public MethodDescriptor(MethodInfo methodInfo, ParameterInfo[] methodParameters)
+            if (string.Equals(method.Name, this.MethodName, StringComparison.Ordinal)
+                && method.ReturnType == typeof(void)
+                && method.IsPublic)
             {
-                this.MethodInfo = methodInfo;
-                this.Parameters = methodParameters;
-            }
-
-            public MethodInfo MethodInfo
-            {
-                get;
-                private set;
-            }
-
-            public ParameterInfo[] Parameters
-            {
-                get;
-                private set;
-            }
-
-            public int ParameterCount
-            {
-                get
+                ParameterInfo[] parameters = method.GetParameters();
+                if (parameters.Length == 0)
                 {
-                    return this.Parameters.Length;
+                    // There can be only one parameterless method of the given name.
+                    this._cachedMethodDescriptor = new MethodDescriptor(method, parameters);
+                }
+                else if (parameters.Length == 2 && parameters[0].ParameterType == typeof(object))
+                {
+                    this._methodDescriptors.Add(new MethodDescriptor(method, parameters));
                 }
             }
+        }
 
-            public TypeInfo SecondParameterTypeInfo
+        // We didn't find a parameterless method, so we want to find a method that accepts null
+        // as a second parameter, but if we have more than one of these it is ambigious which
+        // we should call, so we do nothing.
+        if (this._cachedMethodDescriptor == null)
+        {
+            foreach (MethodDescriptor method in this._methodDescriptors)
             {
-                get
+                TypeInfo typeInfo = method.SecondParameterTypeInfo;
+                if (!typeInfo.IsValueType || (typeInfo.IsGenericType && typeInfo.GetGenericTypeDefinition() == typeof(Nullable<>)))
                 {
-                    if (this.ParameterCount < 2)
+                    if (this._cachedMethodDescriptor != null)
                     {
-                        return null;
+                        this._cachedMethodDescriptor = null;
+                        return;
                     }
-
-                    return this.Parameters[1].ParameterType.GetTypeInfo();
+                    else
+                    {
+                        this._cachedMethodDescriptor = method;
+                    }
                 }
+            }
+        }
+    }
+
+    private static void OnMethodNameChanged(DependencyObject sender, DependencyPropertyChangedEventArgs args)
+    {
+        CallMethodAction callMethodAction = (CallMethodAction)sender;
+        callMethodAction.UpdateMethodDescriptors();
+    }
+
+    private static void OnTargetObjectChanged(DependencyObject sender, DependencyPropertyChangedEventArgs args)
+    {
+        CallMethodAction callMethodAction = (CallMethodAction)sender;
+
+        Type newType = args.NewValue != null ? args.NewValue.GetType() : null;
+        callMethodAction.UpdateTargetType(newType);
+    }
+
+    [DebuggerDisplay("{MethodInfo}")]
+    private class MethodDescriptor
+    {
+        public MethodDescriptor(MethodInfo methodInfo, ParameterInfo[] methodParameters)
+        {
+            this.MethodInfo = methodInfo;
+            this.Parameters = methodParameters;
+        }
+
+        public MethodInfo MethodInfo
+        {
+            get;
+            private set;
+        }
+
+        public ParameterInfo[] Parameters
+        {
+            get;
+            private set;
+        }
+
+        public int ParameterCount
+        {
+            get
+            {
+                return this.Parameters.Length;
+            }
+        }
+
+        public TypeInfo SecondParameterTypeInfo
+        {
+            get
+            {
+                if (this.ParameterCount < 2)
+                {
+                    return null;
+                }
+
+                return this.Parameters[1].ParameterType.GetTypeInfo();
             }
         }
     }

--- a/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactivity.Shared/Core/ChangePropertyAction.cs
+++ b/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactivity.Shared/Core/ChangePropertyAction.cs
@@ -12,193 +12,192 @@ using Microsoft.UI.Xaml;
 using Windows.UI.Xaml;
 #endif
 
-namespace Microsoft.Xaml.Interactivity
+namespace Microsoft.Xaml.Interactivity;
+
+/// <summary>
+/// An action that will change a specified property to a specified value when invoked.
+/// </summary>
+#if NET8_0_OR_GREATER
+[RequiresUnreferencedCode("This action is not trim-safe.")]
+#endif
+public sealed class ChangePropertyAction : DependencyObject, IAction
 {
     /// <summary>
-    /// An action that will change a specified property to a specified value when invoked.
+    /// Identifies the <seealso cref="PropertyName"/> dependency property.
     /// </summary>
-#if NET8_0_OR_GREATER
-    [RequiresUnreferencedCode("This action is not trim-safe.")]
-#endif
-    public sealed class ChangePropertyAction : DependencyObject, IAction
+    [SuppressMessage("Microsoft.Security", "CA2104:DoNotDeclareReadOnlyMutableReferenceTypes")]
+    public static readonly DependencyProperty PropertyNameProperty = DependencyProperty.Register(
+        "PropertyName",
+        typeof(PropertyPath),
+        typeof(ChangePropertyAction),
+        new PropertyMetadata(null));
+
+    /// <summary>
+    /// Identifies the <seealso cref="TargetObject"/> dependency property.
+    /// </summary>
+    [SuppressMessage("Microsoft.Security", "CA2104:DoNotDeclareReadOnlyMutableReferenceTypes")]
+    public static readonly DependencyProperty TargetObjectProperty = DependencyProperty.Register(
+        "TargetObject",
+        typeof(object),
+        typeof(ChangePropertyAction),
+        new PropertyMetadata(null));
+
+    /// <summary>
+    /// Identifies the <seealso cref="Value"/> dependency property.
+    /// </summary>
+    [SuppressMessage("Microsoft.Security", "CA2104:DoNotDeclareReadOnlyMutableReferenceTypes")]
+    public static readonly DependencyProperty ValueProperty = DependencyProperty.Register(
+        "Value",
+        typeof(object),
+        typeof(ChangePropertyAction),
+        new PropertyMetadata(null));
+
+    /// <summary>
+    /// Gets or sets the name of the property to change. This is a dependency property.
+    /// </summary>
+    public PropertyPath PropertyName
     {
-        /// <summary>
-        /// Identifies the <seealso cref="PropertyName"/> dependency property.
-        /// </summary>
-        [SuppressMessage("Microsoft.Security", "CA2104:DoNotDeclareReadOnlyMutableReferenceTypes")]
-        public static readonly DependencyProperty PropertyNameProperty = DependencyProperty.Register(
-            "PropertyName",
-            typeof(PropertyPath),
-            typeof(ChangePropertyAction),
-            new PropertyMetadata(null));
-
-        /// <summary>
-        /// Identifies the <seealso cref="TargetObject"/> dependency property.
-        /// </summary>
-        [SuppressMessage("Microsoft.Security", "CA2104:DoNotDeclareReadOnlyMutableReferenceTypes")]
-        public static readonly DependencyProperty TargetObjectProperty = DependencyProperty.Register(
-            "TargetObject",
-            typeof(object),
-            typeof(ChangePropertyAction),
-            new PropertyMetadata(null));
-
-        /// <summary>
-        /// Identifies the <seealso cref="Value"/> dependency property.
-        /// </summary>
-        [SuppressMessage("Microsoft.Security", "CA2104:DoNotDeclareReadOnlyMutableReferenceTypes")]
-        public static readonly DependencyProperty ValueProperty = DependencyProperty.Register(
-            "Value",
-            typeof(object),
-            typeof(ChangePropertyAction),
-            new PropertyMetadata(null));
-
-        /// <summary>
-        /// Gets or sets the name of the property to change. This is a dependency property.
-        /// </summary>
-        public PropertyPath PropertyName
+        get
         {
-            get
-            {
-                return (PropertyPath)this.GetValue(ChangePropertyAction.PropertyNameProperty);
-            }
-            set
-            {
-                this.SetValue(ChangePropertyAction.PropertyNameProperty, value);
-            }
+            return (PropertyPath)this.GetValue(ChangePropertyAction.PropertyNameProperty);
+        }
+        set
+        {
+            this.SetValue(ChangePropertyAction.PropertyNameProperty, value);
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets the value to set. This is a dependency property.
+    /// </summary>
+    [SuppressMessage("Microsoft.Naming", "CA1721:PropertyNamesShouldNotMatchGetMethods")]
+    public object Value
+    {
+        get
+        {
+            return this.GetValue(ChangePropertyAction.ValueProperty);
+        }
+        set
+        {
+            this.SetValue(ChangePropertyAction.ValueProperty, value);
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets the object whose property will be changed.
+    /// If <seealso cref="TargetObject"/> is not set or cannot be resolved, the sender of <seealso cref="Execute"/> will be used. This is a dependency property.
+    /// </summary>
+    public object TargetObject
+    {
+        get
+        {
+            return (object)this.GetValue(ChangePropertyAction.TargetObjectProperty);
+        }
+        set
+        {
+            this.SetValue(ChangePropertyAction.TargetObjectProperty, value);
+        }
+    }
+
+    /// <summary>
+    /// Executes the action.
+    /// </summary>
+    /// <param name="sender">The <see cref="object"/> that is passed to the action by the behavior. Generally this is <seealso cref="Microsoft.Xaml.Interactivity.IBehavior.AssociatedObject"/> or a target object.</param>
+    /// <param name="parameter">The value of this parameter is determined by the caller.</param>
+    /// <returns>True if updating the property value succeeds; else false.</returns>
+    public object Execute(object sender, object parameter)
+    {
+        object targetObject;
+        if (this.ReadLocalValue(ChangePropertyAction.TargetObjectProperty) != DependencyProperty.UnsetValue)
+        {
+            targetObject = this.TargetObject;
+        }
+        else
+        {
+            targetObject = sender;
         }
 
-        /// <summary>
-        /// Gets or sets the value to set. This is a dependency property.
-        /// </summary>
-        [SuppressMessage("Microsoft.Naming", "CA1721:PropertyNamesShouldNotMatchGetMethods")]
-        public object Value
+        if (targetObject == null || this.PropertyName == null)
         {
-            get
-            {
-                return this.GetValue(ChangePropertyAction.ValueProperty);
-            }
-            set
-            {
-                this.SetValue(ChangePropertyAction.ValueProperty, value);
-            }
+            return false;
         }
 
-        /// <summary>
-        /// Gets or sets the object whose property will be changed.
-        /// If <seealso cref="TargetObject"/> is not set or cannot be resolved, the sender of <seealso cref="Execute"/> will be used. This is a dependency property.
-        /// </summary>
-        public object TargetObject
-        {
-            get
-            {
-                return (object)this.GetValue(ChangePropertyAction.TargetObjectProperty);
-            }
-            set
-            {
-                this.SetValue(ChangePropertyAction.TargetObjectProperty, value);
-            }
-        }
+        this.UpdatePropertyValue(targetObject);
+        return true;
+    }
 
-        /// <summary>
-        /// Executes the action.
-        /// </summary>
-        /// <param name="sender">The <see cref="object"/> that is passed to the action by the behavior. Generally this is <seealso cref="Microsoft.Xaml.Interactivity.IBehavior.AssociatedObject"/> or a target object.</param>
-        /// <param name="parameter">The value of this parameter is determined by the caller.</param>
-        /// <returns>True if updating the property value succeeds; else false.</returns>
-        public object Execute(object sender, object parameter)
+    private void UpdatePropertyValue(object targetObject)
+    {
+        Type targetType = targetObject.GetType();
+        PropertyInfo propertyInfo = targetType.GetRuntimeProperty(this.PropertyName.Path);
+        this.ValidateProperty(targetType.Name, propertyInfo);
+
+        Exception innerException = null;
+        try
         {
-            object targetObject;
-            if (this.ReadLocalValue(ChangePropertyAction.TargetObjectProperty) != DependencyProperty.UnsetValue)
+            object result = null;
+            string valueAsString = null;
+            Type propertyType = propertyInfo.PropertyType;
+            TypeInfo propertyTypeInfo = propertyType.GetTypeInfo();
+            if (this.Value == null)
             {
-                targetObject = this.TargetObject;
+                // The result can be null if the type is generic (nullable), or the default value of the type in question
+                result = propertyTypeInfo.IsValueType ? Activator.CreateInstance(propertyType) : null;
+            }
+            else if (propertyTypeInfo.IsAssignableFrom(this.Value.GetType().GetTypeInfo()))
+            {
+                result = this.Value;
             }
             else
             {
-                targetObject = sender;
+                valueAsString = this.Value.ToString();
+                result = propertyTypeInfo.IsEnum ? Enum.Parse(propertyType, valueAsString, false) :
+                    TypeConverterHelper.Convert(valueAsString, propertyType.FullName);
             }
 
-            if (targetObject == null || this.PropertyName == null)
-            {
-                return false;
-            }
-
-            this.UpdatePropertyValue(targetObject);
-            return true;
+            propertyInfo.SetValue(targetObject, result, new object[0]);
+        }
+        catch (FormatException e)
+        {
+            innerException = e;
+        }
+        catch (ArgumentException e)
+        {
+            innerException = e;
         }
 
-        private void UpdatePropertyValue(object targetObject)
+        if (innerException != null)
         {
-            Type targetType = targetObject.GetType();
-            PropertyInfo propertyInfo = targetType.GetRuntimeProperty(this.PropertyName.Path);
-            this.ValidateProperty(targetType.Name, propertyInfo);
-
-            Exception innerException = null;
-            try
-            {
-                object result = null;
-                string valueAsString = null;
-                Type propertyType = propertyInfo.PropertyType;
-                TypeInfo propertyTypeInfo = propertyType.GetTypeInfo();
-                if (this.Value == null)
-                {
-                    // The result can be null if the type is generic (nullable), or the default value of the type in question
-                    result = propertyTypeInfo.IsValueType ? Activator.CreateInstance(propertyType) : null;
-                }
-                else if (propertyTypeInfo.IsAssignableFrom(this.Value.GetType().GetTypeInfo()))
-                {
-                    result = this.Value;
-                }
-                else
-                {
-                    valueAsString = this.Value.ToString();
-                    result = propertyTypeInfo.IsEnum ? Enum.Parse(propertyType, valueAsString, false) :
-                        TypeConverterHelper.Convert(valueAsString, propertyType.FullName);
-                }
-
-                propertyInfo.SetValue(targetObject, result, new object[0]);
-            }
-            catch (FormatException e)
-            {
-                innerException = e;
-            }
-            catch (ArgumentException e)
-            {
-                innerException = e;
-            }
-
-            if (innerException != null)
-            {
-                throw new ArgumentException(string.Format(
-                    CultureInfo.CurrentCulture,
-                    ResourceHelper.ChangePropertyActionCannotSetValueExceptionMessage,
-                    this.Value != null ? this.Value.GetType().Name : "null",
-                    this.PropertyName,
-                    propertyInfo.PropertyType.Name),
-                    innerException);
-            }
+            throw new ArgumentException(string.Format(
+                CultureInfo.CurrentCulture,
+                ResourceHelper.ChangePropertyActionCannotSetValueExceptionMessage,
+                this.Value != null ? this.Value.GetType().Name : "null",
+                this.PropertyName,
+                propertyInfo.PropertyType.Name),
+                innerException);
         }
+    }
 
-        /// <summary>
-        /// Ensures the property is not null and can be written to.
-        /// </summary>
-        private void ValidateProperty(string targetTypeName, PropertyInfo propertyInfo)
+    /// <summary>
+    /// Ensures the property is not null and can be written to.
+    /// </summary>
+    private void ValidateProperty(string targetTypeName, PropertyInfo propertyInfo)
+    {
+        if (propertyInfo == null)
         {
-            if (propertyInfo == null)
-            {
-                throw new ArgumentException(string.Format(
-                    CultureInfo.CurrentCulture,
-                    ResourceHelper.ChangePropertyActionCannotFindPropertyNameExceptionMessage,
-                    this.PropertyName,
-                    targetTypeName));
-            }
-            else if (!propertyInfo.CanWrite)
-            {
-                throw new ArgumentException(string.Format(
-                    CultureInfo.CurrentCulture,
-                    ResourceHelper.ChangePropertyActionPropertyIsReadOnlyExceptionMessage,
-                    this.PropertyName,
-                    targetTypeName));
-            }
+            throw new ArgumentException(string.Format(
+                CultureInfo.CurrentCulture,
+                ResourceHelper.ChangePropertyActionCannotFindPropertyNameExceptionMessage,
+                this.PropertyName,
+                targetTypeName));
+        }
+        else if (!propertyInfo.CanWrite)
+        {
+            throw new ArgumentException(string.Format(
+                CultureInfo.CurrentCulture,
+                ResourceHelper.ChangePropertyActionPropertyIsReadOnlyExceptionMessage,
+                this.PropertyName,
+                targetTypeName));
         }
     }
 }

--- a/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactivity.Shared/Core/ComparisonConditionType.cs
+++ b/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactivity.Shared/Core/ComparisonConditionType.cs
@@ -1,36 +1,35 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-namespace Microsoft.Xaml.Interactivity
+namespace Microsoft.Xaml.Interactivity;
+
+/// <summary>
+/// Represents one ternary condition.
+/// </summary>
+public enum ComparisonConditionType
 {
     /// <summary>
-    /// Represents one ternary condition.
+    /// Specifies an equal condition.
     /// </summary>
-    public enum ComparisonConditionType
-    {
-        /// <summary>
-        /// Specifies an equal condition.
-        /// </summary>
-        Equal,
-        /// <summary>
-        /// Specifies a not equal condition.
-        /// </summary>
-        NotEqual,
-        /// <summary>
-        /// Specifies a less than condition.
-        /// </summary>
-        LessThan,
-        /// <summary>
-        /// Specifies a less than or equal condition.
-        /// </summary>
-        LessThanOrEqual,
-        /// <summary>
-        /// Specifies a greater than condition.
-        /// </summary>
-        GreaterThan,
-        /// <summary>
-        /// Specifies a greater than or equal condition.
-        /// </summary>
-        GreaterThanOrEqual
-    }
+    Equal,
+    /// <summary>
+    /// Specifies a not equal condition.
+    /// </summary>
+    NotEqual,
+    /// <summary>
+    /// Specifies a less than condition.
+    /// </summary>
+    LessThan,
+    /// <summary>
+    /// Specifies a less than or equal condition.
+    /// </summary>
+    LessThanOrEqual,
+    /// <summary>
+    /// Specifies a greater than condition.
+    /// </summary>
+    GreaterThan,
+    /// <summary>
+    /// Specifies a greater than or equal condition.
+    /// </summary>
+    GreaterThanOrEqual
 }

--- a/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactivity.Shared/Core/DataTriggerBehavior.cs
+++ b/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactivity.Shared/Core/DataTriggerBehavior.cs
@@ -11,215 +11,214 @@ using Microsoft.UI.Xaml;
 using Windows.UI.Xaml;
 #endif
 
-namespace Microsoft.Xaml.Interactivity
+namespace Microsoft.Xaml.Interactivity;
+
+/// <summary>
+/// A behavior that performs actions when the bound data meets a specified condition.
+/// </summary>
+#if NET8_0_OR_GREATER
+[RequiresUnreferencedCode("This behavior is not trim-safe.")]
+#endif
+public sealed class DataTriggerBehavior : Trigger
 {
     /// <summary>
-    /// A behavior that performs actions when the bound data meets a specified condition.
+    /// Identifies the <seealso cref="Binding"/> dependency property.
     /// </summary>
-#if NET8_0_OR_GREATER
-    [RequiresUnreferencedCode("This behavior is not trim-safe.")]
-#endif
-    public sealed class DataTriggerBehavior : Trigger
+    [SuppressMessage("Microsoft.Security", "CA2104:DoNotDeclareReadOnlyMutableReferenceTypes")]
+    public static readonly DependencyProperty BindingProperty = DependencyProperty.Register(
+        "Binding",
+        typeof(object),
+        typeof(DataTriggerBehavior),
+        new PropertyMetadata(null, new PropertyChangedCallback(DataTriggerBehavior.OnValueChanged)));
+
+    /// <summary>
+    /// Identifies the <seealso cref="ComparisonCondition"/> dependency property.
+    /// </summary>
+    [SuppressMessage("Microsoft.Security", "CA2104:DoNotDeclareReadOnlyMutableReferenceTypes")]
+    public static readonly DependencyProperty ComparisonConditionProperty = DependencyProperty.Register(
+        "ComparisonCondition",
+        typeof(ComparisonConditionType),
+        typeof(DataTriggerBehavior),
+        new PropertyMetadata(ComparisonConditionType.Equal,
+            new PropertyChangedCallback(DataTriggerBehavior.OnValueChanged)));
+
+    /// <summary>
+    /// Identifies the <seealso cref="Value"/> dependency property.
+    /// </summary>
+    [SuppressMessage("Microsoft.Security", "CA2104:DoNotDeclareReadOnlyMutableReferenceTypes")]
+    public static readonly DependencyProperty ValueProperty = DependencyProperty.Register(
+        "Value",
+        typeof(object),
+        typeof(DataTriggerBehavior),
+        new PropertyMetadata(null, new PropertyChangedCallback(DataTriggerBehavior.OnValueChanged)));
+
+    /// <summary>
+    /// Gets or sets the bound object that the <see cref="DataTriggerBehavior"/> will listen to. This is a dependency property.
+    /// </summary>
+    public object Binding
     {
-        /// <summary>
-        /// Identifies the <seealso cref="Binding"/> dependency property.
-        /// </summary>
-        [SuppressMessage("Microsoft.Security", "CA2104:DoNotDeclareReadOnlyMutableReferenceTypes")]
-        public static readonly DependencyProperty BindingProperty = DependencyProperty.Register(
-            "Binding",
-            typeof(object),
-            typeof(DataTriggerBehavior),
-            new PropertyMetadata(null, new PropertyChangedCallback(DataTriggerBehavior.OnValueChanged)));
-
-        /// <summary>
-        /// Identifies the <seealso cref="ComparisonCondition"/> dependency property.
-        /// </summary>
-        [SuppressMessage("Microsoft.Security", "CA2104:DoNotDeclareReadOnlyMutableReferenceTypes")]
-        public static readonly DependencyProperty ComparisonConditionProperty = DependencyProperty.Register(
-            "ComparisonCondition",
-            typeof(ComparisonConditionType),
-            typeof(DataTriggerBehavior),
-            new PropertyMetadata(ComparisonConditionType.Equal,
-                new PropertyChangedCallback(DataTriggerBehavior.OnValueChanged)));
-
-        /// <summary>
-        /// Identifies the <seealso cref="Value"/> dependency property.
-        /// </summary>
-        [SuppressMessage("Microsoft.Security", "CA2104:DoNotDeclareReadOnlyMutableReferenceTypes")]
-        public static readonly DependencyProperty ValueProperty = DependencyProperty.Register(
-            "Value",
-            typeof(object),
-            typeof(DataTriggerBehavior),
-            new PropertyMetadata(null, new PropertyChangedCallback(DataTriggerBehavior.OnValueChanged)));
-
-        /// <summary>
-        /// Gets or sets the bound object that the <see cref="DataTriggerBehavior"/> will listen to. This is a dependency property.
-        /// </summary>
-        public object Binding
+        get
         {
-            get
-            {
-                return (object)this.GetValue(DataTriggerBehavior.BindingProperty);
-            }
-            set
-            {
-                this.SetValue(DataTriggerBehavior.BindingProperty, value);
-            }
+            return (object)this.GetValue(DataTriggerBehavior.BindingProperty);
+        }
+        set
+        {
+            this.SetValue(DataTriggerBehavior.BindingProperty, value);
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets the type of comparison to be performed between <see cref="DataTriggerBehavior.Binding"/> and <see cref="DataTriggerBehavior.Value"/>. This is a dependency property.
+    /// </summary>
+    public ComparisonConditionType ComparisonCondition
+    {
+        get
+        {
+            return (ComparisonConditionType)this.GetValue(DataTriggerBehavior.ComparisonConditionProperty);
+        }
+        set
+        {
+            this.SetValue(DataTriggerBehavior.ComparisonConditionProperty, value);
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets the value to be compared with the value of <see cref="DataTriggerBehavior.Binding"/>. This is a dependency property.
+    /// </summary>
+    [SuppressMessage("Microsoft.Naming", "CA1721:PropertyNamesShouldNotMatchGetMethods")]
+    public object Value
+    {
+        get
+        {
+            return (object)this.GetValue(DataTriggerBehavior.ValueProperty);
+        }
+        set
+        {
+            this.SetValue(DataTriggerBehavior.ValueProperty, value);
+        }
+    }
+
+    private static bool Compare(object leftOperand, ComparisonConditionType operatorType, object rightOperand)
+    {
+        if (leftOperand != null && rightOperand != null)
+        {
+            rightOperand = TypeConverterHelper.Convert(rightOperand.ToString(), leftOperand.GetType().FullName);
         }
 
-        /// <summary>
-        /// Gets or sets the type of comparison to be performed between <see cref="DataTriggerBehavior.Binding"/> and <see cref="DataTriggerBehavior.Value"/>. This is a dependency property.
-        /// </summary>
-        public ComparisonConditionType ComparisonCondition
+        IComparable leftComparableOperand = leftOperand as IComparable;
+        IComparable rightComparableOperand = rightOperand as IComparable;
+        if ((leftComparableOperand != null) && (rightComparableOperand != null))
         {
-            get
-            {
-                return (ComparisonConditionType)this.GetValue(DataTriggerBehavior.ComparisonConditionProperty);
-            }
-            set
-            {
-                this.SetValue(DataTriggerBehavior.ComparisonConditionProperty, value);
-            }
+            return DataTriggerBehavior.EvaluateComparable(leftComparableOperand, operatorType, rightComparableOperand);
         }
 
-        /// <summary>
-        /// Gets or sets the value to be compared with the value of <see cref="DataTriggerBehavior.Binding"/>. This is a dependency property.
-        /// </summary>
-        [SuppressMessage("Microsoft.Naming", "CA1721:PropertyNamesShouldNotMatchGetMethods")]
-        public object Value
+        switch (operatorType)
         {
-            get
-            {
-                return (object)this.GetValue(DataTriggerBehavior.ValueProperty);
-            }
-            set
-            {
-                this.SetValue(DataTriggerBehavior.ValueProperty, value);
-            }
-        }
+            case ComparisonConditionType.Equal:
+                return object.Equals(leftOperand, rightOperand);
 
-        private static bool Compare(object leftOperand, ComparisonConditionType operatorType, object rightOperand)
-        {
-            if (leftOperand != null && rightOperand != null)
-            {
-                rightOperand = TypeConverterHelper.Convert(rightOperand.ToString(), leftOperand.GetType().FullName);
-            }
+            case ComparisonConditionType.NotEqual:
+                return !object.Equals(leftOperand, rightOperand);
 
-            IComparable leftComparableOperand = leftOperand as IComparable;
-            IComparable rightComparableOperand = rightOperand as IComparable;
-            if ((leftComparableOperand != null) && (rightComparableOperand != null))
-            {
-                return DataTriggerBehavior.EvaluateComparable(leftComparableOperand, operatorType, rightComparableOperand);
-            }
-
-            switch (operatorType)
-            {
-                case ComparisonConditionType.Equal:
-                    return object.Equals(leftOperand, rightOperand);
-
-                case ComparisonConditionType.NotEqual:
-                    return !object.Equals(leftOperand, rightOperand);
-
-                case ComparisonConditionType.LessThan:
-                case ComparisonConditionType.LessThanOrEqual:
-                case ComparisonConditionType.GreaterThan:
-                case ComparisonConditionType.GreaterThanOrEqual:
+            case ComparisonConditionType.LessThan:
+            case ComparisonConditionType.LessThanOrEqual:
+            case ComparisonConditionType.GreaterThan:
+            case ComparisonConditionType.GreaterThanOrEqual:
+                {
+                    if (leftComparableOperand == null && rightComparableOperand == null)
                     {
-                        if (leftComparableOperand == null && rightComparableOperand == null)
-                        {
-                            throw new ArgumentException(string.Format(
-                                CultureInfo.CurrentCulture,
-                                ResourceHelper.InvalidOperands,
-                                leftOperand != null ? leftOperand.GetType().Name : "null",
-                                rightOperand != null ? rightOperand.GetType().Name : "null",
-                                operatorType.ToString()));
-                        }
-                        else if (leftComparableOperand == null)
-                        {
-                            throw new ArgumentException(string.Format(
-                                CultureInfo.CurrentCulture,
-                                ResourceHelper.InvalidLeftOperand,
-                                leftOperand != null ? leftOperand.GetType().Name : "null",
-                                operatorType.ToString()));
-                        }
-                        else
-                        {
-                            throw new ArgumentException(string.Format(
-                                CultureInfo.CurrentCulture,
-                                ResourceHelper.InvalidRightOperand,
-                                rightOperand != null ? rightOperand.GetType().Name : "null",
-                                operatorType.ToString()));
-                        }
+                        throw new ArgumentException(string.Format(
+                            CultureInfo.CurrentCulture,
+                            ResourceHelper.InvalidOperands,
+                            leftOperand != null ? leftOperand.GetType().Name : "null",
+                            rightOperand != null ? rightOperand.GetType().Name : "null",
+                            operatorType.ToString()));
                     }
-            }
-
-            return false;
+                    else if (leftComparableOperand == null)
+                    {
+                        throw new ArgumentException(string.Format(
+                            CultureInfo.CurrentCulture,
+                            ResourceHelper.InvalidLeftOperand,
+                            leftOperand != null ? leftOperand.GetType().Name : "null",
+                            operatorType.ToString()));
+                    }
+                    else
+                    {
+                        throw new ArgumentException(string.Format(
+                            CultureInfo.CurrentCulture,
+                            ResourceHelper.InvalidRightOperand,
+                            rightOperand != null ? rightOperand.GetType().Name : "null",
+                            operatorType.ToString()));
+                    }
+                }
         }
 
-        /// <summary>
-        /// Evaluates both operands that implement the IComparable interface.
-        /// </summary>
-        private static bool EvaluateComparable(IComparable leftOperand, ComparisonConditionType operatorType, IComparable rightOperand)
+        return false;
+    }
+
+    /// <summary>
+    /// Evaluates both operands that implement the IComparable interface.
+    /// </summary>
+    private static bool EvaluateComparable(IComparable leftOperand, ComparisonConditionType operatorType, IComparable rightOperand)
+    {
+        object convertedOperand = null;
+        try
         {
-            object convertedOperand = null;
-            try
-            {
-                convertedOperand = Convert.ChangeType(rightOperand, leftOperand.GetType(), CultureInfo.CurrentCulture);
-            }
-            catch (FormatException)
-            {
-                // FormatException: Convert.ChangeType("hello", typeof(double), ...);
-            }
-            catch (InvalidCastException)
-            {
-                // InvalidCastException: Convert.ChangeType(4.0d, typeof(Rectangle), ...);
-            }
-
-            if (convertedOperand == null)
-            {
-                return operatorType == ComparisonConditionType.NotEqual;
-            }
-
-            int comparison = leftOperand.CompareTo((IComparable)convertedOperand);
-            switch (operatorType)
-            {
-                case ComparisonConditionType.Equal:
-                    return comparison == 0;
-
-                case ComparisonConditionType.NotEqual:
-                    return comparison != 0;
-
-                case ComparisonConditionType.LessThan:
-                    return comparison < 0;
-
-                case ComparisonConditionType.LessThanOrEqual:
-                    return comparison <= 0;
-
-                case ComparisonConditionType.GreaterThan:
-                    return comparison > 0;
-
-                case ComparisonConditionType.GreaterThanOrEqual:
-                    return comparison >= 0;
-            }
-
-            return false;
+            convertedOperand = Convert.ChangeType(rightOperand, leftOperand.GetType(), CultureInfo.CurrentCulture);
+        }
+        catch (FormatException)
+        {
+            // FormatException: Convert.ChangeType("hello", typeof(double), ...);
+        }
+        catch (InvalidCastException)
+        {
+            // InvalidCastException: Convert.ChangeType(4.0d, typeof(Rectangle), ...);
         }
 
-        private static void OnValueChanged(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs args)
+        if (convertedOperand == null)
         {
-            DataTriggerBehavior dataTriggerBehavior = (DataTriggerBehavior)dependencyObject;
-            if (dataTriggerBehavior.AssociatedObject == null)
-            {
-                return;
-            }
+            return operatorType == ComparisonConditionType.NotEqual;
+        }
 
-            DataBindingHelper.RefreshDataBindingsOnActions(dataTriggerBehavior.Actions);
+        int comparison = leftOperand.CompareTo((IComparable)convertedOperand);
+        switch (operatorType)
+        {
+            case ComparisonConditionType.Equal:
+                return comparison == 0;
 
-            // Some value has changed--either the binding value, reference value, or the comparison condition. Re-evaluate the equation.
-            if (DataTriggerBehavior.Compare(dataTriggerBehavior.Binding, dataTriggerBehavior.ComparisonCondition, dataTriggerBehavior.Value))
-            {
-                Interaction.ExecuteActions(dataTriggerBehavior.AssociatedObject, dataTriggerBehavior.Actions, args);
-            }
+            case ComparisonConditionType.NotEqual:
+                return comparison != 0;
+
+            case ComparisonConditionType.LessThan:
+                return comparison < 0;
+
+            case ComparisonConditionType.LessThanOrEqual:
+                return comparison <= 0;
+
+            case ComparisonConditionType.GreaterThan:
+                return comparison > 0;
+
+            case ComparisonConditionType.GreaterThanOrEqual:
+                return comparison >= 0;
+        }
+
+        return false;
+    }
+
+    private static void OnValueChanged(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs args)
+    {
+        DataTriggerBehavior dataTriggerBehavior = (DataTriggerBehavior)dependencyObject;
+        if (dataTriggerBehavior.AssociatedObject == null)
+        {
+            return;
+        }
+
+        DataBindingHelper.RefreshDataBindingsOnActions(dataTriggerBehavior.Actions);
+
+        // Some value has changed--either the binding value, reference value, or the comparison condition. Re-evaluate the equation.
+        if (DataTriggerBehavior.Compare(dataTriggerBehavior.Binding, dataTriggerBehavior.ComparisonCondition, dataTriggerBehavior.Value))
+        {
+            Interaction.ExecuteActions(dataTriggerBehavior.AssociatedObject, dataTriggerBehavior.Actions, args);
         }
     }
 }

--- a/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactivity.Shared/Core/EventTriggerBehavior.cs
+++ b/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactivity.Shared/Core/EventTriggerBehavior.cs
@@ -16,298 +16,297 @@ using Windows.UI.Xaml.Media;
 using System.Runtime.InteropServices.WindowsRuntime;
 #endif
 
-namespace Microsoft.Xaml.Interactivity
+namespace Microsoft.Xaml.Interactivity;
+
+/// <summary>
+/// A behavior that listens for a specified event on its source and executes its actions when that event is fired.
+/// </summary>
+#if NET8_0_OR_GREATER
+[RequiresUnreferencedCode("This behavior is not trim-safe.")]
+#endif
+public sealed class EventTriggerBehavior : Trigger
 {
     /// <summary>
-    /// A behavior that listens for a specified event on its source and executes its actions when that event is fired.
+    /// Identifies the <seealso cref="EventName"/> dependency property.
     /// </summary>
-#if NET8_0_OR_GREATER
-    [RequiresUnreferencedCode("This behavior is not trim-safe.")]
+    [SuppressMessage("Microsoft.Security", "CA2104:DoNotDeclareReadOnlyMutableReferenceTypes")]
+    public static readonly DependencyProperty EventNameProperty = DependencyProperty.Register(
+        "EventName",
+        typeof(string),
+        typeof(EventTriggerBehavior),
+        new PropertyMetadata("Loaded", new PropertyChangedCallback(EventTriggerBehavior.OnEventNameChanged)));
+
+    /// <summary>
+    /// Identifies the <seealso cref="SourceObject"/> dependency property.
+    /// </summary>
+    [SuppressMessage("Microsoft.Security", "CA2104:DoNotDeclareReadOnlyMutableReferenceTypes")]
+    public static readonly DependencyProperty SourceObjectProperty = DependencyProperty.Register(
+        "SourceObject",
+        typeof(object),
+        typeof(EventTriggerBehavior),
+        new PropertyMetadata(null, new PropertyChangedCallback(EventTriggerBehavior.OnSourceObjectChanged)));
+
+    private object _resolvedSource;
+    private Delegate _eventHandler;
+    private bool _isLoadedEventRegistered;
+#if !NET8_0_OR_GREATER
+    private bool _isWindowsRuntimeEvent;
+    private Func<Delegate, EventRegistrationToken> _addEventHandlerMethod;
+    private Action<EventRegistrationToken> _removeEventHandlerMethod;
 #endif
-    public sealed class EventTriggerBehavior : Trigger
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="EventTriggerBehavior"/> class.
+    /// </summary>
+    public EventTriggerBehavior()
     {
-        /// <summary>
-        /// Identifies the <seealso cref="EventName"/> dependency property.
-        /// </summary>
-        [SuppressMessage("Microsoft.Security", "CA2104:DoNotDeclareReadOnlyMutableReferenceTypes")]
-        public static readonly DependencyProperty EventNameProperty = DependencyProperty.Register(
-            "EventName",
-            typeof(string),
-            typeof(EventTriggerBehavior),
-            new PropertyMetadata("Loaded", new PropertyChangedCallback(EventTriggerBehavior.OnEventNameChanged)));
-
-        /// <summary>
-        /// Identifies the <seealso cref="SourceObject"/> dependency property.
-        /// </summary>
-        [SuppressMessage("Microsoft.Security", "CA2104:DoNotDeclareReadOnlyMutableReferenceTypes")]
-        public static readonly DependencyProperty SourceObjectProperty = DependencyProperty.Register(
-            "SourceObject",
-            typeof(object),
-            typeof(EventTriggerBehavior),
-            new PropertyMetadata(null, new PropertyChangedCallback(EventTriggerBehavior.OnSourceObjectChanged)));
-
-        private object _resolvedSource;
-        private Delegate _eventHandler;
-        private bool _isLoadedEventRegistered;
-#if !NET8_0_OR_GREATER
-        private bool _isWindowsRuntimeEvent;
-        private Func<Delegate, EventRegistrationToken> _addEventHandlerMethod;
-        private Action<EventRegistrationToken> _removeEventHandlerMethod;
-#endif
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="EventTriggerBehavior"/> class.
-        /// </summary>
-        public EventTriggerBehavior()
-        {
-        }
-
-        /// <summary>
-        /// Gets or sets the name of the event to listen for. This is a dependency property.
-        /// </summary>
-        public string EventName
-        {
-            get
-            {
-                return (string)this.GetValue(EventTriggerBehavior.EventNameProperty);
-            }
-
-            set
-            {
-                this.SetValue(EventTriggerBehavior.EventNameProperty, value);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the source object from which this behavior listens for events.
-        /// If <seealso cref="SourceObject"/> is not set, the source will default to <seealso cref="Microsoft.Xaml.Interactivity.Behavior.AssociatedObject"/>. This is a dependency property.
-        /// </summary>
-        public object SourceObject
-        {
-            get
-            {
-                return (object)this.GetValue(EventTriggerBehavior.SourceObjectProperty);
-            }
-
-            set
-            {
-                this.SetValue(EventTriggerBehavior.SourceObjectProperty, value);
-            }
-        }
-
-        /// <summary>
-        /// Called after the behavior is attached to the <see cref="Microsoft.Xaml.Interactivity.Behavior.AssociatedObject"/>.
-        /// </summary>
-        protected override void OnAttached()
-        {
-            base.OnAttached();
-            this.SetResolvedSource(this.ComputeResolvedSource());
-        }
-
-        /// <summary>
-        /// Called when the behavior is being detached from its <see cref="Microsoft.Xaml.Interactivity.Behavior.AssociatedObject"/>.
-        /// </summary>
-        protected override void OnDetaching()
-        {
-            base.OnDetaching();
-            this.SetResolvedSource(null);
-        }
-
-        private void SetResolvedSource(object newSource)
-        {
-            if (this.AssociatedObject == null || this._resolvedSource == newSource)
-            {
-                return;
-            }
-
-            if (this._resolvedSource != null)
-            {
-                this.UnregisterEvent(this.EventName);
-            }
-
-            this._resolvedSource = newSource;
-
-            if (this._resolvedSource != null)
-            {
-                this.RegisterEvent(this.EventName);
-            }
-        }
-
-        private object ComputeResolvedSource()
-        {
-            // If the SourceObject property is set at all, we want to use it. It is possible that it is data
-            // bound and bindings haven't been evaluated yet. Plus, this makes the API more predictable.
-            if (this.ReadLocalValue(EventTriggerBehavior.SourceObjectProperty) != DependencyProperty.UnsetValue)
-            {
-                return this.SourceObject;
-            }
-
-            return this.AssociatedObject;
-        }
-
-        private void RegisterEvent(string eventName)
-        {
-            if (string.IsNullOrEmpty(eventName))
-            {
-                return;
-            }
-
-            if (eventName != "Loaded")
-            {
-                Type sourceObjectType = this._resolvedSource.GetType();
-                EventInfo info = sourceObjectType.GetRuntimeEvent(eventName);
-                if (info == null)
-                {
-                    return;
-                }
-
-                MethodInfo methodInfo = typeof(EventTriggerBehavior).GetTypeInfo().GetDeclaredMethod("OnEvent");
-                this._eventHandler = methodInfo.CreateDelegate(info.EventHandlerType, this);
-
-#if NET8_0_OR_GREATER
-                info.AddEventHandler(this._resolvedSource, this._eventHandler);
-#else
-                this._isWindowsRuntimeEvent = EventTriggerBehavior.IsWindowsRuntimeEvent(info);
-                if (this._isWindowsRuntimeEvent)
-                {
-                    this._addEventHandlerMethod = add => (EventRegistrationToken)info.AddMethod.Invoke(this._resolvedSource, new object[] { add });
-                    this._removeEventHandlerMethod = token => info.RemoveMethod.Invoke(this._resolvedSource, new object[] { token });
-
-                    WindowsRuntimeMarshal.AddEventHandler(this._addEventHandlerMethod, this._removeEventHandlerMethod, this._eventHandler);
-                }
-                else
-                {
-                    info.AddEventHandler(this._resolvedSource, this._eventHandler);
-                }
-#endif
-            }
-            else if (!this._isLoadedEventRegistered)
-            {
-                FrameworkElement element = this._resolvedSource as FrameworkElement;
-                if (element != null && !EventTriggerBehaviorHelpers.IsElementLoaded(element))
-                {
-                    this._isLoadedEventRegistered = true;
-                    element.Loaded += this.OnEvent;
-                }
-            }
-        }
-
-        private void UnregisterEvent(string eventName)
-        {
-            if (string.IsNullOrEmpty(eventName))
-            {
-                return;
-            }
-
-            if (eventName != "Loaded")
-            {
-                if (this._eventHandler == null)
-                {
-                    return;
-                }
-
-                EventInfo info = this._resolvedSource.GetType().GetRuntimeEvent(eventName);
-#if NET8_0_OR_GREATER
-                info.RemoveEventHandler(this._resolvedSource, this._eventHandler);
-#else
-                if (this._isWindowsRuntimeEvent)
-                {
-                    WindowsRuntimeMarshal.RemoveEventHandler(this._removeEventHandlerMethod, this._eventHandler);
-                }
-                else
-                {
-                    info.RemoveEventHandler(this._resolvedSource, this._eventHandler);
-                }
-#endif
-
-                this._eventHandler = null;
-            }
-            else if (this._isLoadedEventRegistered)
-            {
-                this._isLoadedEventRegistered = false;
-                FrameworkElement element = (FrameworkElement)this._resolvedSource;
-                element.Loaded -= this.OnEvent;
-            }
-        }
-
-        private void OnEvent(object sender, object eventArgs)
-        {
-            Interaction.ExecuteActions(this._resolvedSource, this.Actions, eventArgs);
-        }
-
-        private static void OnSourceObjectChanged(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs args)
-        {
-            EventTriggerBehavior behavior = (EventTriggerBehavior)dependencyObject;
-            behavior.SetResolvedSource(behavior.ComputeResolvedSource());
-        }
-
-        private static void OnEventNameChanged(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs args)
-        {
-            EventTriggerBehavior behavior = (EventTriggerBehavior)dependencyObject;
-            if (behavior.AssociatedObject == null || behavior._resolvedSource == null)
-            {
-                return;
-            }
-
-            string oldEventName = (string)args.OldValue;
-            string newEventName = (string)args.NewValue;
-
-            behavior.UnregisterEvent(oldEventName);
-            behavior.RegisterEvent(newEventName);
-        }
-
-#if !NET8_0_OR_GREATER
-        private static bool IsWindowsRuntimeEvent(EventInfo eventInfo)
-        {
-            return eventInfo != null &&
-                EventTriggerBehavior.IsWindowsRuntimeType(eventInfo.EventHandlerType) &&
-                EventTriggerBehavior.IsWindowsRuntimeType(eventInfo.DeclaringType);
-        }
-
-        private static bool IsWindowsRuntimeType(Type type)
-        {
-            if (type != null)
-            {
-                // This will only work when using built-in WinRT interop, ie. where .winmd files are directly
-                // referenced instead of generated projections. That is, this would not work on modern .NET.
-                return type.AssemblyQualifiedName.EndsWith("ContentType=WindowsRuntime", StringComparison.Ordinal);
-            }
-
-            return false;
-        }
-#endif
     }
 
-    internal static class EventTriggerBehaviorHelpers
+    /// <summary>
+    /// Gets or sets the name of the event to listen for. This is a dependency property.
+    /// </summary>
+    public string EventName
     {
-        // This method has to be outside of 'EventTriggerBehavior', because it's actually trim-safe.
-        // We want to allow other callers inside the library use this without getting trim warnings.
-        public static bool IsElementLoaded(FrameworkElement element)
+        get
         {
-            if (element == null)
-            {
-                return false;
-            }
-
-            UIElement rootVisual = default;
-            if (element.XamlRoot != null)
-            {
-                rootVisual = element.XamlRoot.Content;
-            }
-            else if (Window.Current != null)
-            {
-                rootVisual = Window.Current.Content;
-            }
-
-            DependencyObject parent = element.Parent;
-            if (parent == null)
-            {
-                // If the element is the child of a ControlTemplate it will have a null parent even when it is loaded.
-                // To catch that scenario, also check it's parent in the visual tree.
-                parent = VisualTreeHelper.GetParent(element);
-            }
-
-            return (parent != null || (rootVisual != null && element == rootVisual));
+            return (string)this.GetValue(EventTriggerBehavior.EventNameProperty);
         }
+
+        set
+        {
+            this.SetValue(EventTriggerBehavior.EventNameProperty, value);
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets the source object from which this behavior listens for events.
+    /// If <seealso cref="SourceObject"/> is not set, the source will default to <seealso cref="Microsoft.Xaml.Interactivity.Behavior.AssociatedObject"/>. This is a dependency property.
+    /// </summary>
+    public object SourceObject
+    {
+        get
+        {
+            return (object)this.GetValue(EventTriggerBehavior.SourceObjectProperty);
+        }
+
+        set
+        {
+            this.SetValue(EventTriggerBehavior.SourceObjectProperty, value);
+        }
+    }
+
+    /// <summary>
+    /// Called after the behavior is attached to the <see cref="Microsoft.Xaml.Interactivity.Behavior.AssociatedObject"/>.
+    /// </summary>
+    protected override void OnAttached()
+    {
+        base.OnAttached();
+        this.SetResolvedSource(this.ComputeResolvedSource());
+    }
+
+    /// <summary>
+    /// Called when the behavior is being detached from its <see cref="Microsoft.Xaml.Interactivity.Behavior.AssociatedObject"/>.
+    /// </summary>
+    protected override void OnDetaching()
+    {
+        base.OnDetaching();
+        this.SetResolvedSource(null);
+    }
+
+    private void SetResolvedSource(object newSource)
+    {
+        if (this.AssociatedObject == null || this._resolvedSource == newSource)
+        {
+            return;
+        }
+
+        if (this._resolvedSource != null)
+        {
+            this.UnregisterEvent(this.EventName);
+        }
+
+        this._resolvedSource = newSource;
+
+        if (this._resolvedSource != null)
+        {
+            this.RegisterEvent(this.EventName);
+        }
+    }
+
+    private object ComputeResolvedSource()
+    {
+        // If the SourceObject property is set at all, we want to use it. It is possible that it is data
+        // bound and bindings haven't been evaluated yet. Plus, this makes the API more predictable.
+        if (this.ReadLocalValue(EventTriggerBehavior.SourceObjectProperty) != DependencyProperty.UnsetValue)
+        {
+            return this.SourceObject;
+        }
+
+        return this.AssociatedObject;
+    }
+
+    private void RegisterEvent(string eventName)
+    {
+        if (string.IsNullOrEmpty(eventName))
+        {
+            return;
+        }
+
+        if (eventName != "Loaded")
+        {
+            Type sourceObjectType = this._resolvedSource.GetType();
+            EventInfo info = sourceObjectType.GetRuntimeEvent(eventName);
+            if (info == null)
+            {
+                return;
+            }
+
+            MethodInfo methodInfo = typeof(EventTriggerBehavior).GetTypeInfo().GetDeclaredMethod("OnEvent");
+            this._eventHandler = methodInfo.CreateDelegate(info.EventHandlerType, this);
+
+#if NET8_0_OR_GREATER
+            info.AddEventHandler(this._resolvedSource, this._eventHandler);
+#else
+            this._isWindowsRuntimeEvent = EventTriggerBehavior.IsWindowsRuntimeEvent(info);
+            if (this._isWindowsRuntimeEvent)
+            {
+                this._addEventHandlerMethod = add => (EventRegistrationToken)info.AddMethod.Invoke(this._resolvedSource, new object[] { add });
+                this._removeEventHandlerMethod = token => info.RemoveMethod.Invoke(this._resolvedSource, new object[] { token });
+
+                WindowsRuntimeMarshal.AddEventHandler(this._addEventHandlerMethod, this._removeEventHandlerMethod, this._eventHandler);
+            }
+            else
+            {
+                info.AddEventHandler(this._resolvedSource, this._eventHandler);
+            }
+#endif
+        }
+        else if (!this._isLoadedEventRegistered)
+        {
+            FrameworkElement element = this._resolvedSource as FrameworkElement;
+            if (element != null && !EventTriggerBehaviorHelpers.IsElementLoaded(element))
+            {
+                this._isLoadedEventRegistered = true;
+                element.Loaded += this.OnEvent;
+            }
+        }
+    }
+
+    private void UnregisterEvent(string eventName)
+    {
+        if (string.IsNullOrEmpty(eventName))
+        {
+            return;
+        }
+
+        if (eventName != "Loaded")
+        {
+            if (this._eventHandler == null)
+            {
+                return;
+            }
+
+            EventInfo info = this._resolvedSource.GetType().GetRuntimeEvent(eventName);
+#if NET8_0_OR_GREATER
+            info.RemoveEventHandler(this._resolvedSource, this._eventHandler);
+#else
+            if (this._isWindowsRuntimeEvent)
+            {
+                WindowsRuntimeMarshal.RemoveEventHandler(this._removeEventHandlerMethod, this._eventHandler);
+            }
+            else
+            {
+                info.RemoveEventHandler(this._resolvedSource, this._eventHandler);
+            }
+#endif
+
+            this._eventHandler = null;
+        }
+        else if (this._isLoadedEventRegistered)
+        {
+            this._isLoadedEventRegistered = false;
+            FrameworkElement element = (FrameworkElement)this._resolvedSource;
+            element.Loaded -= this.OnEvent;
+        }
+    }
+
+    private void OnEvent(object sender, object eventArgs)
+    {
+        Interaction.ExecuteActions(this._resolvedSource, this.Actions, eventArgs);
+    }
+
+    private static void OnSourceObjectChanged(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs args)
+    {
+        EventTriggerBehavior behavior = (EventTriggerBehavior)dependencyObject;
+        behavior.SetResolvedSource(behavior.ComputeResolvedSource());
+    }
+
+    private static void OnEventNameChanged(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs args)
+    {
+        EventTriggerBehavior behavior = (EventTriggerBehavior)dependencyObject;
+        if (behavior.AssociatedObject == null || behavior._resolvedSource == null)
+        {
+            return;
+        }
+
+        string oldEventName = (string)args.OldValue;
+        string newEventName = (string)args.NewValue;
+
+        behavior.UnregisterEvent(oldEventName);
+        behavior.RegisterEvent(newEventName);
+    }
+
+#if !NET8_0_OR_GREATER
+    private static bool IsWindowsRuntimeEvent(EventInfo eventInfo)
+    {
+        return eventInfo != null &&
+            EventTriggerBehavior.IsWindowsRuntimeType(eventInfo.EventHandlerType) &&
+            EventTriggerBehavior.IsWindowsRuntimeType(eventInfo.DeclaringType);
+    }
+
+    private static bool IsWindowsRuntimeType(Type type)
+    {
+        if (type != null)
+        {
+            // This will only work when using built-in WinRT interop, ie. where .winmd files are directly
+            // referenced instead of generated projections. That is, this would not work on modern .NET.
+            return type.AssemblyQualifiedName.EndsWith("ContentType=WindowsRuntime", StringComparison.Ordinal);
+        }
+
+        return false;
+    }
+#endif
+}
+
+internal static class EventTriggerBehaviorHelpers
+{
+    // This method has to be outside of 'EventTriggerBehavior', because it's actually trim-safe.
+    // We want to allow other callers inside the library use this without getting trim warnings.
+    public static bool IsElementLoaded(FrameworkElement element)
+    {
+        if (element == null)
+        {
+            return false;
+        }
+
+        UIElement rootVisual = default;
+        if (element.XamlRoot != null)
+        {
+            rootVisual = element.XamlRoot.Content;
+        }
+        else if (Window.Current != null)
+        {
+            rootVisual = Window.Current.Content;
+        }
+
+        DependencyObject parent = element.Parent;
+        if (parent == null)
+        {
+            // If the element is the child of a ControlTemplate it will have a null parent even when it is loaded.
+            // To catch that scenario, also check it's parent in the visual tree.
+            parent = VisualTreeHelper.GetParent(element);
+        }
+
+        return (parent != null || (rootVisual != null && element == rootVisual));
     }
 }

--- a/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactivity.Shared/Core/GoToStateAction.cs
+++ b/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactivity.Shared/Core/GoToStateAction.cs
@@ -13,133 +13,132 @@ using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 #endif
 
-namespace Microsoft.Xaml.Interactivity
+namespace Microsoft.Xaml.Interactivity;
+
+/// <summary>
+/// An action that will transition a <see cref="FrameworkElement"/> to a specified <seealso cref="VisualState"/> when executed.
+/// </summary>
+/// <remarks>
+/// If the <seealso cref="TargetObject"/> property is set, this action will attempt to change the state of the targeted element. If it is not set, the action walks
+/// the element tree in an attempt to locate an alternative target that defines states. <see cref="ControlTemplate"/> and <see cref="UserControl"/> are 
+/// two common results.
+/// </remarks>
+public sealed class GoToStateAction : DependencyObject, IAction
 {
     /// <summary>
-    /// An action that will transition a <see cref="FrameworkElement"/> to a specified <seealso cref="VisualState"/> when executed.
+    /// Identifies the <seealso cref="UseTransitions"/> dependency property.
     /// </summary>
-    /// <remarks>
-    /// If the <seealso cref="TargetObject"/> property is set, this action will attempt to change the state of the targeted element. If it is not set, the action walks
-    /// the element tree in an attempt to locate an alternative target that defines states. <see cref="ControlTemplate"/> and <see cref="UserControl"/> are 
-    /// two common results.
-    /// </remarks>
-    public sealed class GoToStateAction : DependencyObject, IAction
+    [SuppressMessage("Microsoft.Security", "CA2104:DoNotDeclareReadOnlyMutableReferenceTypes")]
+    public static readonly DependencyProperty UseTransitionsProperty = DependencyProperty.Register(
+        "UseTransitions",
+        typeof(bool),
+        typeof(GoToStateAction),
+        new PropertyMetadata(true));
+
+    /// <summary>
+    /// Identifies the <seealso cref="StateName"/> dependency property.
+    /// </summary>
+    [SuppressMessage("Microsoft.Security", "CA2104:DoNotDeclareReadOnlyMutableReferenceTypes")]
+    public static readonly DependencyProperty StateNameProperty = DependencyProperty.Register(
+        "StateName",
+        typeof(string),
+        typeof(GoToStateAction),
+        new PropertyMetadata(null));
+
+    /// <summary>
+    /// Identifies the <seealso cref="TargetObject"/> dependency property.
+    /// </summary>
+    [SuppressMessage("Microsoft.Security", "CA2104:DoNotDeclareReadOnlyMutableReferenceTypes")]
+    public static readonly DependencyProperty TargetObjectProperty = DependencyProperty.Register(
+        "TargetObject",
+        typeof(FrameworkElement),
+        typeof(GoToStateAction),
+        new PropertyMetadata(null));
+
+    /// <summary>
+    /// Gets or sets whether or not to use a <see cref="VisualTransition"/> to transition between states. This is a dependency property.
+    /// </summary>
+    public bool UseTransitions
     {
-        /// <summary>
-        /// Identifies the <seealso cref="UseTransitions"/> dependency property.
-        /// </summary>
-        [SuppressMessage("Microsoft.Security", "CA2104:DoNotDeclareReadOnlyMutableReferenceTypes")]
-        public static readonly DependencyProperty UseTransitionsProperty = DependencyProperty.Register(
-            "UseTransitions",
-            typeof(bool),
-            typeof(GoToStateAction),
-            new PropertyMetadata(true));
-
-        /// <summary>
-        /// Identifies the <seealso cref="StateName"/> dependency property.
-        /// </summary>
-        [SuppressMessage("Microsoft.Security", "CA2104:DoNotDeclareReadOnlyMutableReferenceTypes")]
-        public static readonly DependencyProperty StateNameProperty = DependencyProperty.Register(
-            "StateName",
-            typeof(string),
-            typeof(GoToStateAction),
-            new PropertyMetadata(null));
-
-        /// <summary>
-        /// Identifies the <seealso cref="TargetObject"/> dependency property.
-        /// </summary>
-        [SuppressMessage("Microsoft.Security", "CA2104:DoNotDeclareReadOnlyMutableReferenceTypes")]
-        public static readonly DependencyProperty TargetObjectProperty = DependencyProperty.Register(
-            "TargetObject",
-            typeof(FrameworkElement),
-            typeof(GoToStateAction),
-            new PropertyMetadata(null));
-
-        /// <summary>
-        /// Gets or sets whether or not to use a <see cref="VisualTransition"/> to transition between states. This is a dependency property.
-        /// </summary>
-        public bool UseTransitions
+        get
         {
-            get
-            {
-                return (bool)this.GetValue(GoToStateAction.UseTransitionsProperty);
-            }
-            set
-            {
-                this.SetValue(GoToStateAction.UseTransitionsProperty, value);
-            }
+            return (bool)this.GetValue(GoToStateAction.UseTransitionsProperty);
+        }
+        set
+        {
+            this.SetValue(GoToStateAction.UseTransitionsProperty, value);
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets the name of the <see cref="VisualState"/>. This is a dependency property.
+    /// </summary>
+    public string StateName
+    {
+        get
+        {
+            return (string)this.GetValue(GoToStateAction.StateNameProperty);
+        }
+        set
+        {
+            this.SetValue(GoToStateAction.StateNameProperty, value);
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets the target object. This is a dependency property.
+    /// </summary>
+    public FrameworkElement TargetObject
+    {
+        get
+        {
+            return (FrameworkElement)this.GetValue(GoToStateAction.TargetObjectProperty);
+        }
+        set
+        {
+            this.SetValue(GoToStateAction.TargetObjectProperty, value);
+        }
+    }
+
+    /// <summary>
+    /// Executes the action.
+    /// </summary>
+    /// <param name="sender">The <see cref="object"/> that is passed to the action by the behavior. Generally this is <seealso cref="Microsoft.Xaml.Interactivity.IBehavior.AssociatedObject"/> or a target object.</param>
+    /// <param name="parameter">The value of this parameter is determined by the caller.</param>
+    /// <returns>True if the transition to the specified state succeeds; else false.</returns>
+    public object Execute(object sender, object parameter)
+    {
+        if (string.IsNullOrEmpty(this.StateName))
+        {
+            return false;
         }
 
-        /// <summary>
-        /// Gets or sets the name of the <see cref="VisualState"/>. This is a dependency property.
-        /// </summary>
-        public string StateName
+        if (this.ReadLocalValue(GoToStateAction.TargetObjectProperty) != DependencyProperty.UnsetValue)
         {
-            get
-            {
-                return (string)this.GetValue(GoToStateAction.StateNameProperty);
-            }
-            set
-            {
-                this.SetValue(GoToStateAction.StateNameProperty, value);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the target object. This is a dependency property.
-        /// </summary>
-        public FrameworkElement TargetObject
-        {
-            get
-            {
-                return (FrameworkElement)this.GetValue(GoToStateAction.TargetObjectProperty);
-            }
-            set
-            {
-                this.SetValue(GoToStateAction.TargetObjectProperty, value);
-            }
-        }
-
-        /// <summary>
-        /// Executes the action.
-        /// </summary>
-        /// <param name="sender">The <see cref="object"/> that is passed to the action by the behavior. Generally this is <seealso cref="Microsoft.Xaml.Interactivity.IBehavior.AssociatedObject"/> or a target object.</param>
-        /// <param name="parameter">The value of this parameter is determined by the caller.</param>
-        /// <returns>True if the transition to the specified state succeeds; else false.</returns>
-        public object Execute(object sender, object parameter)
-        {
-            if (string.IsNullOrEmpty(this.StateName))
+            Control control = this.TargetObject as Control;
+            if (control == null)
             {
                 return false;
             }
 
-            if (this.ReadLocalValue(GoToStateAction.TargetObjectProperty) != DependencyProperty.UnsetValue)
-            {
-                Control control = this.TargetObject as Control;
-                if (control == null)
-                {
-                    return false;
-                }
-
-                return VisualStateUtilities.GoToState(control, this.StateName, this.UseTransitions);
-            }
-
-            FrameworkElement element = sender as FrameworkElement;
-            if (element == null || !EventTriggerBehaviorHelpers.IsElementLoaded(element))
-            {
-                return false;
-            }
-
-            Control resolvedControl = VisualStateUtilities.FindNearestStatefulControl(element);
-            if (resolvedControl == null)
-            {
-                throw new InvalidOperationException(string.Format(
-                    CultureInfo.CurrentCulture,
-                    ResourceHelper.GoToStateActionTargetHasNoStateGroups,
-                    element.Name));
-            }
-
-            return VisualStateUtilities.GoToState(resolvedControl, this.StateName, this.UseTransitions);
+            return VisualStateUtilities.GoToState(control, this.StateName, this.UseTransitions);
         }
+
+        FrameworkElement element = sender as FrameworkElement;
+        if (element == null || !EventTriggerBehaviorHelpers.IsElementLoaded(element))
+        {
+            return false;
+        }
+
+        Control resolvedControl = VisualStateUtilities.FindNearestStatefulControl(element);
+        if (resolvedControl == null)
+        {
+            throw new InvalidOperationException(string.Format(
+                CultureInfo.CurrentCulture,
+                ResourceHelper.GoToStateActionTargetHasNoStateGroups,
+                element.Name));
+        }
+
+        return VisualStateUtilities.GoToState(resolvedControl, this.StateName, this.UseTransitions);
     }
 }

--- a/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactivity.Shared/Core/IncrementalUpdateBehavior.cs
+++ b/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactivity.Shared/Core/IncrementalUpdateBehavior.cs
@@ -17,124 +17,316 @@ using Windows.UI.Xaml.Controls.Primitives;
 using Windows.UI.Xaml.Media;
 #endif
 
-namespace Microsoft.Xaml.Interactivity
+namespace Microsoft.Xaml.Interactivity;
+
+/// <summary>
+/// A behavior that allows incremental updating of <seealso cref="ListView"/> and <seealso cref="GridView"/> contents to support faster updating.
+/// By attaching this behavior to elements in the <seealso cref="ItemsControl.ItemTemplate"/> used by these views, some of the updates can be deferred until there is render time available, resulting in a smoother experience.
+/// </summary>
+public sealed class IncrementalUpdateBehavior : Behavior<FrameworkElement>
 {
     /// <summary>
-    /// A behavior that allows incremental updating of <seealso cref="ListView"/> and <seealso cref="GridView"/> contents to support faster updating.
-    /// By attaching this behavior to elements in the <seealso cref="ItemsControl.ItemTemplate"/> used by these views, some of the updates can be deferred until there is render time available, resulting in a smoother experience.
+    /// Identifies the <seealso cref="Phase"/> dependency property.
     /// </summary>
-    public sealed class IncrementalUpdateBehavior : Behavior<FrameworkElement>
+    [SuppressMessage("Microsoft.Security", "CA2104:DoNotDeclareReadOnlyMutableReferenceTypes")]
+    public static readonly DependencyProperty PhaseProperty = DependencyProperty.Register(
+        "Phase",
+        typeof(int),
+        typeof(IncrementalUpdateBehavior),
+        new PropertyMetadata((int)1, new PropertyChangedCallback(IncrementalUpdateBehavior.OnPhaseChanged)));
+
+    /// <summary>
+    /// Identifies the <seealso cref="IncrementalUpdater"/> dependency property.
+    /// </summary>
+    private static readonly DependencyProperty IncrementalUpdaterProperty = DependencyProperty.RegisterAttached(
+        "IncrementalUpdater",
+        typeof(IncrementalUpdater),
+        typeof(IncrementalUpdateBehavior),
+        new PropertyMetadata(null, new PropertyChangedCallback(IncrementalUpdateBehavior.OnIncrementalUpdaterChanged)));
+
+    private IncrementalUpdater _updater = null;
+
+    /// <summary>
+    /// Gets or sets the relative priority of this incremental update. Lower Phase values are addressed first.
+    /// </summary>
+    public int Phase
     {
-        /// <summary>
-        /// Identifies the <seealso cref="Phase"/> dependency property.
-        /// </summary>
-        [SuppressMessage("Microsoft.Security", "CA2104:DoNotDeclareReadOnlyMutableReferenceTypes")]
-        public static readonly DependencyProperty PhaseProperty = DependencyProperty.Register(
-            "Phase",
-            typeof(int),
-            typeof(IncrementalUpdateBehavior),
-            new PropertyMetadata((int)1, new PropertyChangedCallback(IncrementalUpdateBehavior.OnPhaseChanged)));
+        get { return (int)this.GetValue(IncrementalUpdateBehavior.PhaseProperty); }
+        set { this.SetValue(IncrementalUpdateBehavior.PhaseProperty, value); }
+    }
 
-        /// <summary>
-        /// Identifies the <seealso cref="IncrementalUpdater"/> dependency property.
-        /// </summary>
-        private static readonly DependencyProperty IncrementalUpdaterProperty = DependencyProperty.RegisterAttached(
-            "IncrementalUpdater",
-            typeof(IncrementalUpdater),
-            typeof(IncrementalUpdateBehavior),
-            new PropertyMetadata(null, new PropertyChangedCallback(IncrementalUpdateBehavior.OnIncrementalUpdaterChanged)));
+    private static void OnPhaseChanged(DependencyObject sender, DependencyPropertyChangedEventArgs args)
+    {
+        IncrementalUpdateBehavior behavior = (IncrementalUpdateBehavior)sender;
+        IncrementalUpdater incrementalUpdater = behavior.FindUpdater();
+        FrameworkElement frameworkElement = behavior.AssociatedObject;
 
-        private IncrementalUpdater _updater = null;
-
-        /// <summary>
-        /// Gets or sets the relative priority of this incremental update. Lower Phase values are addressed first.
-        /// </summary>
-        public int Phase
+        if (incrementalUpdater != null && frameworkElement != null)
         {
-            get { return (int)this.GetValue(IncrementalUpdateBehavior.PhaseProperty); }
-            set { this.SetValue(IncrementalUpdateBehavior.PhaseProperty, value); }
+            incrementalUpdater.UncachePhaseElement(frameworkElement, (int)args.OldValue);
+            incrementalUpdater.CachePhaseElement(frameworkElement, (int)args.NewValue);
+        }
+    }
+
+    private static IncrementalUpdater GetIncrementalUpdater(DependencyObject dependencyObject)
+    {
+        return (IncrementalUpdater)dependencyObject.GetValue(IncrementalUpdateBehavior.IncrementalUpdaterProperty);
+    }
+
+    private static void SetIncrementalUpdater(DependencyObject dependencyObject, IncrementalUpdater value)
+    {
+        dependencyObject.SetValue(IncrementalUpdateBehavior.IncrementalUpdaterProperty, value);
+    }
+
+    private static void OnIncrementalUpdaterChanged(DependencyObject sender, DependencyPropertyChangedEventArgs args)
+    {
+        if (args.OldValue != null)
+        {
+            IncrementalUpdater incrementalUpdater = (IncrementalUpdater)args.OldValue;
+            incrementalUpdater.Detach();
+        }
+        if (args.NewValue != null)
+        {
+            IncrementalUpdater incrementalUpdater = (IncrementalUpdater)args.NewValue;
+            incrementalUpdater.Attach(sender);
+        }
+    }
+
+    private void OnAssociatedObjectLoaded(object sender, RoutedEventArgs e)
+    {
+        IncrementalUpdater incrementalUpdater = this.FindUpdater();
+
+        if (incrementalUpdater != null)
+        {
+            incrementalUpdater.CachePhaseElement(this.AssociatedObject, this.Phase);
+        }
+    }
+
+    private void OnAssociatedObjectUnloaded(object sender, RoutedEventArgs e)
+    {
+        if (this._updater != null)
+        {
+            this._updater.UncachePhaseElement(this.AssociatedObject, this.Phase);
         }
 
-        private static void OnPhaseChanged(DependencyObject sender, DependencyPropertyChangedEventArgs args)
-        {
-            IncrementalUpdateBehavior behavior = (IncrementalUpdateBehavior)sender;
-            IncrementalUpdater incrementalUpdater = behavior.FindUpdater();
-            FrameworkElement frameworkElement = behavior.AssociatedObject;
+        this._updater = null;
+    }
 
-            if (incrementalUpdater != null && frameworkElement != null)
+    private IncrementalUpdater FindUpdater()
+    {
+        if (this._updater != null)
+        {
+            return this._updater;
+        }
+
+        DependencyObject ancestor = this.AssociatedObject;
+        while (ancestor != null)
+        {
+            DependencyObject parent = VisualTreeHelper.GetParent(ancestor);
+            ListViewBase listView = parent as ListViewBase;
+
+            if (listView != null)
             {
-                incrementalUpdater.UncachePhaseElement(frameworkElement, (int)args.OldValue);
-                incrementalUpdater.CachePhaseElement(frameworkElement, (int)args.NewValue);
+                IncrementalUpdater currentUpdater = IncrementalUpdateBehavior.GetIncrementalUpdater(listView);
+                if (currentUpdater == null)
+                {
+                    currentUpdater = new IncrementalUpdater();
+
+                    IncrementalUpdateBehavior.SetIncrementalUpdater(listView, currentUpdater);
+                }
+                return currentUpdater;
+            }
+            ancestor = parent;
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Called after the behavior is attached to the <see cref="Microsoft.Xaml.Interactivity.Behavior.AssociatedObject"/>.
+    /// </summary>
+    protected override void OnAttached()
+    {
+        base.OnAttached();
+
+        this.AssociatedObject.Loaded += this.OnAssociatedObjectLoaded;
+        this.AssociatedObject.Unloaded += this.OnAssociatedObjectUnloaded;
+    }
+
+    /// <summary>
+    /// Called when the behavior is being detached from its <see cref="Microsoft.Xaml.Interactivity.Behavior.AssociatedObject"/>.
+    /// </summary>
+    protected override void OnDetaching()
+    {
+        base.OnDetaching();
+
+        this.AssociatedObject.Loaded -= this.OnAssociatedObjectLoaded;
+        this.AssociatedObject.Unloaded -= this.OnAssociatedObjectUnloaded;
+        // no need to perform the work that Unloaded would have done - that's just housekeeping on the cache, which is now going away
+    }
+
+    private class IncrementalUpdater
+    {
+        private ListViewBase _associatedListViewBase = null;
+        private Dictionary<UIElement, ElementCacheRecord> _elementCache = new Dictionary<UIElement, ElementCacheRecord>();
+
+        private class PhasedElementRecord
+        {
+            private readonly FrameworkElement _frameworkElement;
+            private object _localOpacity;
+            private object _localDataContext;
+            private bool _isFrozen;
+
+            public PhasedElementRecord(FrameworkElement frameworkElement)
+            {
+                this._frameworkElement = frameworkElement;
+            }
+
+            public FrameworkElement FrameworkElement { get { return this._frameworkElement; } }
+
+            public void FreezeAndHide()
+            {
+                if (this._isFrozen)
+                {
+                    return;
+                }
+
+                this._isFrozen = true;
+                this._localOpacity = this._frameworkElement.ReadLocalValue(FrameworkElement.OpacityProperty);
+                this._localDataContext = this._frameworkElement.ReadLocalValue(FrameworkElement.DataContextProperty);
+                this._frameworkElement.Opacity = 0.0;
+                this._frameworkElement.DataContext = this._frameworkElement.DataContext;
+            }
+
+            public void ThawAndShow()
+            {
+                if (!this._isFrozen)
+                {
+                    return;
+                }
+
+                if (this._localOpacity != DependencyProperty.UnsetValue)
+                {
+                    this._frameworkElement.SetValue(FrameworkElement.OpacityProperty, this._localOpacity);
+                }
+                else
+                {
+                    this._frameworkElement.ClearValue(FrameworkElement.OpacityProperty);
+                }
+
+                if (this._localDataContext != DependencyProperty.UnsetValue)
+                {
+                    this._frameworkElement.SetValue(FrameworkElement.DataContextProperty, this._localDataContext);
+                }
+                else
+                {
+                    this._frameworkElement.ClearValue(FrameworkElement.DataContextProperty);
+                }
+
+                this._isFrozen = false;
             }
         }
 
-        private static IncrementalUpdater GetIncrementalUpdater(DependencyObject dependencyObject)
+        private class ElementCacheRecord
         {
-            return (IncrementalUpdater)dependencyObject.GetValue(IncrementalUpdateBehavior.IncrementalUpdaterProperty);
-        }
+            private List<int> _phases = new List<int>();
+            private List<List<PhasedElementRecord>> _elementsByPhase = new List<List<PhasedElementRecord>>();
 
-        private static void SetIncrementalUpdater(DependencyObject dependencyObject, IncrementalUpdater value)
-        {
-            dependencyObject.SetValue(IncrementalUpdateBehavior.IncrementalUpdaterProperty, value);
-        }
-
-        private static void OnIncrementalUpdaterChanged(DependencyObject sender, DependencyPropertyChangedEventArgs args)
-        {
-            if (args.OldValue != null)
+            public List<int> Phases
             {
-                IncrementalUpdater incrementalUpdater = (IncrementalUpdater)args.OldValue;
-                incrementalUpdater.Detach();
+                get { return this._phases; }
             }
-            if (args.NewValue != null)
+
+            public List<List<PhasedElementRecord>> ElementsByPhase
             {
-                IncrementalUpdater incrementalUpdater = (IncrementalUpdater)args.NewValue;
-                incrementalUpdater.Attach(sender);
+                get { return this._elementsByPhase; }
             }
         }
 
-        private void OnAssociatedObjectLoaded(object sender, RoutedEventArgs e)
+        private void OnContainerContentChanging(ListViewBase sender, ContainerContentChangingEventArgs e)
         {
-            IncrementalUpdater incrementalUpdater = this.FindUpdater();
+            UIElement contentTemplateRoot = e.ItemContainer.ContentTemplateRoot;
 
-            if (incrementalUpdater != null)
+            ElementCacheRecord elementCacheRecord;
+            if (this._elementCache.TryGetValue(contentTemplateRoot, out elementCacheRecord))
             {
-                incrementalUpdater.CachePhaseElement(this.AssociatedObject, this.Phase);
+                if (!e.InRecycleQueue)
+                {
+                    foreach (List<PhasedElementRecord> phaseRecord in elementCacheRecord.ElementsByPhase)
+                    {
+                        foreach (PhasedElementRecord phasedElementRecord in phaseRecord)
+                        {
+                            phasedElementRecord.FreezeAndHide();
+                        }
+                    }
+
+                    if (elementCacheRecord.Phases.Count > 0)
+                    {
+                        e.RegisterUpdateCallback((uint)elementCacheRecord.Phases[0], this.OnContainerContentChangingCallback);
+                    }
+
+                    // set the DataContext manually since we inhibit default operation by setting e.Handled=true
+                    ((FrameworkElement)contentTemplateRoot).DataContext = e.Item;
+                }
+                else
+                {
+                    // clear the DataContext manually since we inhibit default operation by setting e.Handled=true
+                    contentTemplateRoot.ClearValue(FrameworkElement.DataContextProperty);
+
+                    foreach (List<PhasedElementRecord> phaseRecord in elementCacheRecord.ElementsByPhase)
+                    {
+                        foreach (PhasedElementRecord phasedElementRecord in phaseRecord)
+                        {
+                            phasedElementRecord.ThawAndShow();
+                        }
+                    }
+                }
             }
         }
 
-        private void OnAssociatedObjectUnloaded(object sender, RoutedEventArgs e)
+        private void OnContainerContentChangingCallback(ListViewBase sender, ContainerContentChangingEventArgs e)
         {
-            if (this._updater != null)
-            {
-                this._updater.UncachePhaseElement(this.AssociatedObject, this.Phase);
-            }
+            UIElement contentTemplateRoot = e.ItemContainer.ContentTemplateRoot;
 
-            this._updater = null;
+            ElementCacheRecord elementCacheRecord;
+            if (this._elementCache.TryGetValue(contentTemplateRoot, out elementCacheRecord))
+            {
+                int phaseIndex = elementCacheRecord.Phases.BinarySearch((int)e.Phase);
+
+                if (phaseIndex >= 0)
+                {
+                    foreach (PhasedElementRecord phasedElementRecord in elementCacheRecord.ElementsByPhase[phaseIndex])
+                    {
+                        phasedElementRecord.ThawAndShow();
+                    }
+
+                    phaseIndex++;
+                }
+                else
+                {
+                    // don't know why this phase was not found, but by BinarySearch rules, ~phaseIndex is the place
+                    // where it would be inserted, thus the item there has the next higher number.
+                    phaseIndex = ~phaseIndex;
+                }
+
+                if (phaseIndex < elementCacheRecord.Phases.Count)
+                {
+                    e.RegisterUpdateCallback((uint)elementCacheRecord.Phases[phaseIndex], this.OnContainerContentChangingCallback);
+                }
+            }
         }
 
-        private IncrementalUpdater FindUpdater()
+        private static UIElement FindContentTemplateRoot(FrameworkElement phaseElement)
         {
-            if (this._updater != null)
-            {
-                return this._updater;
-            }
-
-            DependencyObject ancestor = this.AssociatedObject;
+            DependencyObject ancestor = phaseElement;
             while (ancestor != null)
             {
                 DependencyObject parent = VisualTreeHelper.GetParent(ancestor);
-                ListViewBase listView = parent as ListViewBase;
+                SelectorItem item = parent as SelectorItem;
 
-                if (listView != null)
+                if (item != null)
                 {
-                    IncrementalUpdater currentUpdater = IncrementalUpdateBehavior.GetIncrementalUpdater(listView);
-                    if (currentUpdater == null)
-                    {
-                        currentUpdater = new IncrementalUpdater();
-
-                        IncrementalUpdateBehavior.SetIncrementalUpdater(listView, currentUpdater);
-                    }
-                    return currentUpdater;
+                    return item.ContentTemplateRoot;
                 }
                 ancestor = parent;
             }
@@ -142,308 +334,115 @@ namespace Microsoft.Xaml.Interactivity
             return null;
         }
 
-        /// <summary>
-        /// Called after the behavior is attached to the <see cref="Microsoft.Xaml.Interactivity.Behavior.AssociatedObject"/>.
-        /// </summary>
-        protected override void OnAttached()
+        public void CachePhaseElement(FrameworkElement phaseElement, int phase)
         {
-            base.OnAttached();
-
-            this.AssociatedObject.Loaded += this.OnAssociatedObjectLoaded;
-            this.AssociatedObject.Unloaded += this.OnAssociatedObjectUnloaded;
-        }
-
-        /// <summary>
-        /// Called when the behavior is being detached from its <see cref="Microsoft.Xaml.Interactivity.Behavior.AssociatedObject"/>.
-        /// </summary>
-        protected override void OnDetaching()
-        {
-            base.OnDetaching();
-
-            this.AssociatedObject.Loaded -= this.OnAssociatedObjectLoaded;
-            this.AssociatedObject.Unloaded -= this.OnAssociatedObjectUnloaded;
-            // no need to perform the work that Unloaded would have done - that's just housekeeping on the cache, which is now going away
-        }
-
-        private class IncrementalUpdater
-        {
-            private ListViewBase _associatedListViewBase = null;
-            private Dictionary<UIElement, ElementCacheRecord> _elementCache = new Dictionary<UIElement, ElementCacheRecord>();
-
-            private class PhasedElementRecord
+            if (phase < 0)
             {
-                private readonly FrameworkElement _frameworkElement;
-                private object _localOpacity;
-                private object _localDataContext;
-                private bool _isFrozen;
+                throw new ArgumentOutOfRangeException(nameof(phase));
+            }
 
-                public PhasedElementRecord(FrameworkElement frameworkElement)
+            if (phase <= 0)
+            {
+                return;
+            }
+
+            UIElement contentTemplateRoot = IncrementalUpdater.FindContentTemplateRoot(phaseElement);
+            if (contentTemplateRoot != null)
+            {
+                // get the cache for this element
+                ElementCacheRecord elementCacheRecord;
+                if (!this._elementCache.TryGetValue(contentTemplateRoot, out elementCacheRecord))
                 {
-                    this._frameworkElement = frameworkElement;
+                    elementCacheRecord = new ElementCacheRecord();
+                    this._elementCache.Add(contentTemplateRoot, elementCacheRecord);
                 }
 
-                public FrameworkElement FrameworkElement { get { return this._frameworkElement; } }
+                // get the cache for this phase
+                int phaseIndex = elementCacheRecord.Phases.BinarySearch(phase);
 
-                public void FreezeAndHide()
+                if (phaseIndex < 0)
                 {
-                    if (this._isFrozen)
+                    // not found - insert
+                    phaseIndex = ~phaseIndex;
+                    elementCacheRecord.Phases.Insert(phaseIndex, phase);
+                    elementCacheRecord.ElementsByPhase.Insert(phaseIndex, new List<PhasedElementRecord>());
+                }
+
+                List<PhasedElementRecord> phasedElementRecords = elementCacheRecord.ElementsByPhase[phaseIndex];
+
+                // first see if the element is already there
+                for (int i = 0; i < phasedElementRecords.Count; i++)
+                {
+                    if (phasedElementRecords[i].FrameworkElement == phaseElement)
                     {
                         return;
                     }
-
-                    this._isFrozen = true;
-                    this._localOpacity = this._frameworkElement.ReadLocalValue(FrameworkElement.OpacityProperty);
-                    this._localDataContext = this._frameworkElement.ReadLocalValue(FrameworkElement.DataContextProperty);
-                    this._frameworkElement.Opacity = 0.0;
-                    this._frameworkElement.DataContext = this._frameworkElement.DataContext;
                 }
 
-                public void ThawAndShow()
-                {
-                    if (!this._isFrozen)
-                    {
-                        return;
-                    }
+                // insert the element
+                phasedElementRecords.Add(new PhasedElementRecord(phaseElement));
+            }
+        }
 
-                    if (this._localOpacity != DependencyProperty.UnsetValue)
-                    {
-                        this._frameworkElement.SetValue(FrameworkElement.OpacityProperty, this._localOpacity);
-                    }
-                    else
-                    {
-                        this._frameworkElement.ClearValue(FrameworkElement.OpacityProperty);
-                    }
-
-                    if (this._localDataContext != DependencyProperty.UnsetValue)
-                    {
-                        this._frameworkElement.SetValue(FrameworkElement.DataContextProperty, this._localDataContext);
-                    }
-                    else
-                    {
-                        this._frameworkElement.ClearValue(FrameworkElement.DataContextProperty);
-                    }
-
-                    this._isFrozen = false;
-                }
+        public void UncachePhaseElement(FrameworkElement phaseElement, int phase)
+        {
+            if (phase <= 0)
+            {
+                return;
             }
 
-            private class ElementCacheRecord
+            UIElement contentTemplateRoot = IncrementalUpdater.FindContentTemplateRoot(phaseElement);
+            if (contentTemplateRoot != null)
             {
-                private List<int> _phases = new List<int>();
-                private List<List<PhasedElementRecord>> _elementsByPhase = new List<List<PhasedElementRecord>>();
-
-                public List<int> Phases
-                {
-                    get { return this._phases; }
-                }
-
-                public List<List<PhasedElementRecord>> ElementsByPhase
-                {
-                    get { return this._elementsByPhase; }
-                }
-            }
-
-            private void OnContainerContentChanging(ListViewBase sender, ContainerContentChangingEventArgs e)
-            {
-                UIElement contentTemplateRoot = e.ItemContainer.ContentTemplateRoot;
-
+                // get the cache for this element
                 ElementCacheRecord elementCacheRecord;
                 if (this._elementCache.TryGetValue(contentTemplateRoot, out elementCacheRecord))
                 {
-                    if (!e.InRecycleQueue)
-                    {
-                        foreach (List<PhasedElementRecord> phaseRecord in elementCacheRecord.ElementsByPhase)
-                        {
-                            foreach (PhasedElementRecord phasedElementRecord in phaseRecord)
-                            {
-                                phasedElementRecord.FreezeAndHide();
-                            }
-                        }
-
-                        if (elementCacheRecord.Phases.Count > 0)
-                        {
-                            e.RegisterUpdateCallback((uint)elementCacheRecord.Phases[0], this.OnContainerContentChangingCallback);
-                        }
-
-                        // set the DataContext manually since we inhibit default operation by setting e.Handled=true
-                        ((FrameworkElement)contentTemplateRoot).DataContext = e.Item;
-                    }
-                    else
-                    {
-                        // clear the DataContext manually since we inhibit default operation by setting e.Handled=true
-                        contentTemplateRoot.ClearValue(FrameworkElement.DataContextProperty);
-
-                        foreach (List<PhasedElementRecord> phaseRecord in elementCacheRecord.ElementsByPhase)
-                        {
-                            foreach (PhasedElementRecord phasedElementRecord in phaseRecord)
-                            {
-                                phasedElementRecord.ThawAndShow();
-                            }
-                        }
-                    }
-                }
-            }
-
-            private void OnContainerContentChangingCallback(ListViewBase sender, ContainerContentChangingEventArgs e)
-            {
-                UIElement contentTemplateRoot = e.ItemContainer.ContentTemplateRoot;
-
-                ElementCacheRecord elementCacheRecord;
-                if (this._elementCache.TryGetValue(contentTemplateRoot, out elementCacheRecord))
-                {
-                    int phaseIndex = elementCacheRecord.Phases.BinarySearch((int)e.Phase);
-
-                    if (phaseIndex >= 0)
-                    {
-                        foreach (PhasedElementRecord phasedElementRecord in elementCacheRecord.ElementsByPhase[phaseIndex])
-                        {
-                            phasedElementRecord.ThawAndShow();
-                        }
-
-                        phaseIndex++;
-                    }
-                    else
-                    {
-                        // don't know why this phase was not found, but by BinarySearch rules, ~phaseIndex is the place
-                        // where it would be inserted, thus the item there has the next higher number.
-                        phaseIndex = ~phaseIndex;
-                    }
-
-                    if (phaseIndex < elementCacheRecord.Phases.Count)
-                    {
-                        e.RegisterUpdateCallback((uint)elementCacheRecord.Phases[phaseIndex], this.OnContainerContentChangingCallback);
-                    }
-                }
-            }
-
-            private static UIElement FindContentTemplateRoot(FrameworkElement phaseElement)
-            {
-                DependencyObject ancestor = phaseElement;
-                while (ancestor != null)
-                {
-                    DependencyObject parent = VisualTreeHelper.GetParent(ancestor);
-                    SelectorItem item = parent as SelectorItem;
-
-                    if (item != null)
-                    {
-                        return item.ContentTemplateRoot;
-                    }
-                    ancestor = parent;
-                }
-
-                return null;
-            }
-
-            public void CachePhaseElement(FrameworkElement phaseElement, int phase)
-            {
-                if (phase < 0)
-                {
-                    throw new ArgumentOutOfRangeException(nameof(phase));
-                }
-
-                if (phase <= 0)
-                {
-                    return;
-                }
-
-                UIElement contentTemplateRoot = IncrementalUpdater.FindContentTemplateRoot(phaseElement);
-                if (contentTemplateRoot != null)
-                {
-                    // get the cache for this element
-                    ElementCacheRecord elementCacheRecord;
-                    if (!this._elementCache.TryGetValue(contentTemplateRoot, out elementCacheRecord))
-                    {
-                        elementCacheRecord = new ElementCacheRecord();
-                        this._elementCache.Add(contentTemplateRoot, elementCacheRecord);
-                    }
-
                     // get the cache for this phase
                     int phaseIndex = elementCacheRecord.Phases.BinarySearch(phase);
 
-                    if (phaseIndex < 0)
+                    if (phaseIndex >= 0)
                     {
-                        // not found - insert
-                        phaseIndex = ~phaseIndex;
-                        elementCacheRecord.Phases.Insert(phaseIndex, phase);
-                        elementCacheRecord.ElementsByPhase.Insert(phaseIndex, new List<PhasedElementRecord>());
-                    }
+                        // remove the element: the linear search here is not spectacular but the list should be very short
+                        List<PhasedElementRecord> phasedElementRecords = elementCacheRecord.ElementsByPhase[phaseIndex];
 
-                    List<PhasedElementRecord> phasedElementRecords = elementCacheRecord.ElementsByPhase[phaseIndex];
-
-                    // first see if the element is already there
-                    for (int i = 0; i < phasedElementRecords.Count; i++)
-                    {
-                        if (phasedElementRecords[i].FrameworkElement == phaseElement)
+                        for (int i = 0; i < phasedElementRecords.Count; i++)
                         {
-                            return;
-                        }
-                    }
-
-                    // insert the element
-                    phasedElementRecords.Add(new PhasedElementRecord(phaseElement));
-                }
-            }
-
-            public void UncachePhaseElement(FrameworkElement phaseElement, int phase)
-            {
-                if (phase <= 0)
-                {
-                    return;
-                }
-
-                UIElement contentTemplateRoot = IncrementalUpdater.FindContentTemplateRoot(phaseElement);
-                if (contentTemplateRoot != null)
-                {
-                    // get the cache for this element
-                    ElementCacheRecord elementCacheRecord;
-                    if (this._elementCache.TryGetValue(contentTemplateRoot, out elementCacheRecord))
-                    {
-                        // get the cache for this phase
-                        int phaseIndex = elementCacheRecord.Phases.BinarySearch(phase);
-
-                        if (phaseIndex >= 0)
-                        {
-                            // remove the element: the linear search here is not spectacular but the list should be very short
-                            List<PhasedElementRecord> phasedElementRecords = elementCacheRecord.ElementsByPhase[phaseIndex];
-
-                            for (int i = 0; i < phasedElementRecords.Count; i++)
+                            if (phasedElementRecords[i].FrameworkElement == phaseElement)
                             {
-                                if (phasedElementRecords[i].FrameworkElement == phaseElement)
+                                phasedElementRecords[i].ThawAndShow();
+
+                                phasedElementRecords.RemoveAt(i);
+
+                                if (phasedElementRecords.Count == 0)
                                 {
-                                    phasedElementRecords[i].ThawAndShow();
-
-                                    phasedElementRecords.RemoveAt(i);
-
-                                    if (phasedElementRecords.Count == 0)
-                                    {
-                                        elementCacheRecord.Phases.RemoveAt(phaseIndex);
-                                        elementCacheRecord.ElementsByPhase.RemoveAt(phaseIndex);
-                                    }
+                                    elementCacheRecord.Phases.RemoveAt(phaseIndex);
+                                    elementCacheRecord.ElementsByPhase.RemoveAt(phaseIndex);
                                 }
                             }
                         }
                     }
                 }
             }
+        }
 
-            public void Attach(DependencyObject dependencyObject)
+        public void Attach(DependencyObject dependencyObject)
+        {
+            this._associatedListViewBase = dependencyObject as ListViewBase;
+
+            if (this._associatedListViewBase != null)
             {
-                this._associatedListViewBase = dependencyObject as ListViewBase;
-
-                if (this._associatedListViewBase != null)
-                {
-                    this._associatedListViewBase.ContainerContentChanging += this.OnContainerContentChanging;
-                }
+                this._associatedListViewBase.ContainerContentChanging += this.OnContainerContentChanging;
             }
+        }
 
-            public void Detach()
+        public void Detach()
+        {
+            if (this._associatedListViewBase != null)
             {
-                if (this._associatedListViewBase != null)
-                {
-                    this._associatedListViewBase.ContainerContentChanging -= this.OnContainerContentChanging;
-                }
-                this._associatedListViewBase = null;
+                this._associatedListViewBase.ContainerContentChanging -= this.OnContainerContentChanging;
             }
+            this._associatedListViewBase = null;
         }
     }
 }

--- a/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactivity.Shared/Core/InvokeCommandAction.cs
+++ b/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactivity.Shared/Core/InvokeCommandAction.cs
@@ -13,183 +13,182 @@ using Windows.UI.Xaml;
 using Windows.UI.Xaml.Data;
 #endif
 
-namespace Microsoft.Xaml.Interactivity
+namespace Microsoft.Xaml.Interactivity;
+
+/// <summary>
+/// Executes a specified <see cref="global::System.Windows.Input.ICommand"/> when invoked. 
+/// </summary>
+public sealed class InvokeCommandAction : DependencyObject, IAction
 {
     /// <summary>
-    /// Executes a specified <see cref="global::System.Windows.Input.ICommand"/> when invoked. 
+    /// Identifies the <seealso cref="Command"/> dependency property.
     /// </summary>
-    public sealed class InvokeCommandAction : DependencyObject, IAction
+    [SuppressMessage("Microsoft.Security", "CA2104:DoNotDeclareReadOnlyMutableReferenceTypes")]
+    public static readonly DependencyProperty CommandProperty = DependencyProperty.Register(
+        "Command",
+        typeof(ICommand),
+        typeof(InvokeCommandAction),
+        new PropertyMetadata(null));
+
+    /// <summary>
+    /// Identifies the <seealso cref="CommandParameter"/> dependency property.
+    /// </summary>
+    [SuppressMessage("Microsoft.Security", "CA2104:DoNotDeclareReadOnlyMutableReferenceTypes")]
+    public static readonly DependencyProperty CommandParameterProperty = DependencyProperty.Register(
+        "CommandParameter",
+        typeof(object),
+        typeof(InvokeCommandAction),
+        new PropertyMetadata(null));
+
+    /// <summary>
+    /// Identifies the <seealso cref="InputConverter"/> dependency property.
+    /// </summary>
+    [SuppressMessage("Microsoft.Security", "CA2104:DoNotDeclareReadOnlyMutableReferenceTypes")]
+    public static readonly DependencyProperty InputConverterProperty = DependencyProperty.Register(
+        "InputConverter",
+        typeof(IValueConverter),
+        typeof(InvokeCommandAction),
+        new PropertyMetadata(null));
+
+    /// <summary>
+    /// Identifies the <seealso cref="InputConverterParameter"/> dependency property.
+    /// </summary>
+    [SuppressMessage("Microsoft.Security", "CA2104:DoNotDeclareReadOnlyMutableReferenceTypes")]
+    public static readonly DependencyProperty InputConverterParameterProperty = DependencyProperty.Register(
+        "InputConverterParameter",
+        typeof(object),
+        typeof(InvokeCommandAction),
+        new PropertyMetadata(null));
+
+    /// <summary>
+    /// Identifies the <seealso cref="InputConverterLanguage"/> dependency property.
+    /// </summary>
+    [SuppressMessage("Microsoft.Security", "CA2104:DoNotDeclareReadOnlyMutableReferenceTypes")]
+    public static readonly DependencyProperty InputConverterLanguageProperty = DependencyProperty.Register(
+        "InputConverterLanguage",
+        typeof(string),
+        typeof(InvokeCommandAction),
+        new PropertyMetadata(string.Empty)); // Empty string means the invariant culture.
+
+    /// <summary>
+    /// Gets or sets the command this action should invoke. This is a dependency property.
+    /// </summary>
+    public ICommand Command
     {
-        /// <summary>
-        /// Identifies the <seealso cref="Command"/> dependency property.
-        /// </summary>
-        [SuppressMessage("Microsoft.Security", "CA2104:DoNotDeclareReadOnlyMutableReferenceTypes")]
-        public static readonly DependencyProperty CommandProperty = DependencyProperty.Register(
-            "Command",
-            typeof(ICommand),
-            typeof(InvokeCommandAction),
-            new PropertyMetadata(null));
-
-        /// <summary>
-        /// Identifies the <seealso cref="CommandParameter"/> dependency property.
-        /// </summary>
-        [SuppressMessage("Microsoft.Security", "CA2104:DoNotDeclareReadOnlyMutableReferenceTypes")]
-        public static readonly DependencyProperty CommandParameterProperty = DependencyProperty.Register(
-            "CommandParameter",
-            typeof(object),
-            typeof(InvokeCommandAction),
-            new PropertyMetadata(null));
-
-        /// <summary>
-        /// Identifies the <seealso cref="InputConverter"/> dependency property.
-        /// </summary>
-        [SuppressMessage("Microsoft.Security", "CA2104:DoNotDeclareReadOnlyMutableReferenceTypes")]
-        public static readonly DependencyProperty InputConverterProperty = DependencyProperty.Register(
-            "InputConverter",
-            typeof(IValueConverter),
-            typeof(InvokeCommandAction),
-            new PropertyMetadata(null));
-
-        /// <summary>
-        /// Identifies the <seealso cref="InputConverterParameter"/> dependency property.
-        /// </summary>
-        [SuppressMessage("Microsoft.Security", "CA2104:DoNotDeclareReadOnlyMutableReferenceTypes")]
-        public static readonly DependencyProperty InputConverterParameterProperty = DependencyProperty.Register(
-            "InputConverterParameter",
-            typeof(object),
-            typeof(InvokeCommandAction),
-            new PropertyMetadata(null));
-
-        /// <summary>
-        /// Identifies the <seealso cref="InputConverterLanguage"/> dependency property.
-        /// </summary>
-        [SuppressMessage("Microsoft.Security", "CA2104:DoNotDeclareReadOnlyMutableReferenceTypes")]
-        public static readonly DependencyProperty InputConverterLanguageProperty = DependencyProperty.Register(
-            "InputConverterLanguage",
-            typeof(string),
-            typeof(InvokeCommandAction),
-            new PropertyMetadata(string.Empty)); // Empty string means the invariant culture.
-
-        /// <summary>
-        /// Gets or sets the command this action should invoke. This is a dependency property.
-        /// </summary>
-        public ICommand Command
+        get
         {
-            get
-            {
-                return (ICommand)this.GetValue(InvokeCommandAction.CommandProperty);
-            }
-            set
-            {
-                this.SetValue(InvokeCommandAction.CommandProperty, value);
-            }
+            return (ICommand)this.GetValue(InvokeCommandAction.CommandProperty);
+        }
+        set
+        {
+            this.SetValue(InvokeCommandAction.CommandProperty, value);
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets the parameter that is passed to <see cref="global::System.Windows.Input.ICommand.Execute(object)"/>.
+    /// If this is not set, the parameter from the <seealso cref="Execute(object, object)"/> method will be used.
+    /// This is an optional dependency property.
+    /// </summary>
+    public object CommandParameter
+    {
+        get
+        {
+            return this.GetValue(InvokeCommandAction.CommandParameterProperty);
+        }
+        set
+        {
+            this.SetValue(InvokeCommandAction.CommandParameterProperty, value);
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets the converter that is run on the parameter from the <seealso cref="Execute(object, object)"/> method.
+    /// This is an optional dependency property.
+    /// </summary>
+    public IValueConverter InputConverter
+    {
+        get
+        {
+            return (IValueConverter)this.GetValue(InvokeCommandAction.InputConverterProperty);
+        }
+        set
+        {
+            this.SetValue(InvokeCommandAction.InputConverterProperty, value);
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets the parameter that is passed to the <see cref="IValueConverter.Convert"/>
+    /// method of <see cref="InputConverter"/>.
+    /// This is an optional dependency property.
+    /// </summary>
+    public object InputConverterParameter
+    {
+        get
+        {
+            return this.GetValue(InvokeCommandAction.InputConverterParameterProperty);
+        }
+        set
+        {
+            this.SetValue(InvokeCommandAction.InputConverterParameterProperty, value);
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets the language that is passed to the <see cref="IValueConverter.Convert"/>
+    /// method of <see cref="InputConverter"/>.
+    /// This is an optional dependency property.
+    /// </summary>
+    public string InputConverterLanguage
+    {
+        get
+        {
+            return (string)this.GetValue(InvokeCommandAction.InputConverterLanguageProperty);
+        }
+        set
+        {
+            this.SetValue(InvokeCommandAction.InputConverterLanguageProperty, value);
+        }
+    }
+
+    /// <summary>
+    /// Executes the action.
+    /// </summary>
+    /// <param name="sender">The <see cref="global::System.Object"/> that is passed to the action by the behavior. Generally this is <seealso cref="Microsoft.Xaml.Interactivity.IBehavior.AssociatedObject"/> or a target object.</param>
+    /// <param name="parameter">The value of this parameter is determined by the caller.</param>
+    /// <returns>True if the command is successfully executed; else false.</returns>
+    public object Execute(object sender, object parameter)
+    {
+        if (this.Command == null)
+        {
+            return false;
         }
 
-        /// <summary>
-        /// Gets or sets the parameter that is passed to <see cref="global::System.Windows.Input.ICommand.Execute(object)"/>.
-        /// If this is not set, the parameter from the <seealso cref="Execute(object, object)"/> method will be used.
-        /// This is an optional dependency property.
-        /// </summary>
-        public object CommandParameter
+        object resolvedParameter;
+        if (this.ReadLocalValue(InvokeCommandAction.CommandParameterProperty) != DependencyProperty.UnsetValue)
         {
-            get
-            {
-                return this.GetValue(InvokeCommandAction.CommandParameterProperty);
-            }
-            set
-            {
-                this.SetValue(InvokeCommandAction.CommandParameterProperty, value);
-            }
+            resolvedParameter = this.CommandParameter;
+        }
+        else if (this.InputConverter != null)
+        {
+            resolvedParameter = this.InputConverter.Convert(
+                parameter,
+                typeof(object),
+                this.InputConverterParameter,
+                this.InputConverterLanguage);
+        }
+        else
+        {
+            resolvedParameter = parameter;
         }
 
-        /// <summary>
-        /// Gets or sets the converter that is run on the parameter from the <seealso cref="Execute(object, object)"/> method.
-        /// This is an optional dependency property.
-        /// </summary>
-        public IValueConverter InputConverter
+        if (!this.Command.CanExecute(resolvedParameter))
         {
-            get
-            {
-                return (IValueConverter)this.GetValue(InvokeCommandAction.InputConverterProperty);
-            }
-            set
-            {
-                this.SetValue(InvokeCommandAction.InputConverterProperty, value);
-            }
+            return false;
         }
 
-        /// <summary>
-        /// Gets or sets the parameter that is passed to the <see cref="IValueConverter.Convert"/>
-        /// method of <see cref="InputConverter"/>.
-        /// This is an optional dependency property.
-        /// </summary>
-        public object InputConverterParameter
-        {
-            get
-            {
-                return this.GetValue(InvokeCommandAction.InputConverterParameterProperty);
-            }
-            set
-            {
-                this.SetValue(InvokeCommandAction.InputConverterParameterProperty, value);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the language that is passed to the <see cref="IValueConverter.Convert"/>
-        /// method of <see cref="InputConverter"/>.
-        /// This is an optional dependency property.
-        /// </summary>
-        public string InputConverterLanguage
-        {
-            get
-            {
-                return (string)this.GetValue(InvokeCommandAction.InputConverterLanguageProperty);
-            }
-            set
-            {
-                this.SetValue(InvokeCommandAction.InputConverterLanguageProperty, value);
-            }
-        }
-
-        /// <summary>
-        /// Executes the action.
-        /// </summary>
-        /// <param name="sender">The <see cref="global::System.Object"/> that is passed to the action by the behavior. Generally this is <seealso cref="Microsoft.Xaml.Interactivity.IBehavior.AssociatedObject"/> or a target object.</param>
-        /// <param name="parameter">The value of this parameter is determined by the caller.</param>
-        /// <returns>True if the command is successfully executed; else false.</returns>
-        public object Execute(object sender, object parameter)
-        {
-            if (this.Command == null)
-            {
-                return false;
-            }
-
-            object resolvedParameter;
-            if (this.ReadLocalValue(InvokeCommandAction.CommandParameterProperty) != DependencyProperty.UnsetValue)
-            {
-                resolvedParameter = this.CommandParameter;
-            }
-            else if (this.InputConverter != null)
-            {
-                resolvedParameter = this.InputConverter.Convert(
-                    parameter,
-                    typeof(object),
-                    this.InputConverterParameter,
-                    this.InputConverterLanguage);
-            }
-            else
-            {
-                resolvedParameter = parameter;
-            }
-
-            if (!this.Command.CanExecute(resolvedParameter))
-            {
-                return false;
-            }
-
-            this.Command.Execute(resolvedParameter);
-            return true;
-        }
+        this.Command.Execute(resolvedParameter);
+        return true;
     }
 }

--- a/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactivity.Shared/Core/NavigateToPageAction.cs
+++ b/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactivity.Shared/Core/NavigateToPageAction.cs
@@ -15,151 +15,150 @@ using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Markup;
 #endif
 
-namespace Microsoft.Xaml.Interactivity
+namespace Microsoft.Xaml.Interactivity;
+
+/// <summary>
+/// An action that switches the current visual to the specified <see cref="Page"/>.
+/// </summary>
+public sealed class NavigateToPageAction : DependencyObject, IAction
 {
+    private readonly IVisualTreeHelper _visualTreeHelper;
+
     /// <summary>
-    /// An action that switches the current visual to the specified <see cref="Page"/>.
+    /// Identifies the <seealso cref="TargetPage"/> dependency property.
     /// </summary>
-    public sealed class NavigateToPageAction : DependencyObject, IAction
+    [SuppressMessage("Microsoft.Security", "CA2104:DoNotDeclareReadOnlyMutableReferenceTypes")]
+    public static readonly DependencyProperty TargetPageProperty = DependencyProperty.Register(
+        "TargetPage",
+        typeof(string),
+        typeof(NavigateToPageAction),
+        new PropertyMetadata(null));
+
+    /// <summary>
+    /// Identifies the <seealso cref="Parameter"/> dependency property.
+    /// </summary>
+    [SuppressMessage("Microsoft.Security", "CA2104:DoNotDeclareReadOnlyMutableReferenceTypes")]
+    public static readonly DependencyProperty ParameterProperty = DependencyProperty.Register(
+        "Parameter",
+        typeof(object),
+        typeof(NavigateToPageAction),
+        new PropertyMetadata(null));
+
+    /// <summary>
+    /// Initializes a new instance of the NavigateToPageAction class. 
+    /// </summary>
+    public NavigateToPageAction()
+        : this(new UwpVisualTreeHelper())
     {
-        private readonly IVisualTreeHelper _visualTreeHelper;
+    }
 
-        /// <summary>
-        /// Identifies the <seealso cref="TargetPage"/> dependency property.
-        /// </summary>
-        [SuppressMessage("Microsoft.Security", "CA2104:DoNotDeclareReadOnlyMutableReferenceTypes")]
-        public static readonly DependencyProperty TargetPageProperty = DependencyProperty.Register(
-            "TargetPage",
-            typeof(string),
-            typeof(NavigateToPageAction),
-            new PropertyMetadata(null));
+    /// <summary>
+    /// Initializes a new instance of the NavigateToPageAction class. 
+    /// </summary>
+    /// <param name="visualTreeHelper">
+    /// IVisualTreeHelper implementation to use when searching the tree for an
+    /// INavigate target.
+    /// </param>
+    internal NavigateToPageAction(IVisualTreeHelper visualTreeHelper)
+    {
+        this._visualTreeHelper = visualTreeHelper;
+    }
 
-        /// <summary>
-        /// Identifies the <seealso cref="Parameter"/> dependency property.
-        /// </summary>
-        [SuppressMessage("Microsoft.Security", "CA2104:DoNotDeclareReadOnlyMutableReferenceTypes")]
-        public static readonly DependencyProperty ParameterProperty = DependencyProperty.Register(
-            "Parameter",
-            typeof(object),
-            typeof(NavigateToPageAction),
-            new PropertyMetadata(null));
-
-        /// <summary>
-        /// Initializes a new instance of the NavigateToPageAction class. 
-        /// </summary>
-        public NavigateToPageAction()
-            : this(new UwpVisualTreeHelper())
+    /// <summary>
+    /// Gets or sets the fully qualified name of the <see cref="Page"/> to navigate to. This is a dependency property.
+    /// </summary>
+    public string TargetPage
+    {
+        get
         {
+            return (string)this.GetValue(NavigateToPageAction.TargetPageProperty);
+        }
+        set
+        {
+            this.SetValue(NavigateToPageAction.TargetPageProperty, value);
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets the parameter which will be passed to the <see cref="Frame.Navigate(global::System.Type,object)"/> method.
+    /// </summary>
+    public object Parameter
+    {
+        get
+        {
+            return (object)this.GetValue(NavigateToPageAction.ParameterProperty);
+        }
+        set
+        {
+            this.SetValue(NavigateToPageAction.ParameterProperty, value);
+        }
+    }
+
+    /// <summary>
+    /// Executes the action.
+    /// </summary>
+    /// <param name="sender">The <see cref="object"/> that is passed to the action by the behavior. Generally this is <seealso cref="Microsoft.Xaml.Interactivity.IBehavior.AssociatedObject"/> or a target object.</param>
+    /// <param name="parameter">The value of this parameter is determined by the caller.</param>
+    /// <returns>True if the navigation to the specified page is successful; else false.</returns>
+    public object Execute(object sender, object parameter)
+    {
+        if (string.IsNullOrEmpty(this.TargetPage))
+        {
+            return false;
         }
 
-        /// <summary>
-        /// Initializes a new instance of the NavigateToPageAction class. 
-        /// </summary>
-        /// <param name="visualTreeHelper">
-        /// IVisualTreeHelper implementation to use when searching the tree for an
-        /// INavigate target.
-        /// </param>
-        internal NavigateToPageAction(IVisualTreeHelper visualTreeHelper)
+        IXamlMetadataProvider metadataProvider = Application.Current as IXamlMetadataProvider;
+        if (metadataProvider == null)
         {
-            this._visualTreeHelper = visualTreeHelper;
+            // This will happen if there are no XAML files in the project other than App.xaml.
+            // The markup compiler doesn't bother implementing IXamlMetadataProvider on the app
+            // in that case.
+            return false;
         }
 
-        /// <summary>
-        /// Gets or sets the fully qualified name of the <see cref="Page"/> to navigate to. This is a dependency property.
-        /// </summary>
-        public string TargetPage
+        IXamlType xamlType = metadataProvider.GetXamlType(this.TargetPage);
+        if (xamlType == null)
         {
-            get
-            {
-                return (string)this.GetValue(NavigateToPageAction.TargetPageProperty);
-            }
-            set
-            {
-                this.SetValue(NavigateToPageAction.TargetPageProperty, value);
-            }
+            return false;
         }
 
-        /// <summary>
-        /// Gets or sets the parameter which will be passed to the <see cref="Frame.Navigate(global::System.Type,object)"/> method.
-        /// </summary>
-        public object Parameter
+        INavigate navigateElement;
+        if (sender is UIElement element && element.XamlRoot != null)
         {
-            get
-            {
-                return (object)this.GetValue(NavigateToPageAction.ParameterProperty);
-            }
-            set
-            {
-                this.SetValue(NavigateToPageAction.ParameterProperty, value);
-            }
+            navigateElement = element.XamlRoot.Content as INavigate;
+        }
+        else
+        {
+            navigateElement = Window.Current?.Content as INavigate;
         }
 
-        /// <summary>
-        /// Executes the action.
-        /// </summary>
-        /// <param name="sender">The <see cref="object"/> that is passed to the action by the behavior. Generally this is <seealso cref="Microsoft.Xaml.Interactivity.IBehavior.AssociatedObject"/> or a target object.</param>
-        /// <param name="parameter">The value of this parameter is determined by the caller.</param>
-        /// <returns>True if the navigation to the specified page is successful; else false.</returns>
-        public object Execute(object sender, object parameter)
+        DependencyObject senderObject = sender as DependencyObject;
+
+        // If the sender wasn't an INavigate, then keep looking up the tree from the
+        // root we were given for another INavigate.
+        while (senderObject != null && navigateElement == null)
         {
-            if (string.IsNullOrEmpty(this.TargetPage))
-            {
-                return false;
-            }
-
-            IXamlMetadataProvider metadataProvider = Application.Current as IXamlMetadataProvider;
-            if (metadataProvider == null)
-            {
-                // This will happen if there are no XAML files in the project other than App.xaml.
-                // The markup compiler doesn't bother implementing IXamlMetadataProvider on the app
-                // in that case.
-                return false;
-            }
-
-            IXamlType xamlType = metadataProvider.GetXamlType(this.TargetPage);
-            if (xamlType == null)
-            {
-                return false;
-            }
-
-            INavigate navigateElement;
-            if (sender is UIElement element && element.XamlRoot != null)
-            {
-                navigateElement = element.XamlRoot.Content as INavigate;
-            }
-            else
-            {
-                navigateElement = Window.Current?.Content as INavigate;
-            }
-
-            DependencyObject senderObject = sender as DependencyObject;
-
-            // If the sender wasn't an INavigate, then keep looking up the tree from the
-            // root we were given for another INavigate.
-            while (senderObject != null && navigateElement == null)
-            {
-                navigateElement = senderObject as INavigate;
-                if (navigateElement == null)
-                {
-                    senderObject = this._visualTreeHelper.GetParent(senderObject);
-                }
-            }
-
+            navigateElement = senderObject as INavigate;
             if (navigateElement == null)
             {
-                return false;
+                senderObject = this._visualTreeHelper.GetParent(senderObject);
             }
+        }
 
-            Frame frame = navigateElement as Frame;
+        if (navigateElement == null)
+        {
+            return false;
+        }
 
-            if (frame != null)
-            {
-                return frame.Navigate(xamlType.UnderlyingType, this.Parameter ?? parameter);
-            }
-            else
-            {
-                return navigateElement.Navigate(xamlType.UnderlyingType);
-            }
+        Frame frame = navigateElement as Frame;
+
+        if (frame != null)
+        {
+            return frame.Navigate(xamlType.UnderlyingType, this.Parameter ?? parameter);
+        }
+        else
+        {
+            return navigateElement.Navigate(xamlType.UnderlyingType);
         }
     }
 }

--- a/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactivity.Shared/Core/ResourceHelper.cs
+++ b/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactivity.Shared/Core/ResourceHelper.cs
@@ -1,101 +1,101 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-namespace Microsoft.Xaml.Interactivity
+
+namespace Microsoft.Xaml.Interactivity;
+
+using Windows.ApplicationModel.Resources;
+
+internal static class ResourceHelper
 {
-    using Windows.ApplicationModel.Resources;
-
-    internal static class ResourceHelper
-    {
 #if NET8_0_OR_GREATER && !MODERN_WINDOWS_UWP
-        private static ResourceLoader strings = new ResourceLoader(ResourceLoader.GetDefaultResourceFilePath(), "Microsoft.Xaml.Interactivity/Strings");
+    private static ResourceLoader strings = new ResourceLoader(ResourceLoader.GetDefaultResourceFilePath(), "Microsoft.Xaml.Interactivity/Strings");
 #endif
 
-        public static string GetString(string resourceName)
-        {
+    public static string GetString(string resourceName)
+    {
 #if !NET8_0_OR_GREATER || MODERN_WINDOWS_UWP
-            ResourceLoader strings = ResourceLoader.GetForCurrentView("Microsoft.Xaml.Interactivity/Strings");
+        ResourceLoader strings = ResourceLoader.GetForCurrentView("Microsoft.Xaml.Interactivity/Strings");
 #endif
-            return strings.GetString(resourceName);
-        }
+        return strings.GetString(resourceName);
+    }
 
-        public static string CallMethodActionValidMethodNotFoundExceptionMessage
+    public static string CallMethodActionValidMethodNotFoundExceptionMessage
+    {
+        get
         {
-            get
-            {
-                return ResourceHelper.GetString("CallMethodActionValidMethodNotFoundExceptionMessage");
-            }
+            return ResourceHelper.GetString("CallMethodActionValidMethodNotFoundExceptionMessage");
         }
+    }
 
-        public static string ChangePropertyActionCannotFindPropertyNameExceptionMessage
+    public static string ChangePropertyActionCannotFindPropertyNameExceptionMessage
+    {
+        get
         {
-            get
-            {
-                return ResourceHelper.GetString("ChangePropertyActionCannotFindPropertyNameExceptionMessage");
-            }
+            return ResourceHelper.GetString("ChangePropertyActionCannotFindPropertyNameExceptionMessage");
         }
+    }
 
-        public static string ChangePropertyActionCannotSetValueExceptionMessage
+    public static string ChangePropertyActionCannotSetValueExceptionMessage
+    {
+        get
         {
-            get
-            {
-                return ResourceHelper.GetString("ChangePropertyActionCannotSetValueExceptionMessage");
-            }
+            return ResourceHelper.GetString("ChangePropertyActionCannotSetValueExceptionMessage");
         }
+    }
 
-        public static string ChangePropertyActionPropertyIsReadOnlyExceptionMessage
+    public static string ChangePropertyActionPropertyIsReadOnlyExceptionMessage
+    {
+        get
         {
-            get
-            {
-                return ResourceHelper.GetString("ChangePropertyActionPropertyIsReadOnlyExceptionMessage");
-            }
+            return ResourceHelper.GetString("ChangePropertyActionPropertyIsReadOnlyExceptionMessage");
         }
+    }
 
-        public static string GoToStateActionTargetHasNoStateGroups
+    public static string GoToStateActionTargetHasNoStateGroups
+    {
+        get
         {
-            get
-            {
-                return ResourceHelper.GetString("GoToStateActionTargetHasNoStateGroups");
-            }
+            return ResourceHelper.GetString("GoToStateActionTargetHasNoStateGroups");
         }
+    }
 
-        public static string CannotAttachBehaviorMultipleTimesExceptionMessage
+    public static string CannotAttachBehaviorMultipleTimesExceptionMessage
+    {
+        get
         {
-            get
-            {
-                return ResourceHelper.GetString("CannotAttachBehaviorMultipleTimesExceptionMessage");
-            }
+            return ResourceHelper.GetString("CannotAttachBehaviorMultipleTimesExceptionMessage");
         }
+    }
 
-        public static string CannotFindEventNameExceptionMessage
+    public static string CannotFindEventNameExceptionMessage
+    {
+        get
         {
-            get
-            {
-                return ResourceHelper.GetString("CannotFindEventNameExceptionMessage");
-            }
+            return ResourceHelper.GetString("CannotFindEventNameExceptionMessage");
         }
+    }
 
-        public static string InvalidLeftOperand
+    public static string InvalidLeftOperand
+    {
+        get
         {
-            get
-            {
-                return ResourceHelper.GetString("InvalidLeftOperand");
-            }
+            return ResourceHelper.GetString("InvalidLeftOperand");
         }
+    }
 
-        public static string InvalidRightOperand
+    public static string InvalidRightOperand
+    {
+        get
         {
-            get
-            {
-                return ResourceHelper.GetString("InvalidRightOperand");
-            }
+            return ResourceHelper.GetString("InvalidRightOperand");
         }
+    }
 
-        public static string InvalidOperands
+    public static string InvalidOperands
+    {
+        get
         {
-            get
-            {
-                return ResourceHelper.GetString("InvalidOperands");
-            }
+            return ResourceHelper.GetString("InvalidOperands");
         }
     }
 }

--- a/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactivity.Shared/Core/TypeConverterHelper.cs
+++ b/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactivity.Shared/Core/TypeConverterHelper.cs
@@ -12,84 +12,83 @@ using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Markup;
 #endif
 
-namespace Microsoft.Xaml.Interactivity
+namespace Microsoft.Xaml.Interactivity;
+
+/// <summary>
+/// A helper class that enables converting values specified in markup (strings) to their object representation.
+/// </summary>
+internal static class TypeConverterHelper
 {
+    private const string ContentControlFormatString = "<ContentControl xmlns='http://schemas.microsoft.com/winfx/2006/xaml/presentation' xmlns:c='using:{0}'><c:{1}>{2}</c:{1}></ContentControl>";
+
     /// <summary>
-    /// A helper class that enables converting values specified in markup (strings) to their object representation.
+    /// Converts string representation of a value to its object representation.
     /// </summary>
-    internal static class TypeConverterHelper
+    /// <param name="value">The value to convert.</param>
+    /// <param name="destinationTypeFullName">The full name of the destination type.</param>
+    /// <returns>Object representation of the string value.</returns>
+    /// <exception cref="ArgumentNullException">destinationTypeFullName cannot be null.</exception>
+    public static Object Convert(string value, string destinationTypeFullName)
     {
-        private const string ContentControlFormatString = "<ContentControl xmlns='http://schemas.microsoft.com/winfx/2006/xaml/presentation' xmlns:c='using:{0}'><c:{1}>{2}</c:{1}></ContentControl>";
-
-        /// <summary>
-        /// Converts string representation of a value to its object representation.
-        /// </summary>
-        /// <param name="value">The value to convert.</param>
-        /// <param name="destinationTypeFullName">The full name of the destination type.</param>
-        /// <returns>Object representation of the string value.</returns>
-        /// <exception cref="ArgumentNullException">destinationTypeFullName cannot be null.</exception>
-        public static Object Convert(string value, string destinationTypeFullName)
+        if (string.IsNullOrEmpty(destinationTypeFullName))
         {
-            if (string.IsNullOrEmpty(destinationTypeFullName))
-            {
-                throw new ArgumentNullException(nameof(destinationTypeFullName));
-            }
-
-            string scope = TypeConverterHelper.GetScope(destinationTypeFullName);
-
-            // Value types in the "System" namespace must be special cased due to a bug in the xaml compiler
-            if (string.Equals(scope, "System", StringComparison.Ordinal))
-            {
-                if (string.Equals(destinationTypeFullName, (typeof(string).FullName), StringComparison.Ordinal))
-                {
-                    return value;
-                }
-                else if (string.Equals(destinationTypeFullName, typeof(bool).FullName, StringComparison.Ordinal))
-                {
-                    return bool.Parse(value);
-                }
-                else if (string.Equals(destinationTypeFullName, typeof(int).FullName, StringComparison.Ordinal))
-                {
-                    return int.Parse(value, CultureInfo.InvariantCulture);
-                }
-                else if (string.Equals(destinationTypeFullName, typeof(double).FullName, StringComparison.Ordinal))
-                {
-                    return double.Parse(value, CultureInfo.InvariantCulture);
-                }
-            }
-
-            string type = TypeConverterHelper.GetType(destinationTypeFullName);
-            string contentControlXaml = string.Format(CultureInfo.InvariantCulture, TypeConverterHelper.ContentControlFormatString, scope, type, value);
-
-            ContentControl contentControl = XamlReader.Load(contentControlXaml) as ContentControl;
-            if (contentControl != null)
-            {
-                return contentControl.Content;
-            }
-
-            return null;
+            throw new ArgumentNullException(nameof(destinationTypeFullName));
         }
 
-        private static String GetScope(string name)
-        {
-            int indexOfLastPeriod = name.LastIndexOf('.');
-            if (indexOfLastPeriod != name.Length - 1)
-            {
-                return name.Substring(0, indexOfLastPeriod);
-            }
+        string scope = TypeConverterHelper.GetScope(destinationTypeFullName);
 
-            return name;
+        // Value types in the "System" namespace must be special cased due to a bug in the xaml compiler
+        if (string.Equals(scope, "System", StringComparison.Ordinal))
+        {
+            if (string.Equals(destinationTypeFullName, (typeof(string).FullName), StringComparison.Ordinal))
+            {
+                return value;
+            }
+            else if (string.Equals(destinationTypeFullName, typeof(bool).FullName, StringComparison.Ordinal))
+            {
+                return bool.Parse(value);
+            }
+            else if (string.Equals(destinationTypeFullName, typeof(int).FullName, StringComparison.Ordinal))
+            {
+                return int.Parse(value, CultureInfo.InvariantCulture);
+            }
+            else if (string.Equals(destinationTypeFullName, typeof(double).FullName, StringComparison.Ordinal))
+            {
+                return double.Parse(value, CultureInfo.InvariantCulture);
+            }
         }
 
-        private static String GetType(string name)
-        {
-            int indexOfLastPeriod = name.LastIndexOf('.');
-            if (indexOfLastPeriod != name.Length - 1)
-            {
-                return name.Substring(++indexOfLastPeriod);
-            }
+        string type = TypeConverterHelper.GetType(destinationTypeFullName);
+        string contentControlXaml = string.Format(CultureInfo.InvariantCulture, TypeConverterHelper.ContentControlFormatString, scope, type, value);
 
-            return name;
+        ContentControl contentControl = XamlReader.Load(contentControlXaml) as ContentControl;
+        if (contentControl != null)
+        {
+            return contentControl.Content;
         }
+
+        return null;
+    }
+
+    private static String GetScope(string name)
+    {
+        int indexOfLastPeriod = name.LastIndexOf('.');
+        if (indexOfLastPeriod != name.Length - 1)
+        {
+            return name.Substring(0, indexOfLastPeriod);
+        }
+
+        return name;
+    }
+
+    private static String GetType(string name)
+    {
+        int indexOfLastPeriod = name.LastIndexOf('.');
+        if (indexOfLastPeriod != name.Length - 1)
+        {
+            return name.Substring(++indexOfLastPeriod);
+        }
+
+        return name;
     }
 }

--- a/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactivity.Shared/CustomPropertyValueEditorAttribute.cs
+++ b/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactivity.Shared/CustomPropertyValueEditorAttribute.cs
@@ -3,54 +3,53 @@
 
 using System;
 
-namespace Microsoft.Xaml.Interactivity
+namespace Microsoft.Xaml.Interactivity;
+
+/// <summary>
+/// Enumerates possible values for reusable property value editors.
+/// </summary>
+public enum CustomPropertyValueEditor
 {
 	/// <summary>
-	/// Enumerates possible values for reusable property value editors.
+	/// Uses the storyboard picker, if supported, to edit this property at design time.
 	/// </summary>
-	public enum CustomPropertyValueEditor
+	Storyboard,
+	/// <summary>
+	/// Uses the state picker, if supported, to edit this property at design time.
+	/// </summary>
+	StateName,
+	/// <summary>
+	/// Uses the element-binding picker, if supported, to edit this property at design time.
+	/// </summary>
+	ElementBinding,
+	/// <summary>
+	/// Uses the property-binding picker, if supported, to edit this property at design time.
+	/// </summary>
+	PropertyBinding,
+}
+
+/// <summary>
+/// Associates the given editor type with the property to which the <see cref="CustomPropertyValueEditor"/> is applied.
+/// </summary>
+/// <remarks>Use this attribute to get improved design-time editing for properties that denote element (by name), storyboards, or states (by name).</remarks>
+[AttributeUsage(AttributeTargets.Property, AllowMultiple = false, Inherited = true)]
+public sealed class CustomPropertyValueEditorAttribute : Attribute
+{
+	/// <summary>
+	/// Initializes a new instance of the <see cref="CustomPropertyValueEditorAttribute"/> class.
+	/// </summary>
+	/// <param name="customPropertyValueEditor">The custom property value editor.</param>
+	public CustomPropertyValueEditorAttribute(CustomPropertyValueEditor customPropertyValueEditor)
 	{
-		/// <summary>
-		/// Uses the storyboard picker, if supported, to edit this property at design time.
-		/// </summary>
-		Storyboard,
-		/// <summary>
-		/// Uses the state picker, if supported, to edit this property at design time.
-		/// </summary>
-		StateName,
-		/// <summary>
-		/// Uses the element-binding picker, if supported, to edit this property at design time.
-		/// </summary>
-		ElementBinding,
-		/// <summary>
-		/// Uses the property-binding picker, if supported, to edit this property at design time.
-		/// </summary>
-		PropertyBinding,
+		this.CustomPropertyValueEditor = customPropertyValueEditor;
 	}
 
 	/// <summary>
-	/// Associates the given editor type with the property to which the <see cref="CustomPropertyValueEditor"/> is applied.
+	/// Gets the custom property value editor.
 	/// </summary>
-	/// <remarks>Use this attribute to get improved design-time editing for properties that denote element (by name), storyboards, or states (by name).</remarks>
-	[AttributeUsage(AttributeTargets.Property, AllowMultiple = false, Inherited = true)]
-	public sealed class CustomPropertyValueEditorAttribute : Attribute
+	public CustomPropertyValueEditor CustomPropertyValueEditor
 	{
-		/// <summary>
-		/// Initializes a new instance of the <see cref="CustomPropertyValueEditorAttribute"/> class.
-		/// </summary>
-		/// <param name="customPropertyValueEditor">The custom property value editor.</param>
-		public CustomPropertyValueEditorAttribute(CustomPropertyValueEditor customPropertyValueEditor)
-		{
-			this.CustomPropertyValueEditor = customPropertyValueEditor;
-		}
-
-		/// <summary>
-		/// Gets the custom property value editor.
-		/// </summary>
-		public CustomPropertyValueEditor CustomPropertyValueEditor
-		{
-			get;
-			private set;
-		}
+		get;
+		private set;
 	}
 }

--- a/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactivity.Shared/DefaultEventAttribute.cs
+++ b/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactivity.Shared/DefaultEventAttribute.cs
@@ -3,48 +3,47 @@
 
 using System;
 
-namespace Microsoft.Xaml.Interactivity
+namespace Microsoft.Xaml.Interactivity;
+
+/// <summary>
+/// Provides design tools information about which EventName to set for EventTriggerBehavior when instantiating an <see cref="Microsoft.Xaml.Interactivity.IAction"/>.
+/// </summary>
+[AttributeUsage(AttributeTargets.Class, AllowMultiple = true)]
+public sealed class DefaultEventAttribute : Attribute
 {
+	private readonly Type _targetType;
+	private readonly string _eventName;
+
 	/// <summary>
-	/// Provides design tools information about which EventName to set for EventTriggerBehavior when instantiating an <see cref="Microsoft.Xaml.Interactivity.IAction"/>.
+	/// Initializes a new instance of the <see cref="DefaultEventAttribute"/> class.
 	/// </summary>
-	[AttributeUsage(AttributeTargets.Class, AllowMultiple = true)]
-	public sealed class DefaultEventAttribute : Attribute
+	/// <param name="targetType">The type this attribute applies to.</param>
+	/// <param name="eventName">The event name for the EventTriggerBehavior.</param>
+	public DefaultEventAttribute(Type targetType, string eventName)
 	{
-		private readonly Type _targetType;
-		private readonly string _eventName;
+		this._targetType = targetType;
+		this._eventName = eventName;
+	}
 
-		/// <summary>
-		/// Initializes a new instance of the <see cref="DefaultEventAttribute"/> class.
-		/// </summary>
-		/// <param name="targetType">The type this attribute applies to.</param>
-		/// <param name="eventName">The event name for the EventTriggerBehavior.</param>
-		public DefaultEventAttribute(Type targetType, string eventName)
+	/// <summary>
+	/// Gets the type that the <see cref="DefaultEventAttribute"/> applies to.
+	/// </summary>
+	public Type TargetType
+	{
+		get
 		{
-			this._targetType = targetType;
-			this._eventName = eventName;
+			return this._targetType;
 		}
+	}
 
-		/// <summary>
-		/// Gets the type that the <see cref="DefaultEventAttribute"/> applies to.
-		/// </summary>
-		public Type TargetType
+	/// <summary>
+	/// Gets the event name to pass to the EventTriggerBehavior constructor.
+	/// </summary>
+	public string EventName
+	{
+		get
 		{
-			get
-			{
-				return this._targetType;
-			}
-		}
-
-		/// <summary>
-		/// Gets the event name to pass to the EventTriggerBehavior constructor.
-		/// </summary>
-		public string EventName
-		{
-			get
-			{
-				return this._eventName;
-			}
+			return this._eventName;
 		}
 	}
 }

--- a/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactivity.Shared/IAction.cs
+++ b/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactivity.Shared/IAction.cs
@@ -1,19 +1,19 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-namespace Microsoft.Xaml.Interactivity
+
+namespace Microsoft.Xaml.Interactivity;
+
+/// <summary>
+/// Interface implemented by all custom actions.
+/// </summary>
+public interface IAction
 {
     /// <summary>
-    /// Interface implemented by all custom actions.
+    /// Executes the action.
     /// </summary>
-    public interface IAction
-    {
-        /// <summary>
-        /// Executes the action.
-        /// </summary>
-        /// <param name="sender">The <see cref="object"/> that is passed to the action by the behavior. Generally this is <seealso cref="Microsoft.Xaml.Interactivity.IBehavior.AssociatedObject"/> or a target object.</param>
-        /// <param name="parameter">The value of this parameter is determined by the caller.</param>
-        /// <remarks> An example of parameter usage is EventTriggerBehavior, which passes the EventArgs as a parameter to its actions.</remarks>
-        /// <returns>Returns the result of the action.</returns>
-        object Execute(object sender, object parameter);
-    }
+    /// <param name="sender">The <see cref="object"/> that is passed to the action by the behavior. Generally this is <seealso cref="Microsoft.Xaml.Interactivity.IBehavior.AssociatedObject"/> or a target object.</param>
+    /// <param name="parameter">The value of this parameter is determined by the caller.</param>
+    /// <remarks> An example of parameter usage is EventTriggerBehavior, which passes the EventArgs as a parameter to its actions.</remarks>
+    /// <returns>Returns the result of the action.</returns>
+    object Execute(object sender, object parameter);
 }

--- a/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactivity.Shared/IBehavior.cs
+++ b/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactivity.Shared/IBehavior.cs
@@ -7,30 +7,29 @@ using Microsoft.UI.Xaml;
 using Windows.UI.Xaml;
 #endif
 
-namespace Microsoft.Xaml.Interactivity
+namespace Microsoft.Xaml.Interactivity;
+
+/// <summary>
+/// Interface implemented by all custom behaviors.
+/// </summary>
+public interface IBehavior
 {
     /// <summary>
-    /// Interface implemented by all custom behaviors.
+    /// Gets the <see cref="DependencyObject"/> to which the <seealso cref="IBehavior"/> is attached.
     /// </summary>
-    public interface IBehavior
+    DependencyObject AssociatedObject
     {
-        /// <summary>
-        /// Gets the <see cref="DependencyObject"/> to which the <seealso cref="IBehavior"/> is attached.
-        /// </summary>
-        DependencyObject AssociatedObject
-        {
-            get;
-        }
-
-        /// <summary>
-        /// Attaches to the specified object.
-        /// </summary>
-        /// <param name="associatedObject">The <see cref="DependencyObject"/> to which the <seealso cref="IBehavior"/> will be attached.</param>
-        void Attach(DependencyObject associatedObject);
-
-        /// <summary>
-        /// Detaches this instance from its associated object.
-        /// </summary>
-        void Detach();
+        get;
     }
+
+    /// <summary>
+    /// Attaches to the specified object.
+    /// </summary>
+    /// <param name="associatedObject">The <see cref="DependencyObject"/> to which the <seealso cref="IBehavior"/> will be attached.</param>
+    void Attach(DependencyObject associatedObject);
+
+    /// <summary>
+    /// Detaches this instance from its associated object.
+    /// </summary>
+    void Detach();
 }

--- a/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactivity.Shared/ITrigger.cs
+++ b/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactivity.Shared/ITrigger.cs
@@ -1,15 +1,15 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-namespace Microsoft.Xaml.Interactivity
+
+namespace Microsoft.Xaml.Interactivity;
+
+/// <summary>
+/// Interface implemented by all custom triggers.
+/// </summary>
+public interface ITrigger : IBehavior
 {
     /// <summary>
-    /// Interface implemented by all custom triggers.
+    /// Gets the collection of actions associated with the behavior.
     /// </summary>
-    public interface ITrigger : IBehavior
-    {
-        /// <summary>
-        /// Gets the collection of actions associated with the behavior.
-        /// </summary>
-        ActionCollection Actions { get; }
-    }
+    ActionCollection Actions { get; }
 }

--- a/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactivity.Shared/Interaction.cs
+++ b/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactivity.Shared/Interaction.cs
@@ -11,139 +11,138 @@ using Microsoft.UI.Xaml;
 using Windows.UI.Xaml;
 #endif
 
-namespace Microsoft.Xaml.Interactivity
+namespace Microsoft.Xaml.Interactivity;
+
+/// <summary>
+/// Defines a <see cref="BehaviorCollection"/> attached property and provides a method for executing an <seealso cref="ActionCollection"/>.
+/// </summary>
+public sealed class Interaction
 {
-    /// <summary>
-    /// Defines a <see cref="BehaviorCollection"/> attached property and provides a method for executing an <seealso cref="ActionCollection"/>.
-    /// </summary>
-    public sealed class Interaction
+    /// <remarks>
+    /// CA1053: Static holder types should not have public constructors
+    /// </remarks>
+    private Interaction()
     {
-        /// <remarks>
-        /// CA1053: Static holder types should not have public constructors
-        /// </remarks>
-        private Interaction()
+    }
+
+    /// <summary>
+    /// Gets or sets the <see cref="BehaviorCollection"/> associated with a specified object.
+    /// </summary>
+    [SuppressMessage("Microsoft.Security", "CA2104:DoNotDeclareReadOnlyMutableReferenceTypes")]
+    public static readonly DependencyProperty BehaviorsProperty = DependencyProperty.RegisterAttached(
+        "Behaviors",
+        typeof(BehaviorCollection),
+        typeof(Interaction),
+        new PropertyMetadata(null, new PropertyChangedCallback(Interaction.OnBehaviorsChanged)));
+
+    /// <summary>
+    /// Gets the <see cref="BehaviorCollection"/> associated with a specified object.
+    /// </summary>
+    /// <param name="obj">The <see cref="DependencyObject"/> from which to retrieve the <see cref="BehaviorCollection"/>.</param>
+    /// <returns>A <see cref="BehaviorCollection"/> containing the behaviors associated with the specified object.</returns>
+    public static BehaviorCollection GetBehaviors(DependencyObject obj)
+    {
+        if (obj == null)
         {
+            throw new ArgumentNullException(nameof(obj));
+        }
+        BehaviorCollection behaviorCollection = (BehaviorCollection)obj.GetValue(Interaction.BehaviorsProperty);
+        if (behaviorCollection == null)
+        {
+            behaviorCollection = new BehaviorCollection();
+            obj.SetValue(Interaction.BehaviorsProperty, behaviorCollection);
+
+            var frameworkElement = obj as FrameworkElement;
+
+            if (frameworkElement != null)
+            {
+                frameworkElement.Loaded -= FrameworkElement_Loaded;
+                frameworkElement.Loaded += FrameworkElement_Loaded;
+                frameworkElement.Unloaded -= FrameworkElement_Unloaded;
+                frameworkElement.Unloaded += FrameworkElement_Unloaded;
+            }
         }
 
-        /// <summary>
-        /// Gets or sets the <see cref="BehaviorCollection"/> associated with a specified object.
-        /// </summary>
-        [SuppressMessage("Microsoft.Security", "CA2104:DoNotDeclareReadOnlyMutableReferenceTypes")]
-        public static readonly DependencyProperty BehaviorsProperty = DependencyProperty.RegisterAttached(
-            "Behaviors",
-            typeof(BehaviorCollection),
-            typeof(Interaction),
-            new PropertyMetadata(null, new PropertyChangedCallback(Interaction.OnBehaviorsChanged)));
+        return behaviorCollection;
+    }
 
-        /// <summary>
-        /// Gets the <see cref="BehaviorCollection"/> associated with a specified object.
-        /// </summary>
-        /// <param name="obj">The <see cref="DependencyObject"/> from which to retrieve the <see cref="BehaviorCollection"/>.</param>
-        /// <returns>A <see cref="BehaviorCollection"/> containing the behaviors associated with the specified object.</returns>
-        public static BehaviorCollection GetBehaviors(DependencyObject obj)
+    /// <summary>
+    /// Sets the <see cref="BehaviorCollection"/> associated with a specified object.
+    /// </summary>
+    /// <param name="obj">The <see cref="DependencyObject"/> on which to set the <see cref="BehaviorCollection"/>.</param>
+    /// <param name="value">The <see cref="BehaviorCollection"/> associated with the object.</param>
+    public static void SetBehaviors(DependencyObject obj, BehaviorCollection value)
+    {
+        if (obj == null)
         {
-            if (obj == null)
-            {
-                throw new ArgumentNullException(nameof(obj));
-            }
-            BehaviorCollection behaviorCollection = (BehaviorCollection)obj.GetValue(Interaction.BehaviorsProperty);
-            if (behaviorCollection == null)
-            {
-                behaviorCollection = new BehaviorCollection();
-                obj.SetValue(Interaction.BehaviorsProperty, behaviorCollection);
-
-                var frameworkElement = obj as FrameworkElement;
-
-                if (frameworkElement != null)
-                {
-                    frameworkElement.Loaded -= FrameworkElement_Loaded;
-                    frameworkElement.Loaded += FrameworkElement_Loaded;
-                    frameworkElement.Unloaded -= FrameworkElement_Unloaded;
-                    frameworkElement.Unloaded += FrameworkElement_Unloaded;
-                }
-            }
-
-            return behaviorCollection;
+            throw new ArgumentNullException(nameof(obj));
         }
+        obj.SetValue(Interaction.BehaviorsProperty, value);
+    }
 
-        /// <summary>
-        /// Sets the <see cref="BehaviorCollection"/> associated with a specified object.
-        /// </summary>
-        /// <param name="obj">The <see cref="DependencyObject"/> on which to set the <see cref="BehaviorCollection"/>.</param>
-        /// <param name="value">The <see cref="BehaviorCollection"/> associated with the object.</param>
-        public static void SetBehaviors(DependencyObject obj, BehaviorCollection value)
+    /// <summary>
+    /// Executes all actions in the <see cref="ActionCollection"/> and returns their results.
+    /// </summary>
+    /// <param name="sender">The <see cref="object"/> which will be passed on to the action.</param>
+    /// <param name="actions">The set of actions to execute.</param>
+    /// <param name="parameter">The value of this parameter is determined by the calling behavior.</param>
+    /// <returns>Returns the results of the actions.</returns>
+    public static IEnumerable<object> ExecuteActions(object sender, ActionCollection actions, object parameter)
+    {
+        List<object> results = new List<object>();
+
+        if (actions == null || global::Windows.ApplicationModel.DesignMode.DesignModeEnabled)
         {
-            if (obj == null)
-            {
-                throw new ArgumentNullException(nameof(obj));
-            }
-            obj.SetValue(Interaction.BehaviorsProperty, value);
-        }
-
-        /// <summary>
-        /// Executes all actions in the <see cref="ActionCollection"/> and returns their results.
-        /// </summary>
-        /// <param name="sender">The <see cref="object"/> which will be passed on to the action.</param>
-        /// <param name="actions">The set of actions to execute.</param>
-        /// <param name="parameter">The value of this parameter is determined by the calling behavior.</param>
-        /// <returns>Returns the results of the actions.</returns>
-        public static IEnumerable<object> ExecuteActions(object sender, ActionCollection actions, object parameter)
-        {
-            List<object> results = new List<object>();
-
-            if (actions == null || global::Windows.ApplicationModel.DesignMode.DesignModeEnabled)
-            {
-                return results;
-            }
-
-            foreach (DependencyObject dependencyObject in actions)
-            {
-                IAction action = (IAction)dependencyObject;
-                results.Add(action.Execute(sender, parameter));
-            }
-
             return results;
         }
 
-        private static void OnBehaviorsChanged(DependencyObject sender, DependencyPropertyChangedEventArgs args)
+        foreach (DependencyObject dependencyObject in actions)
         {
-            BehaviorCollection oldCollection = (BehaviorCollection)args.OldValue;
-            BehaviorCollection newCollection = (BehaviorCollection)args.NewValue;
-
-            if (oldCollection == newCollection)
-            {
-                return;
-            }
-
-            if (oldCollection != null && oldCollection.AssociatedObject != null)
-            {
-                oldCollection.Detach();
-            }
-
-            if (newCollection != null && sender != null)
-            {
-                newCollection.Attach(sender);
-            }
+            IAction action = (IAction)dependencyObject;
+            results.Add(action.Execute(sender, parameter));
         }
 
-        private static void FrameworkElement_Loaded(object sender, RoutedEventArgs e)
-        {
-            var d = sender as DependencyObject;
+        return results;
+    }
 
-            if (d != null)
-            {
-                GetBehaviors(d).Attach(d);
-            }
+    private static void OnBehaviorsChanged(DependencyObject sender, DependencyPropertyChangedEventArgs args)
+    {
+        BehaviorCollection oldCollection = (BehaviorCollection)args.OldValue;
+        BehaviorCollection newCollection = (BehaviorCollection)args.NewValue;
+
+        if (oldCollection == newCollection)
+        {
+            return;
         }
 
-        private static void FrameworkElement_Unloaded(object sender, RoutedEventArgs e)
+        if (oldCollection != null && oldCollection.AssociatedObject != null)
         {
-            var d = sender as DependencyObject;
+            oldCollection.Detach();
+        }
 
-            if (d != null)
-            {
-                GetBehaviors(d).Detach();
-            }
+        if (newCollection != null && sender != null)
+        {
+            newCollection.Attach(sender);
+        }
+    }
+
+    private static void FrameworkElement_Loaded(object sender, RoutedEventArgs e)
+    {
+        var d = sender as DependencyObject;
+
+        if (d != null)
+        {
+            GetBehaviors(d).Attach(d);
+        }
+    }
+
+    private static void FrameworkElement_Unloaded(object sender, RoutedEventArgs e)
+    {
+        var d = sender as DependencyObject;
+
+        if (d != null)
+        {
+            GetBehaviors(d).Detach();
         }
     }
 }

--- a/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactivity.Shared/Media/ControlStoryboardAction.cs
+++ b/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactivity.Shared/Media/ControlStoryboardAction.cs
@@ -11,155 +11,154 @@ using Windows.UI.Xaml;
 using Windows.UI.Xaml.Media.Animation;
 #endif
 
-namespace Microsoft.Xaml.Interactivity
+namespace Microsoft.Xaml.Interactivity;
+
+#if WinUI
+/// <summary>
+/// An action that will change the state of the specified <seealso cref="Microsoft.UI.Xaml.Media.Animation.Storyboard"/> when executed.
+/// </summary>
+#else
+/// <summary>
+/// An action that will change the state of the specified <seealso cref="Windows.UI.Xaml.Media.Animation.Storyboard"/> when executed.
+/// </summary>
+#endif
+public sealed class ControlStoryboardAction : DependencyObject, IAction
 {
+    /// <summary>
+    /// Identifies the <seealso cref="ControlStoryboardOption"/> dependency property.
+    /// </summary>
+    [SuppressMessage("Microsoft.Security", "CA2104:DoNotDeclareReadOnlyMutableReferenceTypes")]
+    public static readonly DependencyProperty ControlStoryboardOptionProperty = DependencyProperty.Register(
+        "ControlStoryboardOption",
+        typeof(ControlStoryboardOption),
+        typeof(ControlStoryboardAction),
+        new PropertyMetadata(ControlStoryboardOption.Play));
+
+    /// <summary>
+    /// Identifies the <seealso cref="Storyboard"/> dependency property.
+    /// </summary>
+    [SuppressMessage("Microsoft.Security", "CA2104:DoNotDeclareReadOnlyMutableReferenceTypes")]
+    public static readonly DependencyProperty StoryboardProperty = DependencyProperty.Register(
+        "Storyboard",
+        typeof(Storyboard),
+        typeof(ControlStoryboardAction),
+        new PropertyMetadata(null, new PropertyChangedCallback(ControlStoryboardAction.OnStoryboardChanged)));
+
+    private bool _isPaused;
+
 #if WinUI
     /// <summary>
-    /// An action that will change the state of the specified <seealso cref="Microsoft.UI.Xaml.Media.Animation.Storyboard"/> when executed.
+    /// Gets or sets the action to execute on the <see cref="Microsoft.UI.Xaml.Media.Animation.Storyboard"/>. This is a dependency property.
     /// </summary>
 #else
     /// <summary>
-    /// An action that will change the state of the specified <seealso cref="Windows.UI.Xaml.Media.Animation.Storyboard"/> when executed.
+    /// Gets or sets the action to execute on the <see cref="Windows.UI.Xaml.Media.Animation.Storyboard"/>. This is a dependency property.
     /// </summary>
 #endif
-    public sealed class ControlStoryboardAction : DependencyObject, IAction
-	{
-		/// <summary>
-		/// Identifies the <seealso cref="ControlStoryboardOption"/> dependency property.
-		/// </summary>
-		[SuppressMessage("Microsoft.Security", "CA2104:DoNotDeclareReadOnlyMutableReferenceTypes")]
-		public static readonly DependencyProperty ControlStoryboardOptionProperty = DependencyProperty.Register(
-			"ControlStoryboardOption",
-			typeof(ControlStoryboardOption),
-			typeof(ControlStoryboardAction),
-			new PropertyMetadata(ControlStoryboardOption.Play));
-
-		/// <summary>
-		/// Identifies the <seealso cref="Storyboard"/> dependency property.
-		/// </summary>
-		[SuppressMessage("Microsoft.Security", "CA2104:DoNotDeclareReadOnlyMutableReferenceTypes")]
-		public static readonly DependencyProperty StoryboardProperty = DependencyProperty.Register(
-			"Storyboard",
-			typeof(Storyboard),
-			typeof(ControlStoryboardAction),
-			new PropertyMetadata(null, new PropertyChangedCallback(ControlStoryboardAction.OnStoryboardChanged)));
-
-		private bool _isPaused;
+    public ControlStoryboardOption ControlStoryboardOption
+    {
+        get
+        {
+            return (ControlStoryboardOption)this.GetValue(ControlStoryboardAction.ControlStoryboardOptionProperty);
+        }
+        set
+        {
+            this.SetValue(ControlStoryboardAction.ControlStoryboardOptionProperty, value);
+        }
+    }
 
 #if WinUI
-        /// <summary>
-        /// Gets or sets the action to execute on the <see cref="Microsoft.UI.Xaml.Media.Animation.Storyboard"/>. This is a dependency property.
-        /// </summary>
+    /// <summary>
+    /// Gets or sets the targeted <see cref="Microsoft.UI.Xaml.Media.Animation.Storyboard"/>. This is a dependency property.
+    /// </summary>
 #else
-        /// <summary>
-        /// Gets or sets the action to execute on the <see cref="Windows.UI.Xaml.Media.Animation.Storyboard"/>. This is a dependency property.
-        /// </summary>
+    /// <summary>
+    /// Gets or sets the targeted <see cref="Windows.UI.Xaml.Media.Animation.Storyboard"/>. This is a dependency property.
+    /// </summary>
 #endif
-        public ControlStoryboardOption ControlStoryboardOption
-		{
-			get
-			{
-				return (ControlStoryboardOption)this.GetValue(ControlStoryboardAction.ControlStoryboardOptionProperty);
-			}
-			set
-			{
-				this.SetValue(ControlStoryboardAction.ControlStoryboardOptionProperty, value);
-			}
-		}
+    public Storyboard Storyboard
+    {
+        get
+        {
+            return (Storyboard)this.GetValue(ControlStoryboardAction.StoryboardProperty);
+        }
+        set
+        {
+            this.SetValue(ControlStoryboardAction.StoryboardProperty, value);
+        }
+    }
 
-#if WinUI
-        /// <summary>
-        /// Gets or sets the targeted <see cref="Microsoft.UI.Xaml.Media.Animation.Storyboard"/>. This is a dependency property.
-        /// </summary>
-#else
-        /// <summary>
-        /// Gets or sets the targeted <see cref="Windows.UI.Xaml.Media.Animation.Storyboard"/>. This is a dependency property.
-        /// </summary>
-#endif
-        public Storyboard Storyboard
-		{
-			get
-			{
-				return (Storyboard)this.GetValue(ControlStoryboardAction.StoryboardProperty);
-			}
-			set
-			{
-				this.SetValue(ControlStoryboardAction.StoryboardProperty, value);
-			}
-		}
+    /// <summary>
+    /// Executes the action.
+    /// </summary>
+    /// <param name="sender">The <see cref="object"/> that is passed to the action by the behavior. Generally this is <seealso cref="Microsoft.Xaml.Interactivity.IBehavior.AssociatedObject"/> or a target object.</param>
+    /// <param name="parameter">The value of this parameter is determined by the caller.</param>
+    /// <returns>True if the specified operation is invoked successfully; else false.</returns>
+    public object Execute(object sender, object parameter)
+    {
+        if (this.Storyboard == null)
+        {
+            return false;
+        }
 
-		/// <summary>
-		/// Executes the action.
-		/// </summary>
-		/// <param name="sender">The <see cref="object"/> that is passed to the action by the behavior. Generally this is <seealso cref="Microsoft.Xaml.Interactivity.IBehavior.AssociatedObject"/> or a target object.</param>
-		/// <param name="parameter">The value of this parameter is determined by the caller.</param>
-		/// <returns>True if the specified operation is invoked successfully; else false.</returns>
-		public object Execute(object sender, object parameter)
-		{
-			if (this.Storyboard == null)
-			{
-				return false;
-			}
+        switch (this.ControlStoryboardOption)
+        {
+            case ControlStoryboardOption.Play:
+                this.Storyboard.Begin();
+                break;
 
-			switch (this.ControlStoryboardOption)
-			{
-				case ControlStoryboardOption.Play:
-					this.Storyboard.Begin();
-					break;
+            case ControlStoryboardOption.Stop:
+                this.Storyboard.Stop();
+                break;
 
-				case ControlStoryboardOption.Stop:
-					this.Storyboard.Stop();
-					break;
+            case ControlStoryboardOption.TogglePlayPause:
+                {
+                    ClockState currentState = this.Storyboard.GetCurrentState();
 
-				case ControlStoryboardOption.TogglePlayPause:
-					{
-						ClockState currentState = this.Storyboard.GetCurrentState();
+                    if (currentState == ClockState.Stopped)
+                    {
+                        this._isPaused = false;
+                        this.Storyboard.Begin();
+                    }
+                    else if (this._isPaused)
+                    {
+                        this._isPaused = false;
+                        this.Storyboard.Resume();
+                    }
+                    else
+                    {
+                        this._isPaused = true;
+                        this.Storyboard.Pause();
+                    }
+                }
 
-						if (currentState == ClockState.Stopped)
-						{
-							this._isPaused = false;
-							this.Storyboard.Begin();
-						}
-						else if (this._isPaused)
-						{
-							this._isPaused = false;
-							this.Storyboard.Resume();
-						}
-						else
-						{
-							this._isPaused = true;
-							this.Storyboard.Pause();
-						}
-					}
+                break;
 
-					break;
+            case ControlStoryboardOption.Pause:
+                this.Storyboard.Pause();
+                break;
 
-				case ControlStoryboardOption.Pause:
-					this.Storyboard.Pause();
-					break;
+            case ControlStoryboardOption.Resume:
+                this.Storyboard.Resume();
+                break;
 
-				case ControlStoryboardOption.Resume:
-					this.Storyboard.Resume();
-					break;
+            case ControlStoryboardOption.SkipToFill:
+                this.Storyboard.SkipToFill();
+                break;
 
-				case ControlStoryboardOption.SkipToFill:
-					this.Storyboard.SkipToFill();
-					break;
+            default:
+                return false;
+        }
 
-				default:
-					return false;
-			}
+        return true;
+    }
 
-			return true;
-		}
-
-		private static void OnStoryboardChanged(DependencyObject sender, DependencyPropertyChangedEventArgs args)
-		{
-			ControlStoryboardAction action = sender as ControlStoryboardAction;
-			if (action != null)
-			{
-				action._isPaused = false;
-			}
-		}
-	}
+    private static void OnStoryboardChanged(DependencyObject sender, DependencyPropertyChangedEventArgs args)
+    {
+        ControlStoryboardAction action = sender as ControlStoryboardAction;
+        if (action != null)
+        {
+            action._isPaused = false;
+        }
+    }
 }

--- a/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactivity.Shared/Media/ControlStoryboardOption.cs
+++ b/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactivity.Shared/Media/ControlStoryboardOption.cs
@@ -6,36 +6,35 @@ using Windows.UI.Xaml.Media.Animation;
 
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-namespace Microsoft.Xaml.Interactivity
+namespace Microsoft.Xaml.Interactivity;
+
+/// <summary>
+/// Represents operations that can be applied to <seealso cref="Storyboard"/>.
+/// </summary>
+public enum ControlStoryboardOption
 {
     /// <summary>
-    /// Represents operations that can be applied to <seealso cref="Storyboard"/>.
+    /// Specifies the play operation.
     /// </summary>
-    public enum ControlStoryboardOption
-    {
-        /// <summary>
-        /// Specifies the play operation.
-        /// </summary>
-        Play,
-        /// <summary>
-        /// Specifies the stop operation.
-        /// </summary>
-        Stop,
-        /// <summary>
-        /// Specifies the TogglePlayPause operation.
-        /// </summary>
-        TogglePlayPause,
-        /// <summary>
-        /// Specifies the pause operation.
-        /// </summary>
-        Pause,
-        /// <summary>
-        /// Specifies the resume operation.
-        /// </summary>
-        Resume,
-        /// <summary>
-        /// Specifies the SkipToFill operation.
-        /// </summary>
-        SkipToFill
-    }
+    Play,
+    /// <summary>
+    /// Specifies the stop operation.
+    /// </summary>
+    Stop,
+    /// <summary>
+    /// Specifies the TogglePlayPause operation.
+    /// </summary>
+    TogglePlayPause,
+    /// <summary>
+    /// Specifies the pause operation.
+    /// </summary>
+    Pause,
+    /// <summary>
+    /// Specifies the resume operation.
+    /// </summary>
+    Resume,
+    /// <summary>
+    /// Specifies the SkipToFill operation.
+    /// </summary>
+    SkipToFill
 }

--- a/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactivity.Shared/Media/PlaySoundAction.cs
+++ b/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactivity.Shared/Media/PlaySoundAction.cs
@@ -21,158 +21,157 @@ using MediaPlayerElement = Windows.UI.Xaml.Controls.MediaPlayerElement;
 using Windows.UI.Xaml.Controls.Primitives;
 #endif
 
-namespace Microsoft.Xaml.Interactivity
-{
-	/// <summary>
-	/// An action that will play a sound to completion.
-	/// </summary>
-	/// <remarks>
-	/// This action is intended for use with short sound effects that don't need to be stopped or controlled. If you are trying 
-	/// to create a music player or game, it may not meet your needs.
-	/// </remarks>
-	public sealed class PlaySoundAction : DependencyObject, IAction
-	{        
-        private readonly DispatcherQueue _queue = DispatcherQueue.GetForCurrentThread();
+namespace Microsoft.Xaml.Interactivity;
 
-		private const string MsAppXSchemeFormatString = "ms-appx:///{0}";
+/// <summary>
+/// An action that will play a sound to completion.
+/// </summary>
+/// <remarks>
+/// This action is intended for use with short sound effects that don't need to be stopped or controlled. If you are trying 
+/// to create a music player or game, it may not meet your needs.
+/// </remarks>
+public sealed class PlaySoundAction : DependencyObject, IAction
+{        
+    private readonly DispatcherQueue _queue = DispatcherQueue.GetForCurrentThread();
 
-		/// <summary>
-		/// Identifies the <seealso cref="Source"/> dependency property.
-		/// </summary>
-		[SuppressMessage("Microsoft.Security", "CA2104:DoNotDeclareReadOnlyMutableReferenceTypes")]
-		public static readonly DependencyProperty SourceProperty = DependencyProperty.Register(
-			nameof(Source),
-			typeof(string),
-			typeof(PlaySoundAction),
-			new PropertyMetadata(null));
+    private const string MsAppXSchemeFormatString = "ms-appx:///{0}";
 
-		/// <summary>
-		/// Identifies the <seealso cref="Volume"/> dependency property.
-		/// </summary>
-		[SuppressMessage("Microsoft.Security", "CA2104:DoNotDeclareReadOnlyMutableReferenceTypes")]
-		public static readonly DependencyProperty VolumeProperty = DependencyProperty.Register(
-			nameof(Volume),
-			typeof(double),
-			typeof(PlaySoundAction),
-			new PropertyMetadata(0.5));
+    /// <summary>
+    /// Identifies the <seealso cref="Source"/> dependency property.
+    /// </summary>
+    [SuppressMessage("Microsoft.Security", "CA2104:DoNotDeclareReadOnlyMutableReferenceTypes")]
+    public static readonly DependencyProperty SourceProperty = DependencyProperty.Register(
+        nameof(Source),
+        typeof(string),
+        typeof(PlaySoundAction),
+        new PropertyMetadata(null));
 
-		private Popup _popup;
+    /// <summary>
+    /// Identifies the <seealso cref="Volume"/> dependency property.
+    /// </summary>
+    [SuppressMessage("Microsoft.Security", "CA2104:DoNotDeclareReadOnlyMutableReferenceTypes")]
+    public static readonly DependencyProperty VolumeProperty = DependencyProperty.Register(
+        nameof(Volume),
+        typeof(double),
+        typeof(PlaySoundAction),
+        new PropertyMetadata(0.5));
 
-        /// <summary>
-        /// Gets or sets the location of the sound file. This is used to set the source property of a <see cref="MediaPlayerElement"/>. This is a dependency property.
-        /// </summary>
-        /// <remarks>
-        /// The sound can be any file format supported by <see cref="MediaPlayerElement"/>. In the case of a video, it will play only the
-        /// audio portion.
-        /// </remarks>
-        public string Source
-		{
-			get
-			{
-				return (string)this.GetValue(SourceProperty);
-			}
-			set
-			{
-				this.SetValue(SourceProperty, value);
-			}
-		}
+    private Popup _popup;
 
-        /// <summary>
-        /// Gets or set the volume of the sound. This is used to set the <see cref="MediaPlayer.Volume"/> property of the <see cref="MediaPlayerElement"/>. This is a dependency property.
-        /// </summary>
-        /// <remarks>
-        /// By default this is set to 0.5.
-        /// </remarks>
-        public double Volume
-		{
-			get
-			{
-				return (double)this.GetValue(VolumeProperty);
-			}
-			set
-			{
-				this.SetValue(VolumeProperty, value);
-			}
-		}
-
-        /// <summary>
-        /// Executes the action.
-        /// </summary>
-        /// <param name="sender">The <see cref="object"/> that is passed to the action by the behavior. Generally this is <seealso cref="IBehavior.AssociatedObject"/> or a target object.</param>
-        /// <param name="parameter">The value of this parameter is determined by the caller.</param>
-        /// <returns>True if <see cref="MediaPlayerElement.Source"/> is set successfully; else false.</returns>
-        public object Execute(object sender, object parameter)
-		{
-			if (string.IsNullOrEmpty(this.Source))
-			{
-				return false;
-			}
-
-			Uri sourceUri;
-			if (!Uri.TryCreate(this.Source, UriKind.Absolute, out sourceUri))
-			{
-				// Impose ms-appx:// scheme if user has specified a relative URI
-				string absoluteSource = string.Format(CultureInfo.InvariantCulture, MsAppXSchemeFormatString, this.Source);
-				if (!Uri.TryCreate(absoluteSource, UriKind.Absolute, out sourceUri))
-				{
-					return false;
-				}
-			}
-
-			_popup = new Popup();
-            if (sender is UIElement element && element.XamlRoot != null)
-            {
-                _popup.XamlRoot = element.XamlRoot;
-            }
-
-            MediaPlayerElement mediaElement = new MediaPlayerElement();
-			_popup.Child = mediaElement;
-
-			// It is legal (although not advisable) to provide a video file. By setting visibility to collapsed, only the sound track should play.
-			mediaElement.Visibility = Visibility.Collapsed;
-
-            mediaElement.Source = MediaSource.CreateFromUri(sourceUri);
-            mediaElement.AutoPlay = true;
-            mediaElement.MediaPlayer.Volume = this.Volume;
-            mediaElement.MediaPlayer.MediaEnded += this.MediaElement_MediaEnded;
-            mediaElement.MediaPlayer.MediaFailed += this.MediaPlayer_MediaFailed;
-
-            this._popup.IsOpen = true;
-			return true;
-		}
-
-        private void MediaPlayer_MediaFailed(MediaPlayer sender, MediaPlayerFailedEventArgs args)
-		{
-            // TODO: We should probably have some system/properties to report/bubble errors here
-            ClosePopup();
-		}
-
-        private void MediaElement_MediaEnded(MediaPlayer sender, object args)
+    /// <summary>
+    /// Gets or sets the location of the sound file. This is used to set the source property of a <see cref="MediaPlayerElement"/>. This is a dependency property.
+    /// </summary>
+    /// <remarks>
+    /// The sound can be any file format supported by <see cref="MediaPlayerElement"/>. In the case of a video, it will play only the
+    /// audio portion.
+    /// </remarks>
+    public string Source
+    {
+        get
         {
-            ClosePopup();
-		}
-
-        private void ClosePopup()
+            return (string)this.GetValue(SourceProperty);
+        }
+        set
         {
-            void closePopupImpl()
-            {
-                if (this._popup != null)
-                {
-                    this._popup.IsOpen = false;
-                    this._popup.Child = null;
-                    this._popup = null;
-                }
-            }
+            this.SetValue(SourceProperty, value);
+        }
+    }
 
-            if (_queue.HasThreadAccess)
+    /// <summary>
+    /// Gets or set the volume of the sound. This is used to set the <see cref="MediaPlayer.Volume"/> property of the <see cref="MediaPlayerElement"/>. This is a dependency property.
+    /// </summary>
+    /// <remarks>
+    /// By default this is set to 0.5.
+    /// </remarks>
+    public double Volume
+    {
+        get
+        {
+            return (double)this.GetValue(VolumeProperty);
+        }
+        set
+        {
+            this.SetValue(VolumeProperty, value);
+        }
+    }
+
+    /// <summary>
+    /// Executes the action.
+    /// </summary>
+    /// <param name="sender">The <see cref="object"/> that is passed to the action by the behavior. Generally this is <seealso cref="IBehavior.AssociatedObject"/> or a target object.</param>
+    /// <param name="parameter">The value of this parameter is determined by the caller.</param>
+    /// <returns>True if <see cref="MediaPlayerElement.Source"/> is set successfully; else false.</returns>
+    public object Execute(object sender, object parameter)
+    {
+        if (string.IsNullOrEmpty(this.Source))
+        {
+            return false;
+        }
+
+        Uri sourceUri;
+        if (!Uri.TryCreate(this.Source, UriKind.Absolute, out sourceUri))
+        {
+            // Impose ms-appx:// scheme if user has specified a relative URI
+            string absoluteSource = string.Format(CultureInfo.InvariantCulture, MsAppXSchemeFormatString, this.Source);
+            if (!Uri.TryCreate(absoluteSource, UriKind.Absolute, out sourceUri))
             {
-                closePopupImpl();
+                return false;
             }
-            else
+        }
+
+        _popup = new Popup();
+        if (sender is UIElement element && element.XamlRoot != null)
+        {
+            _popup.XamlRoot = element.XamlRoot;
+        }
+
+        MediaPlayerElement mediaElement = new MediaPlayerElement();
+        _popup.Child = mediaElement;
+
+        // It is legal (although not advisable) to provide a video file. By setting visibility to collapsed, only the sound track should play.
+        mediaElement.Visibility = Visibility.Collapsed;
+
+        mediaElement.Source = MediaSource.CreateFromUri(sourceUri);
+        mediaElement.AutoPlay = true;
+        mediaElement.MediaPlayer.Volume = this.Volume;
+        mediaElement.MediaPlayer.MediaEnded += this.MediaElement_MediaEnded;
+        mediaElement.MediaPlayer.MediaFailed += this.MediaPlayer_MediaFailed;
+
+        this._popup.IsOpen = true;
+        return true;
+    }
+
+    private void MediaPlayer_MediaFailed(MediaPlayer sender, MediaPlayerFailedEventArgs args)
+    {
+        // TODO: We should probably have some system/properties to report/bubble errors here
+        ClosePopup();
+    }
+
+    private void MediaElement_MediaEnded(MediaPlayer sender, object args)
+    {
+        ClosePopup();
+    }
+
+    private void ClosePopup()
+    {
+        void closePopupImpl()
+        {
+            if (this._popup != null)
             {
-                // In WinUI3 the Media events are called on a background thread, so ensure we're on the UI thread to modify our popup container.
-                _queue.TryEnqueue(DispatcherQueuePriority.Normal, closePopupImpl);
-            }            
-        }        
-	}
+                this._popup.IsOpen = false;
+                this._popup.Child = null;
+                this._popup = null;
+            }
+        }
+
+        if (_queue.HasThreadAccess)
+        {
+            closePopupImpl();
+        }
+        else
+        {
+            // In WinUI3 the Media events are called on a background thread, so ensure we're on the UI thread to modify our popup container.
+            _queue.TryEnqueue(DispatcherQueuePriority.Normal, closePopupImpl);
+        }            
+    }        
 }

--- a/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactivity.Shared/Trigger.cs
+++ b/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactivity.Shared/Trigger.cs
@@ -12,40 +12,39 @@ using Windows.UI.Xaml;
 using Windows.UI.Xaml.Markup;
 #endif
 
-namespace Microsoft.Xaml.Interactivity
+namespace Microsoft.Xaml.Interactivity;
+
+/// <summary>
+/// A base class for behaviors, implementing the basic plumbing of ITrigger
+/// </summary>
+[ContentPropertyAttribute(Name = "Actions")]
+public abstract class Trigger : Behavior, ITrigger
 {
     /// <summary>
-    /// A base class for behaviors, implementing the basic plumbing of ITrigger
+    /// Identifies the <seealso cref="Actions"/> dependency property.
     /// </summary>
-    [ContentPropertyAttribute(Name = "Actions")]
-    public abstract class Trigger : Behavior, ITrigger
+    [SuppressMessage("Microsoft.Security", "CA2104:DoNotDeclareReadOnlyMutableReferenceTypes")]
+    public static readonly DependencyProperty ActionsProperty = DependencyProperty.Register(
+        "Actions",
+        typeof(ActionCollection),
+        typeof(Trigger),
+        new PropertyMetadata(null));
+
+    /// <summary>
+    /// Gets the collection of actions associated with the behavior. This is a dependency property.
+    /// </summary>
+    public ActionCollection Actions
     {
-        /// <summary>
-        /// Identifies the <seealso cref="Actions"/> dependency property.
-        /// </summary>
-        [SuppressMessage("Microsoft.Security", "CA2104:DoNotDeclareReadOnlyMutableReferenceTypes")]
-        public static readonly DependencyProperty ActionsProperty = DependencyProperty.Register(
-            "Actions",
-            typeof(ActionCollection),
-            typeof(Trigger),
-            new PropertyMetadata(null));
-
-        /// <summary>
-        /// Gets the collection of actions associated with the behavior. This is a dependency property.
-        /// </summary>
-        public ActionCollection Actions
+        get
         {
-            get
+            ActionCollection actionCollection = (ActionCollection)this.GetValue(Trigger.ActionsProperty);
+            if (actionCollection == null)
             {
-                ActionCollection actionCollection = (ActionCollection)this.GetValue(Trigger.ActionsProperty);
-                if (actionCollection == null)
-                {
-                    actionCollection = new ActionCollection();
-                    this.SetValue(Trigger.ActionsProperty, actionCollection);
-                }
-
-                return actionCollection;
+                actionCollection = new ActionCollection();
+                this.SetValue(Trigger.ActionsProperty, actionCollection);
             }
+
+            return actionCollection;
         }
     }
 }

--- a/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactivity.Shared/TriggerOfT.cs
+++ b/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactivity.Shared/TriggerOfT.cs
@@ -10,40 +10,39 @@ using Microsoft.UI.Xaml;
 using Windows.UI.Xaml;
 #endif
 
-namespace Microsoft.Xaml.Interactivity
+namespace Microsoft.Xaml.Interactivity;
+
+/// <summary>
+/// A base class for behaviors, implementing the basic plumbing of ITrigger
+/// </summary>
+/// <typeparam name="T">The object type to attach to</typeparam>
+public abstract class Trigger<T> : Trigger where T : DependencyObject
 {
     /// <summary>
-    /// A base class for behaviors, implementing the basic plumbing of ITrigger
+    /// Gets the object to which this behavior is attached.
     /// </summary>
-    /// <typeparam name="T">The object type to attach to</typeparam>
-    public abstract class Trigger<T> : Trigger where T : DependencyObject
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public new T AssociatedObject
     {
-        /// <summary>
-        /// Gets the object to which this behavior is attached.
-        /// </summary>
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public new T AssociatedObject
-        {
-            get { return base.AssociatedObject as T; }
-        }
+        get { return base.AssociatedObject as T; }
+    }
 
-        /// <summary>
-        /// Called after the behavior is attached to the <see cref="Microsoft.Xaml.Interactivity.Behavior.AssociatedObject"/>.
-        /// </summary>
-        /// <remarks>
-        /// Override this to hook up functionality to the <see cref="Microsoft.Xaml.Interactivity.Behavior.AssociatedObject"/>
-        /// </remarks>
-        protected override void OnAttached()
-        {
-            base.OnAttached();
+    /// <summary>
+    /// Called after the behavior is attached to the <see cref="Microsoft.Xaml.Interactivity.Behavior.AssociatedObject"/>.
+    /// </summary>
+    /// <remarks>
+    /// Override this to hook up functionality to the <see cref="Microsoft.Xaml.Interactivity.Behavior.AssociatedObject"/>
+    /// </remarks>
+    protected override void OnAttached()
+    {
+        base.OnAttached();
 
-            if (this.AssociatedObject == null)
-            {
-                string actualType = base.AssociatedObject.GetType().FullName;
-                string expectedType = typeof(T).FullName;
-                string message = string.Format(ResourceHelper.GetString("InvalidAssociatedObjectExceptionMessage"), actualType, expectedType);
-                throw new InvalidOperationException(message);
-            }
+        if (this.AssociatedObject == null)
+        {
+            string actualType = base.AssociatedObject.GetType().FullName;
+            string expectedType = typeof(T).FullName;
+            string message = string.Format(ResourceHelper.GetString("InvalidAssociatedObjectExceptionMessage"), actualType, expectedType);
+            throw new InvalidOperationException(message);
         }
     }
 }

--- a/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactivity.Shared/TypeConstraintAttribute.cs
+++ b/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactivity.Shared/TypeConstraintAttribute.cs
@@ -3,30 +3,29 @@
 
 using System;
 
-namespace Microsoft.Xaml.Interactivity
+namespace Microsoft.Xaml.Interactivity;
+
+/// <summary>
+/// Specifies type constraints on the AssociatedObject of  <see cref="Microsoft.Xaml.Interactivity.IBehavior"/>.
+/// </summary>
+[AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = false)]
+public sealed class TypeConstraintAttribute : Attribute
 {
 	/// <summary>
-	/// Specifies type constraints on the AssociatedObject of  <see cref="Microsoft.Xaml.Interactivity.IBehavior"/>.
+	/// Initializes a new instance of the <see cref="TypeConstraintAttribute"/> class.
 	/// </summary>
-	[AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = false)]
-	public sealed class TypeConstraintAttribute : Attribute
+	/// <param name="constraint">The constraint type.</param>
+	public TypeConstraintAttribute(Type constraint)
 	{
-		/// <summary>
-		/// Initializes a new instance of the <see cref="TypeConstraintAttribute"/> class.
-		/// </summary>
-		/// <param name="constraint">The constraint type.</param>
-		public TypeConstraintAttribute(Type constraint)
-		{
-			this.Constraint = constraint;
-		}
+		this.Constraint = constraint;
+	}
 
-		/// <summary>
-		/// Gets the constraint type.
-		/// </summary>
-		public Type Constraint
-		{
-			get;
-			private set;
-		}
+	/// <summary>
+	/// Gets the constraint type.
+	/// </summary>
+	public Type Constraint
+	{
+		get;
+		private set;
 	}
 }

--- a/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactivity.Shared/Utility/IVisualTreeHelper.cs
+++ b/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactivity.Shared/Utility/IVisualTreeHelper.cs
@@ -7,26 +7,25 @@ using Microsoft.UI.Xaml;
 using Windows.UI.Xaml;
 #endif
 
-namespace Microsoft.Xaml.Interactivity.Utility
+namespace Microsoft.Xaml.Interactivity.Utility;
+
+/// <summary>
+/// Abstraction layer over the UWP's VisualTreeHelper class so we can 
+/// mock it for unit testing purposes where an actual view won't be available.
+/// </summary>
+internal interface IVisualTreeHelper
 {
     /// <summary>
-    /// Abstraction layer over the UWP's VisualTreeHelper class so we can 
-    /// mock it for unit testing purposes where an actual view won't be available.
+    /// Returns an object's parent object in the visual tree.
     /// </summary>
-    internal interface IVisualTreeHelper
-    {
-        /// <summary>
-        /// Returns an object's parent object in the visual tree.
-        /// </summary>
-        /// <param name="reference">
-        /// The object for which to get the parent object.
-        /// </param>
-        /// <returns>
-        /// The parent object of the reference object in the visual tree. 
-        /// </returns>
-        /// <remarks>
-        /// THREAD SAFETY: This method should be called on the object's Dispatcher thread.
-        /// </remarks>
-        DependencyObject GetParent(DependencyObject reference);
-    }
+    /// <param name="reference">
+    /// The object for which to get the parent object.
+    /// </param>
+    /// <returns>
+    /// The parent object of the reference object in the visual tree. 
+    /// </returns>
+    /// <remarks>
+    /// THREAD SAFETY: This method should be called on the object's Dispatcher thread.
+    /// </remarks>
+    DependencyObject GetParent(DependencyObject reference);
 }

--- a/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactivity.Shared/Utility/UwpVisualTreeHelper.cs
+++ b/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactivity.Shared/Utility/UwpVisualTreeHelper.cs
@@ -9,20 +9,19 @@ using Windows.UI.Xaml;
 using Windows.UI.Xaml.Media;
 #endif
 
-namespace Microsoft.Xaml.Interactivity.Utility
+namespace Microsoft.Xaml.Interactivity.Utility;
+
+/// <summary>
+/// IVisualTreeHelper implementation that calls the real VisualTreeHelper.
+/// </summary>
+internal class UwpVisualTreeHelper : IVisualTreeHelper
 {
-    /// <summary>
-    /// IVisualTreeHelper implementation that calls the real VisualTreeHelper.
-    /// </summary>
-    internal class UwpVisualTreeHelper : IVisualTreeHelper
+    #region IVisualTreeHelper implementation
+
+    public DependencyObject GetParent(DependencyObject reference)
     {
-        #region IVisualTreeHelper implementation
-
-        public DependencyObject GetParent(DependencyObject reference)
-        {
-            return VisualTreeHelper.GetParent(reference);
-        }
-
-        #endregion
+        return VisualTreeHelper.GetParent(reference);
     }
+
+    #endregion
 }

--- a/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactivity.Shared/VisualStateUtilities.cs
+++ b/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactivity.Shared/VisualStateUtilities.cs
@@ -15,137 +15,136 @@ using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Media;
 #endif
 
-namespace Microsoft.Xaml.Interactivity
+namespace Microsoft.Xaml.Interactivity;
+
+/// <summary>
+/// Provides various standard operations for working with <seealso cref="VisualStateManager"/>.
+/// </summary>
+public static class VisualStateUtilities
 {
     /// <summary>
-    /// Provides various standard operations for working with <seealso cref="VisualStateManager"/>.
+    /// Transitions the control between two states.
     /// </summary>
-    public static class VisualStateUtilities
+    /// <param name="control">The <see cref="Control"/> to transition between states.</param>
+    /// <param name="stateName">The state to transition to.</param>
+    /// <param name="useTransitions">True to use a <see cref="VisualTransition"/> to transition between states; otherwise, false.</param>
+    /// <returns>True if the <paramref name="control"/> is successfully transitioned to the new state; otherwise, false.</returns>
+    /// <exception cref="global::System.ArgumentNullException"><paramref name="control"/> or <paramref name="stateName"/> is null.</exception>
+    public static bool GoToState(Control control, string stateName, bool useTransitions)
     {
-        /// <summary>
-        /// Transitions the control between two states.
-        /// </summary>
-        /// <param name="control">The <see cref="Control"/> to transition between states.</param>
-        /// <param name="stateName">The state to transition to.</param>
-        /// <param name="useTransitions">True to use a <see cref="VisualTransition"/> to transition between states; otherwise, false.</param>
-        /// <returns>True if the <paramref name="control"/> is successfully transitioned to the new state; otherwise, false.</returns>
-        /// <exception cref="global::System.ArgumentNullException"><paramref name="control"/> or <paramref name="stateName"/> is null.</exception>
-        public static bool GoToState(Control control, string stateName, bool useTransitions)
+        if (control == null)
         {
-            if (control == null)
-            {
-                throw new ArgumentNullException(nameof(control));
-            }
-
-            if (string.IsNullOrEmpty(stateName))
-            {
-                throw new ArgumentNullException(nameof(stateName));
-            }
-
-            control.ApplyTemplate();
-            return VisualStateManager.GoToState(control, stateName, useTransitions);
+            throw new ArgumentNullException(nameof(control));
         }
 
-        /// <summary>
-        /// Gets the value of the VisualStateManager.VisualStateGroups attached property.
-        /// </summary>
-        /// <param name="element">The <see cref="FrameworkElement"/> from which to get the VisualStateManager.VisualStateGroups.</param>
-        /// <returns>The list of VisualStateGroups in the given element.</returns>
-        /// <exception cref="global::System.ArgumentNullException"><paramref name="element"/> is null.</exception>
-        public static IList<VisualStateGroup> GetVisualStateGroups(FrameworkElement element)
+        if (string.IsNullOrEmpty(stateName))
         {
-            if (element == null)
-            {
-                throw new ArgumentNullException(nameof(element));
-            }
+            throw new ArgumentNullException(nameof(stateName));
+        }
 
-            IList<VisualStateGroup> visualStateGroups = VisualStateManager.GetVisualStateGroups(element);
+        control.ApplyTemplate();
+        return VisualStateManager.GoToState(control, stateName, useTransitions);
+    }
 
-            if (visualStateGroups == null || visualStateGroups.Count == 0)
+    /// <summary>
+    /// Gets the value of the VisualStateManager.VisualStateGroups attached property.
+    /// </summary>
+    /// <param name="element">The <see cref="FrameworkElement"/> from which to get the VisualStateManager.VisualStateGroups.</param>
+    /// <returns>The list of VisualStateGroups in the given element.</returns>
+    /// <exception cref="global::System.ArgumentNullException"><paramref name="element"/> is null.</exception>
+    public static IList<VisualStateGroup> GetVisualStateGroups(FrameworkElement element)
+    {
+        if (element == null)
+        {
+            throw new ArgumentNullException(nameof(element));
+        }
+
+        IList<VisualStateGroup> visualStateGroups = VisualStateManager.GetVisualStateGroups(element);
+
+        if (visualStateGroups == null || visualStateGroups.Count == 0)
+        {
+            int childrenCount = VisualTreeHelper.GetChildrenCount(element);
+            if (childrenCount > 0)
             {
-                int childrenCount = VisualTreeHelper.GetChildrenCount(element);
-                if (childrenCount > 0)
+                FrameworkElement childElement = VisualTreeHelper.GetChild(element, 0) as FrameworkElement;
+                if (childElement != null)
                 {
-                    FrameworkElement childElement = VisualTreeHelper.GetChild(element, 0) as FrameworkElement;
-                    if (childElement != null)
-                    {
-                        visualStateGroups = VisualStateManager.GetVisualStateGroups(childElement);
-                    }
+                    visualStateGroups = VisualStateManager.GetVisualStateGroups(childElement);
                 }
             }
-
-            return visualStateGroups;
         }
 
-        /// <summary>
-        /// Find the nearest parent which contains visual states.
-        /// </summary>
-        /// <param name="element">The <see cref="FrameworkElement"/> from which to find the nearest stateful control.</param>
-        /// <returns>The nearest <see cref="Control"/> that contains visual states; else null.</returns>
-        /// <exception cref="global::System.ArgumentNullException"><paramref name="element"/> is null.</exception>
-        [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "Stateful")]
-        public static Control FindNearestStatefulControl(FrameworkElement element)
+        return visualStateGroups;
+    }
+
+    /// <summary>
+    /// Find the nearest parent which contains visual states.
+    /// </summary>
+    /// <param name="element">The <see cref="FrameworkElement"/> from which to find the nearest stateful control.</param>
+    /// <returns>The nearest <see cref="Control"/> that contains visual states; else null.</returns>
+    /// <exception cref="global::System.ArgumentNullException"><paramref name="element"/> is null.</exception>
+    [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "Stateful")]
+    public static Control FindNearestStatefulControl(FrameworkElement element)
+    {
+        if (element == null)
         {
-            if (element == null)
-            {
-                throw new ArgumentNullException(nameof(element));
-            }
-
-            // Try to find an element which is the immediate child of a UserControl, ControlTemplate or other such "boundary" element
-            FrameworkElement parent = element.Parent as FrameworkElement;
-
-            // bubble up looking for a place to stop
-            while (!VisualStateUtilities.HasVisualStateGroupsDefined(element) && VisualStateUtilities.ShouldContinueTreeWalk(parent))
-            {
-                element = parent;
-                parent = parent.Parent as FrameworkElement;
-            }
-
-            if (VisualStateUtilities.HasVisualStateGroupsDefined(element))
-            {
-                // Once we've found such an element, use the VisualTreeHelper to get it's parent. For most elements the two are the 
-                // same, but for children of a ControlElement this will give the control that contains the template.
-                Control templatedParent = VisualTreeHelper.GetParent(element) as Control;
-
-                if (templatedParent != null)
-                {
-                    return templatedParent;
-                }
-                else
-                {
-                    return element as Control;
-                }
-            }
-
-            return null;
+            throw new ArgumentNullException(nameof(element));
         }
 
-        private static bool HasVisualStateGroupsDefined(FrameworkElement element)
+        // Try to find an element which is the immediate child of a UserControl, ControlTemplate or other such "boundary" element
+        FrameworkElement parent = element.Parent as FrameworkElement;
+
+        // bubble up looking for a place to stop
+        while (!VisualStateUtilities.HasVisualStateGroupsDefined(element) && VisualStateUtilities.ShouldContinueTreeWalk(parent))
         {
-            return element != null && VisualStateManager.GetVisualStateGroups(element).Count != 0;
+            element = parent;
+            parent = parent.Parent as FrameworkElement;
         }
 
-        private static bool ShouldContinueTreeWalk(FrameworkElement element)
+        if (VisualStateUtilities.HasVisualStateGroupsDefined(element))
         {
-            if (element == null)
+            // Once we've found such an element, use the VisualTreeHelper to get it's parent. For most elements the two are the 
+            // same, but for children of a ControlElement this will give the control that contains the template.
+            Control templatedParent = VisualTreeHelper.GetParent(element) as Control;
+
+            if (templatedParent != null)
+            {
+                return templatedParent;
+            }
+            else
+            {
+                return element as Control;
+            }
+        }
+
+        return null;
+    }
+
+    private static bool HasVisualStateGroupsDefined(FrameworkElement element)
+    {
+        return element != null && VisualStateManager.GetVisualStateGroups(element).Count != 0;
+    }
+
+    private static bool ShouldContinueTreeWalk(FrameworkElement element)
+    {
+        if (element == null)
+        {
+            return false;
+        }
+        else if (element is UserControl)
+        {
+            return false;
+        }
+        else if (element.Parent == null)
+        {
+            // Stop if parent's parent is null AND parent isn't the template root of a ControlTemplate or DataTemplate.
+            FrameworkElement templatedParent = VisualTreeHelper.GetParent(element) as FrameworkElement;
+            if (templatedParent == null || (!(templatedParent is Control) && !(templatedParent is ContentPresenter)))
             {
                 return false;
             }
-            else if (element is UserControl)
-            {
-                return false;
-            }
-            else if (element.Parent == null)
-            {
-                // Stop if parent's parent is null AND parent isn't the template root of a ControlTemplate or DataTemplate.
-                FrameworkElement templatedParent = VisualTreeHelper.GetParent(element) as FrameworkElement;
-                if (templatedParent == null || (!(templatedParent is Control) && !(templatedParent is ContentPresenter)))
-                {
-                    return false;
-                }
-            }
-
-            return true;
         }
+
+        return true;
     }
 }


### PR DESCRIPTION
### Closes #284

This PR includes two changes:
- Stops bundling source files in the NuGet (we'll use source link)
- Switches all files to file-scoped namespaces

> [!NOTE]
> Review with **whitespaces off**.