### PR TITLE
Always use latest version of .NET 9 SDK

### DIFF
--- a/.github/workflows/managed-build.yml
+++ b/.github/workflows/managed-build.yml
@@ -13,10 +13,10 @@ jobs:
     - name: Checkout XamlBehaviors.git 
       uses: actions/checkout@v4
 
-    - name: Install the .NET 9.0.311 SDK
+    - name: Install the .NET 9.0.x SDK
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 9.0.311
+        dotnet-version: 9.0.x
 
     - name: Setup MSBuild
       uses: microsoft/setup-msbuild@v2
@@ -58,10 +58,10 @@ jobs:
     - name: Checkout XamlBehaviors.git 
       uses: actions/checkout@v4
 
-    - name: Install the .NET 9.0.311 SDK
+    - name: Install the .NET 9.0.x SDK
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 9.0.311
+        dotnet-version: 9.0.x
 
     - name: Setup MSBuild
       uses: microsoft/setup-msbuild@v2

--- a/azure-pipelines/build.yml
+++ b/azure-pipelines/build.yml
@@ -96,9 +96,9 @@ extends:
             SourceFolder: out
             Contents: '**\'
         - task: UseDotNet@2
-          displayName: Use .NET SDK 9.0.311
+          displayName: Use .NET SDK 9.0.x
           inputs:
-            version: 9.0.311
+            version: 9.0.x
             performMultiLevelLookup: true
         - task: NuGetToolInstaller@1
           displayName: Use NuGet 6.x

--- a/src/BehaviorsSDKManaged/global.json
+++ b/src/BehaviorsSDKManaged/global.json
@@ -1,7 +1,7 @@
 {
   "sdk":
   {
-    "version": "9.0.311",
+    "version": "9.0.312",
     "rollForward": "latestFeature",
     "allowPrerelease": false
   },


### PR DESCRIPTION
This change will avoid having to update the build pipeline every time .NET 9 SDK is updated.