### PR TITLE
Update dependencies for 3.0.0 stable

### DIFF
--- a/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactivity.Uwp/Microsoft.Xaml.Interactivity.Uwp.csproj
+++ b/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactivity.Uwp/Microsoft.Xaml.Interactivity.Uwp.csproj
@@ -4,7 +4,7 @@
     <DefineConstants>$(DefineConstants);MODERN_WINDOWS_UWP</DefineConstants>
     <AssemblyName>Microsoft.Xaml.Interactivity</AssemblyName>
     <TargetFramework>net8.0-windows10.0.19041.0</TargetFramework>
-    <WindowsSdkPackageVersion>10.0.19041.54</WindowsSdkPackageVersion>
+    <WindowsSdkPackageVersion>10.0.19041.57</WindowsSdkPackageVersion>
     <TargetPlatformMinVersion>10.0.18362.0</TargetPlatformMinVersion>
     <RootNamespace>Microsoft.Xaml.Interactivity</RootNamespace>
     <UseUwp>true</UseUwp>
@@ -105,7 +105,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.1.6" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.2.0" PrivateAssets="all" />
   </ItemGroup>
   <ItemGroup>
     <PRIResource Include="..\Microsoft.Xaml.Interactivity\Resources\de-DE\Strings.resw">

--- a/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactivity.WinUI/Microsoft.Xaml.Interactivity.WinUI.csproj
+++ b/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactivity.WinUI/Microsoft.Xaml.Interactivity.WinUI.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <TargetFramework>net8.0-windows10.0.17763.0</TargetFramework>
-    <WindowsSdkPackageVersion>10.0.17763.53</WindowsSdkPackageVersion>
+    <WindowsSdkPackageVersion>10.0.17763.56</WindowsSdkPackageVersion>
     <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
     <RootNamespace>Microsoft.Xaml.Interactivity</RootNamespace>
     <Platforms>AnyCPU;x86;x64;arm64</Platforms>
@@ -108,8 +108,8 @@
       that resulted in a broken PRI file with invalid references. Can be removed when WindowsAppSDK 1.7 ships.
     -->
     <PackageReference Include="Microsoft.Web.WebView2" Version="1.0.2903.40" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.1.6" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.6.241114003" />
+    <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.2.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.6.250108002" />
   </ItemGroup>
   <ItemGroup>
     <PRIResource Include="..\Microsoft.Xaml.Interactivity\Resources\de-DE\Strings.resw">

--- a/src/BehaviorsSDKManaged/Version/NuGetPackageVersion.props
+++ b/src/BehaviorsSDKManaged/Version/NuGetPackageVersion.props
@@ -1,5 +1,5 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <PackageVersion>3.0.0-preview2</PackageVersion>
+    <PackageVersion>3.0.0</PackageVersion>
   </PropertyGroup>
 </Project>

--- a/src/BehaviorsSDKManaged/Version/Version.cs
+++ b/src/BehaviorsSDKManaged/Version/Version.cs
@@ -15,4 +15,4 @@ using System.Reflection;
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("3.0.0.0")]
 [assembly: AssemblyFileVersion("3.0.0.0")]
-[assembly: AssemblyInformationalVersion("3.0.0.0-preview2")]
+[assembly: AssemblyInformationalVersion("3.0.0.0")]


### PR DESCRIPTION
Now that CsWinRT 2.2.0 is out in the new .NET SDK and UWP support for .NET 9 is well tested, we can release a stable version.