### PR TITLE
Fix invalid PRI file in WinUI behaviors

### DIFF
--- a/scripts/Microsoft.Xaml.Behaviors.WinUI.Managed.nuspec
+++ b/scripts/Microsoft.Xaml.Behaviors.WinUI.Managed.nuspec
@@ -16,7 +16,7 @@
         <repository type="git" url="http://go.microsoft.com/fwlink/?LinkID=651678" />
         <dependencies>
           <group targetFramework="net8.0-windows10.0.17763.0">
-            <dependency id="Microsoft.WindowsAppSDK" version="1.6.241106002" />
+            <dependency id="Microsoft.WindowsAppSDK" version="1.6.241114003" />
           </group>
         </dependencies>
     </metadata>

--- a/src/BehaviorsSDKManaged/ManagedUnitTests/ManagedUnitTests.csproj
+++ b/src/BehaviorsSDKManaged/ManagedUnitTests/ManagedUnitTests.csproj
@@ -125,16 +125,16 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk">
-      <Version>17.11.1</Version>
+      <Version>17.12.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform">
       <Version>6.2.14</Version>
     </PackageReference>
     <PackageReference Include="MSTest.TestAdapter">
-      <Version>3.6.3</Version>
+      <Version>3.6.4</Version>
     </PackageReference>
     <PackageReference Include="MSTest.TestFramework">
-      <Version>3.6.3</Version>
+      <Version>3.6.4</Version>
     </PackageReference>
     <PackageReference Include="Newtonsoft.Json">
       <Version>13.0.3</Version>

--- a/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactivity.WinUI/Microsoft.Xaml.Interactivity.WinUI.csproj
+++ b/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactivity.WinUI/Microsoft.Xaml.Interactivity.WinUI.csproj
@@ -102,7 +102,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.1.6" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.6.241106002" />
+    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.6.241114003" />
   </ItemGroup>
   <ItemGroup>
     <PRIResource Include="..\Microsoft.Xaml.Interactivity\Resources\de-DE\Strings.resw">

--- a/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactivity.WinUI/Microsoft.Xaml.Interactivity.WinUI.csproj
+++ b/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactivity.WinUI/Microsoft.Xaml.Interactivity.WinUI.csproj
@@ -13,8 +13,9 @@
     <CsWinRTGenerateProjection>false</CsWinRTGenerateProjection>
     <CsWinRTAotWarningLevel>2</CsWinRTAotWarningLevel>
 
-    <!-- Temporary workaround for a WebView2 bug -->
+    <!-- Temporary workaround for a WebView2 bugs -->
     <WebView2EnableCsWinRTProjectionExcludeCoreRef>true</WebView2EnableCsWinRTProjectionExcludeCoreRef>
+    <WebView2LoaderPreference>none</WebView2LoaderPreference>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
   </PropertyGroup>
   <PropertyGroup>
@@ -101,6 +102,12 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    
+    <!--
+      This WebView2 dependency is private, just to get the new tooling to fix some 'WebView2Loader.dll' issues
+      that resulted in a broken PRI file with invalid references. Can be removed when WindowsAppSDK 1.7 ships.
+    -->
+    <PackageReference Include="Microsoft.Web.WebView2" Version="1.0.2903.40" PrivateAssets="all" />
     <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.1.6" PrivateAssets="all" />
     <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.6.241114003" />
   </ItemGroup>

--- a/src/BehaviorsSDKManaged/Version/NuGetPackageVersion.props
+++ b/src/BehaviorsSDKManaged/Version/NuGetPackageVersion.props
@@ -1,5 +1,5 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <PackageVersion>3.0.0-preview1</PackageVersion>
+    <PackageVersion>3.0.0-preview2</PackageVersion>
   </PropertyGroup>
 </Project>

--- a/src/BehaviorsSDKManaged/Version/Version.cs
+++ b/src/BehaviorsSDKManaged/Version/Version.cs
@@ -15,4 +15,4 @@ using System.Reflection;
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("3.0.0.0")]
 [assembly: AssemblyFileVersion("3.0.0.0")]
-[assembly: AssemblyInformationalVersion("3.0.0.0-preview1")]
+[assembly: AssemblyInformationalVersion("3.0.0.0-preview2")]


### PR DESCRIPTION
This PR fixes an issue due to WebView2 that breaks the PRI file in the WinUI behaviors.
Diff with the old one, and the one for this PR:

![image](https://github.com/user-attachments/assets/b9c34a36-0c70-4a64-9f7a-a29ae267adf7)

You can see we now (correctly) no longer have those WebView2 .dll-s listed, as they don't exist.