### PR TITLE
Add git blame ignore file to ignore file scope namespace commit

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,4 @@
+# Ignore commits from git blame
+#
+# Switch files to file-scoped namespaces
+edf908d420313fa9b6e37af847e8287606ce11ea


### PR DESCRIPTION
The [commit](https://github.com/microsoft/XamlBehaviors/commit/edf908d420313fa9b6e37af847e8287606ce11ea) to change the repository to use file-scope-namespaces touched most lines of the repository without introducing any functional difference. 

This PR ignores that commit from the git blame output. This (should) work automatically here on GitHub, locally this might require a change of a git setting. (See: [GitHub Docs](https://docs.github.com/en/repositories/working-with-files/using-files/viewing-and-understanding-files#ignore-commits-in-the-blame-view))

It works locally for me with the setting applied and you can see it working in my fork [here](https://github.com/Marv51/XamlBehaviors/blame/git-blame-ignore/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactivity.Shared/Core/DataTriggerBehavior.cs) (Compare to [original](https://github.com/microsoft/XamlBehaviors/blame/main/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactivity.Shared/Core/DataTriggerBehavior.cs))