### PR TITLE
Update to .NET 9.0.313

### DIFF
--- a/src/BehaviorsSDKManaged/global.json
+++ b/src/BehaviorsSDKManaged/global.json
@@ -1,7 +1,7 @@
 {
   "sdk":
   {
-    "version": "9.0.312",
+    "version": "9.0.313",
     "rollForward": "latestFeature",
     "allowPrerelease": false
   },


### PR DESCRIPTION
Not sure why rollForward=latestFeature isn't good enough in global.json, but .312 was flagged and needs to be updated .313.
Maybe because we need to guard against an old SDK being installed.