### PR TITLE
Manually set 'UseUwpTools' in .csproj

### DIFF
--- a/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactivity.Uwp/Microsoft.Xaml.Interactivity.Uwp.csproj
+++ b/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactivity.Uwp/Microsoft.Xaml.Interactivity.Uwp.csproj
@@ -6,6 +6,12 @@
     <TargetPlatformMinVersion>10.0.18362.0</TargetPlatformMinVersion>
     <RootNamespace>Microsoft.Xaml.Interactivity</RootNamespace>
     <UseUwp>true</UseUwp>
+
+    <!--
+      Temporary workaround to enable building on Visual Studio 17.11,
+      this can be removed on 17.12 as it will be set automatically.
+    -->
+    <UseUwpTools>true</UseUwpTools>
     <DefaultLanguage>en-US</DefaultLanguage>
     <Platforms>AnyCPU;x86;x64;arm64</Platforms>
     <RuntimeIdentifiers>win-x86;win-x64;win-arm64</RuntimeIdentifiers>


### PR DESCRIPTION
Temporary workaround to try building with VS 17.11 for now.